### PR TITLE
test: align OpenAI Responses manual tests with Anthropic style and add multi-turn tools test

### DIFF
--- a/src/utils/adapters/openai_response_adapter.js
+++ b/src/utils/adapters/openai_response_adapter.js
@@ -1,0 +1,472 @@
+/**
+ * Adapter for converting between OpenAI Responses API format and OpenAI Chat Completions format.
+ *
+ * OpenAI Responses API Format:
+ * - Uses `input` instead of `messages`
+ * - Uses `max_output_tokens` instead of `max_tokens`
+ * - Uses output items (message, function_call) in `output` array
+ * - Streaming responses are event-based with response.* event types
+ *
+ * This adapter handles:
+ * 1. Converting Responses API requests to Chat Completions requests
+ * 2. Parsing Chat Completions responses back to Responses API format
+ * 3. Translating Chat Completions SSE chunks to Responses API streaming events
+ */
+
+import { BaseAdapter } from "./base_adapter.js";
+
+export class OpenAIResponseAdapter extends BaseAdapter {
+  /**
+   * Converts Responses API payload to OpenAI Chat Completions format.
+   *
+   * @param {Object} payload - Responses API request payload
+   * @param {string} [payload.model] - Model ID
+   * @param {string|Array} [payload.input] - Input content (string or structured input array)
+   * @param {string} [payload.instructions] - System instruction text
+   * @param {Array} [payload.tools] - Tool definitions in Responses API format
+   * @param {number} [payload.temperature] - Temperature
+   * @param {number} [payload.top_p] - Top-p sampling
+   * @param {number} [payload.max_output_tokens] - Maximum output tokens
+   * @param {boolean} [payload.stream] - Whether to stream responses
+   * @param {string|Object} [payload.tool_choice] - Tool choice strategy
+   * @param {boolean} [payload.parallel_tool_calls] - Whether parallel tool calls are enabled
+   * @param {string} [payload.user] - End-user identifier
+   * @param {Object} [payload.metadata] - Additional metadata
+   * @returns {Object} OpenAI Chat Completions-formatted request
+   */
+  convertRequest(payload) {
+    const messages = parseResponseInput(payload.input);
+
+    if (payload.instructions) {
+      messages.unshift({
+        role: "system",
+        content: payload.instructions,
+      });
+    }
+
+    return {
+      model: payload.model,
+      messages,
+      tools: parseTools(payload.tools),
+      temperature: payload.temperature,
+      top_p: payload.top_p,
+      max_tokens: payload.max_output_tokens,
+      stream: payload.stream !== undefined ? payload.stream : false,
+      tool_choice: payload.tool_choice,
+      parallel_tool_calls: payload.parallel_tool_calls,
+      user: payload.user,
+      metadata: payload.metadata,
+    };
+  }
+
+  /**
+   * Detects if the Responses API payload contains image input.
+   *
+   * @param {Object} payload - Responses API request payload
+   * @returns {boolean} True if any input item contains image input
+   */
+  detectVisionRequest(payload) {
+    const input = payload.input;
+    if (!Array.isArray(input)) {
+      return false;
+    }
+
+    for (const item of input) {
+      if (!item || typeof item !== "object") {
+        continue;
+      }
+
+      const content = item.content;
+      if (!Array.isArray(content)) {
+        continue;
+      }
+
+      if (
+        content.some(
+          (part) => part?.type === "input_image" || part?.type === "image_url",
+        )
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Parses non-streaming Chat Completions response to Responses API format.
+   *
+   * @param {Object} response - Chat Completions response object
+   * @returns {Object} Responses API response object
+   */
+  parseResponse(response) {
+    const responseId = createResponseId();
+    const createdAt = response.created || Math.floor(Date.now() / 1000);
+    const output = [];
+    const outputTextParts = [];
+
+    for (const choice of response.choices || []) {
+      const message = choice.message || {};
+
+      if (message.content) {
+        outputTextParts.push(message.content);
+      }
+
+      if (message.tool_calls && message.tool_calls.length > 0) {
+        for (const toolCall of message.tool_calls) {
+          output.push({
+            id: toolCall.id || createFunctionCallId(),
+            type: "function_call",
+            status: "completed",
+            name: toolCall.function?.name || "unknown",
+            arguments: toolCall.function?.arguments || "{}",
+            call_id: toolCall.id || createFunctionCallId(),
+          });
+        }
+      }
+    }
+
+    const outputText = outputTextParts.join("");
+    if (outputText) {
+      output.unshift({
+        id: createMessageId(),
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: outputText,
+            annotations: [],
+          },
+        ],
+      });
+    }
+
+    return {
+      id: responseId,
+      object: "response",
+      created_at: createdAt,
+      status: "completed",
+      model: response.model,
+      output,
+      output_text: outputText,
+      usage: buildUsage(response.usage),
+      parallel_tool_calls: true,
+    };
+  }
+
+  /**
+   * Parses streaming Chat Completions SSE chunks to Responses API events.
+   *
+   * @param {string} buffer - Raw SSE buffer from HTTP stream
+   * @param {Object} state - State object for tracking incomplete data across chunks
+   * @returns {{parsedMessages: Array, remainBuffer: string}} Parsed events and remaining buffer
+   */
+  parseStreamChunk(buffer, state) {
+    const respMessages = buffer.split("\n\n");
+    const remainBuffer = respMessages.pop();
+    const parsedMessages = [];
+
+    if (!state.initialized) {
+      state.initialized = true;
+      state.responseId = createResponseId();
+      state.createdAt = Math.floor(Date.now() / 1000);
+      state.model = "";
+      state.outputText = "";
+      state.usage = {};
+      state.toolCalls = {};
+      state.started = false;
+    }
+
+    for (const respMessage of respMessages) {
+      if (!respMessage || respMessage.trim() === "") {
+        continue;
+      }
+
+      const lines = respMessage.split("\n");
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) {
+          continue;
+        }
+
+        const data = line.slice(6);
+        if (data === "[DONE]") {
+          if (state.outputText) {
+            parsedMessages.push({
+              type: "response.output_text.done",
+              response_id: state.responseId,
+              output_index: 0,
+              content_index: 0,
+              text: state.outputText,
+            });
+          }
+
+          for (const toolCall of Object.values(state.toolCalls)) {
+            parsedMessages.push({
+              type: "response.function_call_arguments.done",
+              response_id: state.responseId,
+              output_index: toolCall.outputIndex,
+              item_id: toolCall.itemId,
+              arguments: toolCall.arguments,
+            });
+          }
+
+          parsedMessages.push({
+            type: "response.completed",
+            response: {
+              id: state.responseId,
+              object: "response",
+              created_at: state.createdAt,
+              status: "completed",
+              model: state.model,
+              output_text: state.outputText,
+              usage: buildUsage(state.usage),
+            },
+          });
+          continue;
+        }
+
+        const parsed = JSON.parse(data);
+        state.model = parsed.model || state.model;
+        state.createdAt = parsed.created || state.createdAt;
+
+        if (!state.started) {
+          parsedMessages.push({
+            type: "response.created",
+            response: {
+              id: state.responseId,
+              object: "response",
+              created_at: state.createdAt,
+              status: "in_progress",
+              model: state.model,
+            },
+          });
+          parsedMessages.push({
+            type: "response.in_progress",
+            response: {
+              id: state.responseId,
+              object: "response",
+              created_at: state.createdAt,
+              status: "in_progress",
+              model: state.model,
+            },
+          });
+          state.started = true;
+        }
+
+        if (parsed.usage) {
+          state.usage = {
+            ...state.usage,
+            ...parsed.usage,
+          };
+        }
+
+        const choice = parsed.choices?.[0];
+        if (!choice || !choice.delta) {
+          continue;
+        }
+
+        if (choice.delta.content) {
+          state.outputText += choice.delta.content;
+          parsedMessages.push({
+            type: "response.output_text.delta",
+            response_id: state.responseId,
+            output_index: 0,
+            content_index: 0,
+            delta: choice.delta.content,
+          });
+        }
+
+        if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
+          for (const toolDelta of choice.delta.tool_calls) {
+            const key = toolDelta.index;
+
+            if (!state.toolCalls[key]) {
+              state.toolCalls[key] = {
+                outputIndex: Number(key) + (state.outputText ? 1 : 0),
+                itemId: toolDelta.id || createFunctionCallId(),
+                arguments: "",
+              };
+            }
+
+            if (toolDelta.id) {
+              state.toolCalls[key].itemId = toolDelta.id;
+            }
+
+            if (toolDelta.function?.arguments) {
+              state.toolCalls[key].arguments += toolDelta.function.arguments;
+              parsedMessages.push({
+                type: "response.function_call_arguments.delta",
+                response_id: state.responseId,
+                output_index: state.toolCalls[key].outputIndex,
+                item_id: state.toolCalls[key].itemId,
+                delta: toolDelta.function.arguments,
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return {
+      parsedMessages,
+      remainBuffer,
+    };
+  }
+}
+
+function createResponseId() {
+  return `resp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+function createMessageId() {
+  return `msg_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+function createFunctionCallId() {
+  return `fc_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+function normalizeRequestContent(content) {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return content;
+  }
+
+  const normalizedContent = [];
+
+  for (const item of content) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+
+    if (item.type === "input_text") {
+      normalizedContent.push({
+        type: "text",
+        text: item.text || "",
+      });
+      continue;
+    }
+
+    if (item.type === "input_image") {
+      if (item.image_url) {
+        normalizedContent.push({
+          type: "image_url",
+          image_url: {
+            url: item.image_url,
+          },
+        });
+      }
+      continue;
+    }
+
+    normalizedContent.push(item);
+  }
+
+  if (normalizedContent.length === 1 && normalizedContent[0].type === "text") {
+    return normalizedContent[0].text;
+  }
+
+  return normalizedContent;
+}
+
+function parseResponseInput(input) {
+  if (typeof input === "string") {
+    return [{ role: "user", content: input }];
+  }
+
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  const messages = [];
+
+  for (const item of input) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+
+    if (item.type === "message") {
+      messages.push({
+        role: item.role || "user",
+        content: normalizeRequestContent(item.content),
+      });
+      continue;
+    }
+
+    if (item.type === "function_call_output") {
+      messages.push({
+        role: "tool",
+        tool_call_id: item.call_id,
+        content:
+          typeof item.output === "string"
+            ? item.output
+            : JSON.stringify(item.output || {}),
+      });
+      continue;
+    }
+
+    if (item.role) {
+      messages.push({
+        role: item.role,
+        content: normalizeRequestContent(item.content),
+      });
+    }
+  }
+
+  return messages;
+}
+
+function parseTools(tools) {
+  if (!Array.isArray(tools)) {
+    return undefined;
+  }
+
+  const openaiTools = [];
+
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object") {
+      continue;
+    }
+
+    if (tool.type !== "function") {
+      continue;
+    }
+
+    if (tool.function) {
+      openaiTools.push(tool);
+      continue;
+    }
+
+    openaiTools.push({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      },
+    });
+  }
+
+  return openaiTools.length > 0 ? openaiTools : undefined;
+}
+
+function buildUsage(usage = {}) {
+  return {
+    input_tokens: usage.prompt_tokens || 0,
+    output_tokens: usage.completion_tokens || 0,
+    total_tokens:
+      usage.total_tokens ||
+      (usage.prompt_tokens || 0) + (usage.completion_tokens || 0),
+    input_tokens_details: {
+      cached_tokens: usage.prompt_tokens_details?.cached_tokens || 0,
+    },
+    output_tokens_details: {
+      reasoning_tokens: usage.completion_tokens_details?.reasoning_tokens || 0,
+    },
+  };
+}

--- a/tests/manual/openai_response_image_test.js
+++ b/tests/manual/openai_response_image_test.js
@@ -1,0 +1,130 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const args = process.argv.slice(2);
+const stream = !args.includes("--no-stream");
+const compact = args.includes("--compact");
+const baseUrl = process.env.GHCPO_BASE_URL || "http://localhost:11434";
+const apiKey = process.env.GHCPO_API_KEY || "sk-test";
+
+function encodeImageToBase64(imagePath) {
+  const image = fs.readFileSync(imagePath);
+  return image.toString("base64");
+}
+
+function resolveEndpoint(useCompact) {
+  return `${baseUrl}/v1/response${useCompact ? "/compact" : ""}`;
+}
+
+async function sendResponseRequest(payload, useCompact) {
+  const response = await fetch(resolveEndpoint(useCompact), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  }
+
+  if (!payload.stream) {
+    return await response.json();
+  }
+
+  const events = [];
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for await (const chunk of response.body) {
+    buffer += decoder.decode(chunk, { stream: true });
+
+    const messages = buffer.split("\n\n");
+    buffer = messages.pop() || "";
+
+    for (const message of messages) {
+      for (const line of message.split("\n")) {
+        if (!line.startsWith("data: ")) {
+          continue;
+        }
+
+        const data = line.slice(6);
+        if (data === "[DONE]") {
+          events.push({ type: "done" });
+          continue;
+        }
+
+        try {
+          events.push(JSON.parse(data));
+        } catch {
+          events.push({ type: "parse_error", raw: data });
+        }
+      }
+    }
+  }
+
+  return events;
+}
+
+async function testResponseImageInput(streamMode, useCompact) {
+  try {
+    const imagePath = path.join(__dirname, "..", "images", "vergil.jpg");
+
+    const payload = {
+      model: "gpt-5.2",
+      input: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "Who is the man in this image?",
+            },
+            {
+              type: "input_image",
+              image_url: `data:image/jpeg;base64,${encodeImageToBase64(imagePath)}`,
+            },
+          ],
+        },
+      ],
+      stream: streamMode,
+    };
+
+    console.log("Endpoint:", resolveEndpoint(useCompact));
+
+    let fullResponse = "";
+    if (streamMode) {
+      const events = await sendResponseRequest(payload, useCompact);
+      for (const event of events) {
+        console.log("Event received:", JSON.stringify(event));
+        if (event.type === "response.output_text.delta") {
+          fullResponse += event.delta || "";
+        }
+      }
+    } else {
+      const response = await sendResponseRequest(payload, useCompact);
+      console.log("Response received:", JSON.stringify(response, null, 2));
+      fullResponse = response.output_text || "";
+    }
+
+    console.log("====================\n");
+    console.log("Full Response:\n", fullResponse);
+  } catch (error) {
+    console.error("Error:", error);
+    if (error.message.includes("ENOENT")) {
+      console.error(
+        "Image file not found. Please make sure to place an image named 'vergil.jpg' in the tests/images directory.",
+      );
+    }
+    throw error;
+  }
+}
+
+testResponseImageInput(stream, compact);

--- a/tests/manual/openai_response_mixed_content_test.js
+++ b/tests/manual/openai_response_mixed_content_test.js
@@ -1,0 +1,185 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const args = process.argv.slice(2);
+const stream = !args.includes("--no-stream");
+const compact = args.includes("--compact");
+const baseUrl = process.env.GHCPO_BASE_URL || "http://localhost:11434";
+const apiKey = process.env.GHCPO_API_KEY || "sk-test";
+
+function encodeImageToBase64(imagePath) {
+  const image = fs.readFileSync(imagePath);
+  return image.toString("base64");
+}
+
+function resolveEndpoint(useCompact) {
+  return `${baseUrl}/v1/response${useCompact ? "/compact" : ""}`;
+}
+
+async function sendResponseRequest(payload, useCompact) {
+  const response = await fetch(resolveEndpoint(useCompact), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  }
+
+  if (!payload.stream) {
+    return await response.json();
+  }
+
+  const events = [];
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for await (const chunk of response.body) {
+    buffer += decoder.decode(chunk, { stream: true });
+
+    const messages = buffer.split("\n\n");
+    buffer = messages.pop() || "";
+
+    for (const message of messages) {
+      for (const line of message.split("\n")) {
+        if (!line.startsWith("data: ")) {
+          continue;
+        }
+
+        const data = line.slice(6);
+        if (data === "[DONE]") {
+          events.push({ type: "done" });
+          continue;
+        }
+
+        try {
+          events.push(JSON.parse(data));
+        } catch {
+          events.push({ type: "parse_error", raw: data });
+        }
+      }
+    }
+  }
+
+  return events;
+}
+
+async function testResponseMixedContent(streamMode, useCompact) {
+  try {
+    const imagePath = path.join(__dirname, "..", "images", "vergil.jpg");
+    const base64Image = encodeImageToBase64(imagePath);
+
+    const payload = {
+      model: "gpt-5.2",
+      instructions: "Use tools if needed and keep answers concise.",
+      input: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "Who is in this image?",
+            },
+            {
+              type: "input_image",
+              image_url: `data:image/jpeg;base64,${base64Image}`,
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: "This looks like Vergil from Devil May Cry.",
+        },
+        {
+          role: "user",
+          content: "What games has he appeared in?",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_search_001",
+          output: {
+            games: ["Devil May Cry 3", "Devil May Cry 4", "Devil May Cry 5"],
+          },
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          name: "search_games",
+          description: "Search games by character name",
+          parameters: {
+            type: "object",
+            properties: {
+              character: {
+                type: "string",
+                description: "Character name",
+              },
+            },
+            required: ["character"],
+          },
+        },
+      ],
+      stream: streamMode,
+    };
+
+    console.log("Endpoint:", resolveEndpoint(useCompact));
+
+    let fullResponse = "";
+    const toolEvents = [];
+
+    if (streamMode) {
+      const events = await sendResponseRequest(payload, useCompact);
+      for (const event of events) {
+        console.log("Event received:", JSON.stringify(event));
+
+        if (event.type === "response.output_text.delta") {
+          fullResponse += event.delta || "";
+        }
+
+        if (
+          event.type === "response.function_call_arguments.delta" ||
+          event.type === "response.function_call_arguments.done"
+        ) {
+          toolEvents.push(event);
+        }
+      }
+    } else {
+      const response = await sendResponseRequest(payload, useCompact);
+      console.log("Response received:", JSON.stringify(response, null, 2));
+      fullResponse = response.output_text || "";
+
+      for (const item of response.output || []) {
+        if (item.type === "function_call") {
+          toolEvents.push(item);
+        }
+      }
+    }
+
+    console.log("====================\n");
+    console.log("Full Response:\n", fullResponse);
+
+    if (toolEvents.length > 0) {
+      console.log("\n====================\n");
+      console.log("Tool Events:\n", JSON.stringify(toolEvents, null, 2));
+    }
+  } catch (error) {
+    console.error("Error:", error);
+    if (error.message.includes("ENOENT")) {
+      console.error(
+        "Image file not found. Please make sure to place an image named 'vergil.jpg' in the tests/images directory.",
+      );
+    }
+    throw error;
+  }
+}
+
+testResponseMixedContent(stream, compact);

--- a/tests/manual/openai_response_multi_turn_tools_test.js
+++ b/tests/manual/openai_response_multi_turn_tools_test.js
@@ -1,0 +1,268 @@
+const args = process.argv.slice(2);
+const stream = !args.includes("--no-stream");
+const compact = args.includes("--compact");
+const baseUrl = process.env.GHCPO_BASE_URL || "http://localhost:11434";
+const apiKey = process.env.GHCPO_API_KEY || "sk-test";
+
+const tools = [
+  {
+    type: "function",
+    name: "get_current_time",
+    description: "Get the current time for a specific timezone",
+    parameters: {
+      type: "object",
+      properties: {
+        timezone: {
+          type: "string",
+          description: "The timezone to get the current time for (e.g., Asia/Shanghai)",
+        },
+      },
+      required: ["timezone"],
+    },
+  },
+  {
+    type: "function",
+    name: "get_current_weather",
+    description: "Get the current weather for a location",
+    parameters: {
+      type: "object",
+      properties: {
+        location: {
+          type: "string",
+          description: "The location to get the weather for, e.g. Beijing",
+        },
+        format: {
+          type: "string",
+          description: "The format to return the weather in",
+          enum: ["celsius", "fahrenheit"],
+        },
+      },
+      required: ["location", "format"],
+    },
+  },
+];
+
+function resolveEndpoint(useCompact) {
+  return `${baseUrl}/v1/response${useCompact ? "/compact" : ""}`;
+}
+
+function mockToolExecution(name, input) {
+  if (name === "get_current_time") {
+    return `Current time in ${input.timezone}: 2024-01-15 14:30:00 CST`;
+  }
+  if (name === "get_current_weather") {
+    return `Weather in ${input.location}: Temperature 15°C, Condition: Sunny, Humidity: 45%`;
+  }
+  return `Unknown tool: ${name}`;
+}
+
+async function sendResponseRequest(payload, useCompact) {
+  const response = await fetch(resolveEndpoint(useCompact), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  }
+
+  if (!payload.stream) {
+    return await response.json();
+  }
+
+  const events = [];
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for await (const chunk of response.body) {
+    buffer += decoder.decode(chunk, { stream: true });
+
+    const messages = buffer.split("\n\n");
+    buffer = messages.pop() || "";
+
+    for (const message of messages) {
+      for (const line of message.split("\n")) {
+        if (!line.startsWith("data: ")) {
+          continue;
+        }
+
+        const data = line.slice(6);
+        if (data === "[DONE]") {
+          events.push({ type: "done" });
+          continue;
+        }
+
+        try {
+          events.push(JSON.parse(data));
+        } catch {
+          events.push({ type: "parse_error", raw: data });
+        }
+      }
+    }
+  }
+
+  return events;
+}
+
+async function sendTurn(payload, streamMode, useCompact) {
+  let textResponse = "";
+  const toolCalls = [];
+
+  if (streamMode) {
+    const events = await sendResponseRequest(payload, useCompact);
+    const callMap = {};
+
+    console.log("\n--- Streaming Events ---");
+    for (const event of events) {
+      console.log(JSON.stringify(event));
+
+      if (event.type === "response.output_text.delta") {
+        textResponse += event.delta || "";
+      }
+
+      if (event.type === "response.function_call_arguments.delta") {
+        if (!callMap[event.item_id]) {
+          callMap[event.item_id] = {
+            id: event.item_id,
+            name: "unknown",
+            arguments: "",
+          };
+        }
+        callMap[event.item_id].arguments += event.delta || "";
+      }
+
+      if (event.type === "response.completed") {
+        const outputItems = event.response?.output || [];
+        for (const item of outputItems) {
+          if (item.type === "function_call") {
+            if (!callMap[item.id]) {
+              callMap[item.id] = {
+                id: item.id,
+                name: item.name,
+                arguments: item.arguments || "",
+              };
+            } else {
+              callMap[item.id].name = item.name || callMap[item.id].name;
+            }
+          }
+        }
+      }
+    }
+    console.log("--- End Streaming Events ---\n");
+
+    for (const callId in callMap) {
+      const toolCall = callMap[callId];
+      if (toolCall.arguments && typeof toolCall.arguments === "string") {
+        try {
+          toolCall.arguments = JSON.parse(toolCall.arguments);
+        } catch {
+          // Keep as string
+        }
+      }
+      toolCalls.push(toolCall);
+    }
+  } else {
+    const response = await sendResponseRequest(payload, useCompact);
+    textResponse = response.output_text || "";
+
+    for (const item of response.output || []) {
+      if (item.type === "function_call") {
+        toolCalls.push({
+          id: item.id,
+          name: item.name,
+          arguments: item.arguments,
+        });
+      }
+    }
+
+    for (const toolCall of toolCalls) {
+      if (toolCall.arguments && typeof toolCall.arguments === "string") {
+        try {
+          toolCall.arguments = JSON.parse(toolCall.arguments);
+        } catch {
+          // Keep as string
+        }
+      }
+    }
+  }
+
+  return { textResponse, toolCalls };
+}
+
+async function testMultiTurnWithTools(streamMode, useCompact) {
+  console.log("Endpoint:", resolveEndpoint(useCompact));
+  console.log("========== TURN 1: Triggering function_call ==========" + "\n");
+
+  const turn1Payload = {
+    model: "gpt-5.2",
+    input: [
+      {
+        role: "user",
+        content: "What's the time and weather in Beijing and Shanghai now?",
+      },
+    ],
+    tools,
+    stream: streamMode,
+  };
+
+  const turn1Result = await sendTurn(turn1Payload, streamMode, useCompact);
+
+  console.log("Turn 1 Text Response:", turn1Result.textResponse);
+  console.log("Turn 1 Tool Calls:", JSON.stringify(turn1Result.toolCalls, null, 2));
+
+  if (turn1Result.toolCalls.length === 0) {
+    throw new Error("FAIL: No function_call triggered in turn 1. LLM should have called tools.");
+  }
+
+  console.log("\n========== TURN 2: Sending function_call_output ==========\n");
+
+  const turn2Input = [
+    {
+      role: "user",
+      content: "What's the time and weather in Beijing and Shanghai now?",
+    },
+  ];
+
+  for (const toolCall of turn1Result.toolCalls) {
+    turn2Input.push({
+      type: "function_call_output",
+      call_id: toolCall.id,
+      output: mockToolExecution(toolCall.name, toolCall.arguments || {}),
+    });
+  }
+
+  const turn2Payload = {
+    model: "gpt-5.2",
+    input: turn2Input,
+    tools,
+    stream: streamMode,
+  };
+
+  console.log("\n" + "-".repeat(80));
+  console.log("Turn 2 Payload (before conversion):");
+  console.log(JSON.stringify(turn2Payload, null, 2));
+  console.log("-".repeat(80) + "\n");
+
+  const turn2Result = await sendTurn(turn2Payload, streamMode, useCompact);
+
+  console.log("Turn 2 Text Response:", turn2Result.textResponse);
+  console.log("Turn 2 Tool Calls:", JSON.stringify(turn2Result.toolCalls, null, 2));
+
+  console.log("\n========== TEST RESULT ==========\n");
+
+  if (turn2Result.textResponse) {
+    console.log("SUCCESS: Multi-turn tool call conversation completed.");
+  } else {
+    console.log("WARNING: Empty turn 2 text response.");
+  }
+}
+
+testMultiTurnWithTools(stream, compact).catch((error) => {
+  console.error("Test failed:", error.message);
+  process.exit(1);
+});

--- a/tests/manual/openai_response_textmsg_test.js
+++ b/tests/manual/openai_response_textmsg_test.js
@@ -1,0 +1,110 @@
+const args = process.argv.slice(2);
+const stream = !args.includes("--no-stream");
+const compact = args.includes("--compact");
+const baseUrl = process.env.GHCPO_BASE_URL || "http://localhost:11434";
+const apiKey = process.env.GHCPO_API_KEY || "sk-test";
+
+function resolveEndpoint(useCompact) {
+  return `${baseUrl}/v1/response${useCompact ? "/compact" : ""}`;
+}
+
+async function sendResponseRequest(payload, useCompact) {
+  const response = await fetch(resolveEndpoint(useCompact), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  }
+
+  if (!payload.stream) {
+    return await response.json();
+  }
+
+  const events = [];
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for await (const chunk of response.body) {
+    buffer += decoder.decode(chunk, { stream: true });
+
+    const messages = buffer.split("\n\n");
+    buffer = messages.pop() || "";
+
+    for (const message of messages) {
+      for (const line of message.split("\n")) {
+        if (!line.startsWith("data: ")) {
+          continue;
+        }
+
+        const data = line.slice(6);
+        if (data === "[DONE]") {
+          events.push({ type: "done" });
+          continue;
+        }
+
+        try {
+          events.push(JSON.parse(data));
+        } catch {
+          events.push({ type: "parse_error", raw: data });
+        }
+      }
+    }
+  }
+
+  return events;
+}
+
+async function testResponseText(streamMode, useCompact) {
+  try {
+    const payload = {
+      model: "gpt-5.2",
+      input: [
+        {
+          role: "user",
+          content: "why is the sky blue?",
+        },
+        {
+          role: "assistant",
+          content: "due to rayleigh scattering.",
+        },
+        {
+          role: "user",
+          content: "how is that different than mie scattering?",
+        },
+      ],
+      stream: streamMode,
+    };
+
+    console.log("Endpoint:", resolveEndpoint(useCompact));
+
+    let fullResponse = "";
+    if (streamMode) {
+      const events = await sendResponseRequest(payload, useCompact);
+      for (const event of events) {
+        console.log("Event received:", JSON.stringify(event));
+        if (event.type === "response.output_text.delta") {
+          fullResponse += event.delta || "";
+        }
+      }
+    } else {
+      const response = await sendResponseRequest(payload, useCompact);
+      console.log("Response received:", JSON.stringify(response, null, 2));
+      fullResponse = response.output_text || "";
+    }
+
+    console.log("====================\n");
+    console.log("Full Response:\n", fullResponse);
+  } catch (error) {
+    console.error("Error:", error);
+    throw error;
+  }
+}
+
+testResponseText(stream, compact);

--- a/tests/manual/openai_response_tools_test.js
+++ b/tests/manual/openai_response_tools_test.js
@@ -1,0 +1,176 @@
+const args = process.argv.slice(2);
+const stream = !args.includes("--no-stream");
+const compact = args.includes("--compact");
+const baseUrl = process.env.GHCPO_BASE_URL || "http://localhost:11434";
+const apiKey = process.env.GHCPO_API_KEY || "sk-test";
+
+function resolveEndpoint(useCompact) {
+  return `${baseUrl}/v1/response${useCompact ? "/compact" : ""}`;
+}
+
+async function sendResponseRequest(payload, useCompact) {
+  const response = await fetch(resolveEndpoint(useCompact), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  }
+
+  if (!payload.stream) {
+    return await response.json();
+  }
+
+  const events = [];
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for await (const chunk of response.body) {
+    buffer += decoder.decode(chunk, { stream: true });
+
+    const messages = buffer.split("\n\n");
+    buffer = messages.pop() || "";
+
+    for (const message of messages) {
+      for (const line of message.split("\n")) {
+        if (!line.startsWith("data: ")) {
+          continue;
+        }
+
+        const data = line.slice(6);
+        if (data === "[DONE]") {
+          events.push({ type: "done" });
+          continue;
+        }
+
+        try {
+          events.push(JSON.parse(data));
+        } catch {
+          events.push({ type: "parse_error", raw: data });
+        }
+      }
+    }
+  }
+
+  return events;
+}
+
+async function testResponseToolInvocation(streamMode, useCompact) {
+  try {
+    const payload = {
+      model: "gpt-5.2",
+      input: [
+        {
+          role: "user",
+          content: "What's the time and weather in Beijing now?",
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          name: "get_current_time",
+          description: "Get the current time for a specific timezone",
+          parameters: {
+            type: "object",
+            properties: {
+              timezone: {
+                type: "string",
+                description:
+                  "The timezone to get the current time for (e.g., Asia/Shanghai)",
+              },
+            },
+            required: ["timezone"],
+          },
+        },
+        {
+          type: "function",
+          name: "get_current_weather",
+          description: "Get the current weather for a location",
+          parameters: {
+            type: "object",
+            properties: {
+              location: {
+                type: "string",
+                description: "The location to get weather for",
+              },
+              format: {
+                type: "string",
+                enum: ["celsius", "fahrenheit"],
+              },
+            },
+            required: ["location", "format"],
+          },
+        },
+      ],
+      tool_choice: "auto",
+      stream: streamMode,
+    };
+
+    console.log("Endpoint:", resolveEndpoint(useCompact));
+
+    const toolResponses = {};
+    let textResponse = "";
+
+    if (streamMode) {
+      const events = await sendResponseRequest(payload, useCompact);
+      for (const event of events) {
+        console.log("Event received:", JSON.stringify(event));
+
+        if (event.type === "response.output_text.delta") {
+          textResponse += event.delta || "";
+        }
+
+        if (event.type === "response.function_call_arguments.delta") {
+          if (!toolResponses[event.item_id]) {
+            toolResponses[event.item_id] = {
+              id: event.item_id,
+              arguments: "",
+            };
+          }
+          toolResponses[event.item_id].arguments += event.delta || "";
+        }
+      }
+    } else {
+      const response = await sendResponseRequest(payload, useCompact);
+      console.log("Response received:", JSON.stringify(response, null, 2));
+      textResponse = response.output_text || "";
+
+      for (const item of response.output || []) {
+        if (item.type === "function_call") {
+          toolResponses[item.id] = {
+            id: item.id,
+            name: item.name,
+            arguments: item.arguments,
+          };
+        }
+      }
+    }
+
+    console.log("====================\n");
+    console.log("Text Response:\n", textResponse);
+    console.log("\n====================\n");
+    console.log("Tool Response:\n");
+    for (const toolId in toolResponses) {
+      const toolResponse = toolResponses[toolId];
+      if (toolResponse.arguments && typeof toolResponse.arguments === "string") {
+        try {
+          toolResponse.arguments = JSON.parse(toolResponse.arguments);
+        } catch {
+          // Keep as string if parsing fails.
+        }
+      }
+      console.log(JSON.stringify(toolResponse, null, 2));
+    }
+  } catch (error) {
+    console.error("Error:", error);
+    throw error;
+  }
+}
+
+testResponseToolInvocation(stream, compact);

--- a/tests/unit/adapters/openai_response_adapter.test.js
+++ b/tests/unit/adapters/openai_response_adapter.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { OpenAIResponseAdapter } from "../../../src/utils/adapters/openai_response_adapter.js";
+import { createMockChatClient } from "../helpers/mock_chat_client.js";
+import {
+  textResponse,
+  toolCallsResponse,
+  textStreamChunks,
+  toolCallStreamChunks,
+  createStreamBuffer,
+} from "../fixtures/openai_responses.js";
+
+describe("OpenAIResponseAdapter", () => {
+  let adapter;
+
+  beforeEach(() => {
+    adapter = new OpenAIResponseAdapter(createMockChatClient());
+  });
+
+  describe("convertRequest", () => {
+    it("should convert response input to chat.completions messages", () => {
+      const payload = {
+        model: "gpt-4o",
+        instructions: "You are a helpful assistant.",
+        input: [
+          {
+            role: "user",
+            content: [
+              { type: "input_text", text: "Hello" },
+            ],
+          },
+        ],
+        temperature: 0.5,
+      };
+
+      const result = adapter.convertRequest(payload);
+
+      expect(result.model).toBe("gpt-4o");
+      expect(result.messages[0]).toEqual({
+        role: "system",
+        content: "You are a helpful assistant.",
+      });
+      expect(result.messages[1]).toEqual({
+        role: "user",
+        content: "Hello",
+      });
+      expect(result.temperature).toBe(0.5);
+    });
+
+    it("should convert function tools into chat completion format", () => {
+      const payload = {
+        model: "gpt-4o",
+        input: "call tool",
+        tools: [
+          {
+            type: "function",
+            name: "get_weather",
+            description: "Get weather",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      };
+
+      const result = adapter.convertRequest(payload);
+
+      expect(result.tools).toEqual([
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "Get weather",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ]);
+    });
+  });
+
+  describe("detectVisionRequest", () => {
+    it("should detect image content in responses input", () => {
+      const payload = {
+        input: [
+          {
+            role: "user",
+            content: [
+              { type: "input_text", text: "describe" },
+              { type: "input_image", image_url: "data:image/png;base64,abc" },
+            ],
+          },
+        ],
+      };
+
+      expect(adapter.detectVisionRequest(payload)).toBe(true);
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should convert text completion response to responses format", () => {
+      const result = adapter.parseResponse(textResponse);
+
+      expect(result.object).toBe("response");
+      expect(result.status).toBe("completed");
+      expect(result.output_text).toContain("The sky is blue");
+      expect(result.output[0].type).toBe("message");
+    });
+
+    it("should include function_call output for tool call responses", () => {
+      const result = adapter.parseResponse(toolCallsResponse);
+
+      expect(result.output.some((item) => item.type === "function_call")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("parseStreamChunk", () => {
+    it("should emit response.output_text.delta events from chat completion chunks", () => {
+      const state = {};
+      const buffer = createStreamBuffer(textStreamChunks.slice(0, 4));
+
+      const { parsedMessages } = adapter.parseStreamChunk(buffer, state);
+
+      const deltaEvents = parsedMessages.filter(
+        (message) => message.type === "response.output_text.delta",
+      );
+      expect(deltaEvents.length).toBeGreaterThan(0);
+      expect(deltaEvents[0].delta).toBe("The ");
+    });
+
+    it("should emit function_call_arguments delta events", () => {
+      const state = {};
+      const buffer = createStreamBuffer(toolCallStreamChunks.slice(0, 5));
+
+      const { parsedMessages } = adapter.parseStreamChunk(buffer, state);
+
+      const deltaEvents = parsedMessages.filter(
+        (message) => message.type === "response.function_call_arguments.delta",
+      );
+      expect(deltaEvents.length).toBeGreaterThan(0);
+    });
+
+    it("should emit response.completed on done", () => {
+      const state = {};
+      const buffer = createStreamBuffer(textStreamChunks);
+
+      const { parsedMessages } = adapter.parseStreamChunk(buffer, state);
+
+      expect(
+        parsedMessages.some((message) => message.type === "response.completed"),
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Make OpenAI Responses manual tests follow the same direct, self-contained style used by the Anthropic manual tests to simplify inspection and execution.
- Add the missing multi-turn tools manual test to validate function-call / function_call_output multi-turn flows for the Responses API.

### Description
- Refactored manual OpenAI Responses tests to be self-contained by inlining endpoint resolution, HTTP request sending, and SSE parsing logic into each script instead of using a shared helper.
- Updated the following manual test scripts: `tests/manual/openai_response_textmsg_test.js`, `tests/manual/openai_response_tools_test.js`, `tests/manual/openai_response_image_test.js`, and `tests/manual/openai_response_mixed_content_test.js`.
- Removed the extracted helper file `tests/manual/openai_response_test_utils.js` and added the missing `tests/manual/openai_response_multi_turn_tools_test.js` which exercises turn-1 tool calls, mocked tool execution, and turn-2 `function_call_output` follow-up.

### Testing
- Ran `node --check` on the updated manual test scripts and the syntax checks passed for all scripts.
- Ran `npm run lint && npm run test:unit` and the lint check completed and the unit test suite passed (6 test files, 133 tests all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6a98473c832798fc0014ab8f0b7a)