### PR TITLE
docs: define ghcp-gateway refactor architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@
 - [Ollama Chat → Chat Completions](./ollama_chat_to_chat_completions.md)
 - [Anthropic Messages → Chat Completions](./claude_messages_to_chat_completions.md)
 - [OpenAI Responses → Chat Completions](./codex_response_to_chat_completions.md)
+- [OpenAI Responses 上游路由](./openai_responses_routing.md)
 - [GitHub Copilot 模型列表](./github_copilot_model_listing_apis.md)
 
 `docs/cc-switch/` 和 `docs/litellm/` 是来源说明，不是运行时 profile。架构与生产规范冲突时，
@@ -45,17 +46,17 @@ middleware；协议精确字节输出不使用会改变序列化结果的便捷 
 
 CLI 使用一个 executable 和分组 subcommands：
 
-```tex
+```text
 ghcp-gateway serve
 ghcp-gateway status
 ghcp-gateway auth login
-ghcp-gateway auth logou
+ghcp-gateway auth logout
 ghcp-gateway auth status
-ghcp-gateway models lis
-ghcp-gateway models curren
+ghcp-gateway models list
+ghcp-gateway models current
 ghcp-gateway models set <model>
 ghcp-gateway admin open
-
+```
 
 `serve` 在前台运行并处理 graceful shutdown。后台常驻由 systemd、launchd、Windows Service 或调用方
 process manager 管理，不再维护一个跨平台 PID-file `serverctl` executable。Web 管理页面是配置与
@@ -66,10 +67,11 @@ README 在代码、CLI 和迁移行为完成后统一更新，避免文档先于
 
 ## 3. 设计目标
 
-1. 完整支持四份生产规范，不用公共抽象改写协议特有语义。
+1. 完整支持五份生产规范，不用公共抽象改写协议特有语义。
 2. raw HTTP/SSE、typed Chat chunks、协议状态机和 downstream wire serialization 各自有明确归属。
 3. 每个请求的状态独占；跨请求状态只能通过显式 interface 修改。
-4. 同一 GitHub Copilot Chat upstream 支撑 OpenAI Chat、Responses、Anthropic 和 Ollama。
+4. 同一 GitHub Copilot backend 提供 Chat Completions 与 native Responses；Responses planner 决定
+   直接调用 native endpoint，还是使用 Chat bridge。
 5. 协议代码按行为纵向聚合，避免 `controllers/services/repositories` 式横向跳转。
 6. 公共 interface 小而深，调用者不需要了解 tool、reasoning、terminal 或 serializer 内部状态。
 7. 缓存、history、日志、指标和流队列全部有界。
@@ -78,7 +80,8 @@ README 在代码、CLI 和迁移行为完成后统一更新，避免文档先于
 
 ## 4. 非目标
 
-- 不实现运行时 protocol profile、capability switch 或 legacy compatibility branch。
+- 不实现用户可任意切换的 protocol profile、按名称猜测 capability 或 legacy compatibility branch；
+  允许由固定 model routing metadata 决定 native Responses/Chat bridge。
 - 不创建会丢失信息的通用 message/canonical model。
 - 不提供动态 protocol plugin loader。
 - 不支持未被生产规范定义的 `/responses`、`/models` 或 compact aliases。
@@ -94,9 +97,9 @@ README 在代码、CLI 和迁移行为完成后统一更新，避免文档先于
 | Method | Route | 协议 | 行为 |
 | --- | --- | --- | --- |
 | `POST` | `/v1/chat/completions` | OpenAI Chat Completions | 原生 Chat 路径；stream 为 OpenAI SSE |
-| `POST` | `/v1/responses` | OpenAI Responses | 转换为 Chat；返回 Responses JSON/SSE |
+| `POST` | `/v1/responses` | OpenAI Responses | 按 model metadata 选择 native Responses 或 Chat bridge |
 | `POST` | `/v1/messages` | Anthropic Messages | 转换为 Chat；返回 Anthropic JSON/SSE |
-| `GET` | `/v1/models` | OpenAI Models | 同一 Copilot model catalog 的 OpenAI 表示 |
+| `GET` | `/v1/models` | OpenAI/Anthropic Models | 默认 OpenAI shape；存在 `anthropic-version` 时为 Anthropic shape |
 | `POST` | `/api/chat` | Ollama Chat | 转换为 Chat；返回 Ollama JSON/NDJSON |
 | `GET` | `/api/tags` | Ollama List Models | 同一 Copilot model catalog 的 Ollama 表示 |
 | `GET` | `/api/version` | Ollama probe | 只提供兼容版本信息，不参与模型转换 |
@@ -146,7 +149,7 @@ flowchart LR
     State[(SQLite state.db)]
     Admin[Admin module]
 
-    Clients --> Hos
+    Clients --> Host
     Host --> Protocols
     Host --> Catalog
     Protocols --> Backend
@@ -155,15 +158,16 @@ flowchart LR
     Backend --> GitHub
     Backend --> CAPI
     History --> State
-    AdminBrowser --> Hos
+    AdminBrowser --> Host
     Host --> Admin
     Admin --> Catalog
     Admin --> History
     Admin --> State
+```
 
-
-所有推理最终只调用 Chat Completions upstream。这里的 Chat DTO 是上游 wire pivot，不是把所有下游
-协议统一成同一种 domain model。
+OpenAI Chat、Anthropic、Ollama 以及 Responses 的 bridge plan 调用 Chat Completions upstream；
+Responses native plan 直接调用 GitHub Copilot Responses upstream。Chat DTO 只是在 bridge 路径中的
+wire pivot，不是把所有下游协议统一成同一种 domain model。
 
 ## 7. 总体 module 设计
 
@@ -193,17 +197,17 @@ flowchart TD
     Http --> Ollama
     Http --> Models
     Http --> Admin
-    OpenAI --> Copilo
-    Responses --> Copilo
-    Anthropic --> Copilo
-    Ollama --> Copilo
+    OpenAI --> Copilot
+    Responses --> Copilot
+    Anthropic --> Copilot
+    Ollama --> Copilot
     Responses --> History
     Responses --> Models
-    Models --> Copilo
+    Models --> Copilot
     Copilot --> Stream
     History --> Persistence
     Admin --> Persistence
-
+```
 
 依赖只能沿箭头方向。Protocol modules 不 import Hono、SQLite、`process.env` 或具体 HTTP client。
 
@@ -220,7 +224,7 @@ export interface Gateway {
 export async function createGateway(
   config: Readonly<GatewayConfig>,
 ): Promise<Gateway>;
-
+```
 
 `fetch` 后隐藏：
 
@@ -245,14 +249,14 @@ export type ProtocolEndpoint = (
   request: Request,
   scope: Readonly<RequestScope>,
 ) => Promise<Response>;
-
+```
 
 ```ts
 createOpenAiChatEndpoint(dependencies): ProtocolEndpoint;
 createResponsesEndpoint(dependencies): ProtocolEndpoint;
 createAnthropicMessagesEndpoint(dependencies): ProtocolEndpoint;
 createOllamaChatEndpoint(dependencies): ProtocolEndpoint;
-
+```
 
 这四个 factories 具有相同调用形状，但不继承 `BaseAdapter`，也不要求内部实现同一组
 `convertRequest/parseResponse/parseStreamChunk` methods。统一调用形状来自 Fetch interface，
@@ -261,10 +265,10 @@ createOllamaChatEndpoint(dependencies): ProtocolEndpoint;
 每个 endpoint module 内部隐藏：
 
 1. request decoding 和协议特有 validation；
-2. request → Chat conversion；
-3. non-stream Chat → protocol response；
-4. stream request-local state machine；
-5. protocol wire encoder；
+2. upstream execution planning；
+3. 需要 bridge 时的 request/response conversion；
+4. native 或 bridge stream request-local state；
+5. protocol/native wire encoder；
 6. protocol公开错误映射；
 7. exact clock/UUID/token-counter 调用时机。
 
@@ -273,7 +277,7 @@ Hono route 只做显式注册：
 ```ts
 app.post("/v1/responses", (context) =>
   responsesEndpoint(context.req.raw, createRequestScope(context)));
-
+```
 
 固定 route 数量较少，显式注册比 protocol registry 更易读。增加第五种协议时新增一个纵向 module 和
 一条 route，不修改现有协议 implementation。
@@ -286,7 +290,7 @@ export interface RequestScope {
   readonly principal: InferencePrincipal;
   readonly signal: AbortSignal;
 }
-
+```
 
 Scope 只包含所有请求都真正需要的宿主信息。Protocol-specific context、ToolContext、reasoning
 configuration、original request 和 stream cursors 留在对应 protocol module，不能加入
@@ -307,18 +311,36 @@ interface ResponsesRequestPlanner {
   ): Promise<PreparedResponsesRequest>;
 }
 
-interface PreparedResponsesRequest {
+type PreparedResponsesRequest =
+  | PreparedNativeResponsesRequest
+  | PreparedChatBridgeRequest;
+
+interface PreparedNativeResponsesRequest {
+  readonly kind: "native_responses";
+  readonly responsesRequest: ResponsesRequest;
+}
+
+interface PreparedChatBridgeRequest {
+  readonly kind: "chat_bridge";
   readonly chatRequest: ChatRequest;
   readonly responseContext: ResponseContext;
   readonly streamContext: StreamContext;
 }
+```
 
+Planner 先用实际 upstream model resolver 得到唯一 `ResolvedModel`，再读取该 model 的 immutable
+routing metadata，并按 [Responses 上游路由规范](./openai_responses_routing.md) 选择 plan。
+Alias、默认模型或 deployment mapping 不得在 planning 后再次改变 model；不得按 `gpt-*`、vendor
+或 hostname 猜测。
 
-Planner 在 Responses module 内严格执行：
+Native plan 复用 planning 前的 model selection 结果，直接构造 `PreparedNativeResponsesRequest`，
+不访问本地 history 或 Chat converter。
+
+ChatBridgePlan 继续严格执行原顺序：
 
 1. 保存客户端显式 `prompt_cache_key`；
 2. 调用 Responses history enrichment；
-3. 根据已绑定账号的 catalog 选择 model，并同步写入 request 与 request context；
+3. 把 planning 前唯一解析的 `ResolvedModel.upstreamModel` 同步写入 request 与 request context；
 4. 构造 immutable ToolContext；
 5. 从 provider/model 配置解析 ReasoningConfig；
 6. 调用纯 request converter；
@@ -340,10 +362,16 @@ export interface BoundCopilot {
   readonly accountId: AccountId;
   readonly target: Readonly<CopilotTarget>;
 
-  complete(request: Readonly<ChatRequest>): Promise<ChatResponse>;
-  openStream(request: Readonly<ChatRequest>): Promise<UpstreamByteStream>;
+  completeChat(request: Readonly<ChatRequest>): Promise<ChatResponse>;
+  openChatStream(request: Readonly<ChatRequest>): Promise<UpstreamByteStream>;
+  completeResponses(
+    request: Readonly<ResponsesRequest>,
+  ): Promise<NativeResponsesResponse>;
+  openResponsesStream(
+    request: Readonly<ResponsesRequest>,
+  ): Promise<UpstreamByteStream>;
 }
-
+```
 
 `bindDefault()` 在一次请求内只执行一次默认账号解析。返回的 `BoundCopilot` 固定 account、credential
 和 target；请求执行期间默认账号变化不能影响它。
@@ -356,9 +384,10 @@ Production adapter 隐藏：
 - 固定出站 headers；
 - timeout、redirect、取消和连接复用；
 - secret redaction；
-- `/chat/completions` URL 构造。
+- `/chat/completions` 与 `/responses` URL 构造。
 
-Tests 使用 scripted adapter，直接返回 Chat JSON 或可按 byte boundary 控制的 upstream stream。
+Tests 使用 scripted adapter，分别返回 Chat JSON、native Responses JSON，或可按 byte boundary
+控制的 upstream stream。
 
 Model catalog 通过独立、较窄的 source seam 获取 CAPI 数据，不扩大推理 interface：
 
@@ -369,7 +398,7 @@ interface CopilotModelsSource {
     signal: AbortSignal,
   ): Promise<CapiModelsResponse>;
 }
-
+```
 
 Production adapter 复用同一 credential provider 和 HTTP pool；tests 使用 scripted source。
 
@@ -389,7 +418,7 @@ interface CopilotCredentialProvider {
     signal: AbortSignal,
   ): Promise<string>;
 }
-
+```
 
 账号不存在、credential 无效、token endpoint 401、网络错误和 timeout 必须保持不同错误类别。
 Protocol modules 不知道 token 的存储方式。
@@ -398,35 +427,53 @@ Protocol modules 不知道 token 的存储方式。
 
 ### 9.1 Pipeline
 
-```tex
+Chat bridge pipeline：
+
+```text
 upstream Uint8Array
   -> incremental UTF-8 decoder
   -> SSE framer
-  -> SSE even
+  -> SSE event
   -> Chat SSE decoder
   -> ChatStreamFrame
   -> protocol-local stream state
   -> protocol-local wire encoder
   -> downstream Uint8Array
+```
 
+Native Responses pipeline：
+
+```text
+upstream Responses SSE Uint8Array
+  -> Responses SSE framing
+  -> native event validation
+  -> output-index item-ID normalization
+  -> Responses SSE encoder
+  -> downstream Uint8Array
+```
+
+Native Responses 不进入 Chat SSE decoder，也不重新构造 Chat-bridge Responses item lifecycle。
+它只按 `output_index` 把 sub-event 和 `output_item.done` 的 ID 统一到
+`output_item.added.item.id`，其余 event fields、usage 和 ordering 保持不变。Client abort 和
+backpressure 仍由同一个 stream pump 管理。
 
 ```ts
 export type ChatStreamFrame =
   | { readonly kind: "chunk"; readonly chunk: ChatChunk }
   | { readonly kind: "error"; readonly value: WireJson | string }
   | { readonly kind: "done" };
-
+```
 
 Async iterator 正常结束与 `kind:"done"` 是不同信号。这样可以同时表达：
 
 - Ollama 对 `[DONE]`、truncation 和唯一 terminal owner 的要求；
 - Anthropic 的 `start/consume/finish` lifecycle；
-- Responses 的 typed chunk iterator 与 item lifecycle；
+- Responses ChatBridgePlan 的 typed chunk iterator 与 item lifecycle；
 - OpenAI Chat 对 raw SSE 的低开销透传。
 
 Raw SSE module 只处理 bytes、UTF-8、BOM、换行、field、multi-data、error frame 和 `[DONE]`。
-它不生成 Ollama、Anthropic 或 Responses object。Typed converters 永远不读取 `data:` 或残余
-UTF-8 bytes。
+它不生成 Ollama、Anthropic 或 Responses object。Bridge typed converters 永远不读取 `data:` 或
+残余 UTF-8 bytes。Native Responses 使用独立的 Responses SSE parser 和 stream-scoped item-ID map。
 
 ### 9.2 Backpressure 与取消
 
@@ -443,7 +490,7 @@ UTF-8 bytes。
 
 任何 module 都不能通过 callback 在 writer 未消费前继续积压 chunks。
 
-### 9.3 Response commi
+### 9.3 Response commit
 
 Stream writer 显式跟踪 `responseCommitted`：
 
@@ -455,15 +502,17 @@ Stream writer 显式跟踪 `responseCommitted`：
 | --- | --- |
 | Ollama | 非 abort 时恰好追加一个安全 NDJSON error；不再输出 `done:true` |
 | Anthropic | 关闭连接；不合成 `event:error` 或 `message_stop` |
-| Responses | 关闭连接；不合成 `response.failed` |
+| Responses Chat bridge | 关闭连接；不合成 `response.failed` |
+| Responses native | 关闭连接；不把 native failure 改写成 Chat bridge events |
 | OpenAI Chat | 关闭连接；不合成 `[DONE]` |
 
 ### 9.4 Protocol-local terminal ownership
 
 - Ollama reducer 是 `Done` 的唯一消费者和 terminal owner。
 - Anthropic converter 维护 start、active block、pending finish/usage 和 exactly-once stop。
-- Responses converter 独立维护 response、reasoning、message、tool item、output index 和
-  `sequence_number`。
+- Responses Chat bridge converter 独立维护 response、reasoning、message、tool item、output index
+  和 `sequence_number`。
+- Responses native stream 不创建 bridge state machine，也不读写本地 Responses history。
 - OpenAI Chat stream 采用 raw fast path；不为透传请求创建其他协议的状态机。
 
 这些状态机不能合并成通用 `StreamTransformer`。
@@ -472,7 +521,7 @@ Stream writer 显式跟踪 `responseCommitted`：
 
 ### 10.1 Wire JSON
 
-普通 `JSON.parse()` 会重排 integer-like object keys，并把所有 JSON number 转为 JavaScrip
+普通 `JSON.parse()` 会重排 integer-like object keys，并把所有 JSON number 转为 JavaScript
 `number`。这不足以满足 ordered arguments、canonical JSON 和 byte golden 要求。
 
 HTTP body reader 因此输出保留 member 顺序和 number lexeme 的语法 AST：
@@ -491,7 +540,7 @@ export type WireJson =
         value: WireJson;
       }>[];
     };
-
+```
 
 Wire JSON module 是 in-process deep module，负责：
 
@@ -518,7 +567,7 @@ Wire JSON module 是 in-process deep module，负责：
   "noImplicitOverride": true,
   "verbatimModuleSyntax": true
 }
-
+```
 
 - Event、frame、error category 和 state phase 使用 discriminated unions。
 - `unknown` 只允许出现在 HTTP、SQLite JSON 和 remote response seams。
@@ -532,7 +581,8 @@ Wire JSON module 是 in-process deep module，负责：
 
 - Ollama：Go-compatible field order、`omitempty`、HTML escaping、RFC3339Nano 和每 object 一个 LF。
 - Anthropic：Python default `json.dumps` spacing、`ensure_ascii=true` 和精确 SSE event 文本。
-- Responses：Responses event envelope、managed IDs、item ordering 和严格递增 sequence。
+- Responses Chat bridge：Responses event envelope、managed IDs、item ordering 和严格递增 sequence。
+- Responses native：保留上游 usage/events，只归一化同一 output index 的 item IDs。
 - OpenAI Chat：原生 JSON/SSE 和一个成功 `[DONE]`。
 
 不能用一个全局 `serializeResponse(protocol, value)` 条件矩阵实现这些差异。
@@ -542,10 +592,11 @@ Wire JSON module 是 in-process deep module，负责：
 | Module | Request-local state | Shared state | Downstream wire |
 | --- | --- | --- | --- |
 | OpenAI Chat | stream passthrough 与 request metadata | 无 | JSON / OpenAI SSE |
-| Responses | original request、ToolContext、reasoning config、item states、IDs、sequence | Responses history | JSON / Responses SSE |
+| Responses native | resolved model、native request、output-index item-ID map | 无 | Native Responses JSON/SSE |
+| Responses Chat bridge | original request、ToolContext、reasoning config、item states、IDs、sequence | Responses history | Converted Responses JSON/SSE |
 | Anthropic | original model、active block、tool partial JSON、pending finish/usage、UUID | 无 | JSON / Anthropic SSE |
 | Ollama | original model、finish、usage、content/reasoning fragments、sparse tools、clock | 无 | JSON / NDJSON |
-| Model catalog | request-bound account、fetch generation | per-account catalog cache | OpenAI Models / Ollama Tags JSON |
+| Model catalog | request-bound account、fetch generation | per-account catalog cache | OpenAI/Anthropic Models / Ollama Tags JSON |
 
 协议规范明确引用同一算法时才共享 helper，例如指定的 tool-result media extraction。名称相似但
 defaults、ordering、errors 或 bytes 不同的逻辑先保留在协议目录内。
@@ -566,10 +617,13 @@ export interface ResponsesHistory {
     signal: AbortSignal,
   ): Promise<void>;
 }
-
+```
 
 Admin 使用单独的 `ResponsesHistoryAdmin` interface 查询统计和清理，避免推理路径获得不需要的
 管理能力。
+
+该 module 只注入 Responses ChatBridgePlan。NativeResponsesPlan 使用上游
+`previous_response_id`/`encrypted_content`，不访问本地 history。
 
 ### 12.2 持久化语义
 
@@ -586,7 +640,7 @@ TTL、expiry lookup 和测试写入该生产规范；architecture 不能单方�
 
 建议 schema：
 
-```tex
+```text
 responses(
   response_id,
   insertion_seq,
@@ -607,11 +661,12 @@ response_calls(
 INDEX response_calls(call_id)
 UNIQUE INDEX responses(insertion_seq)
 INDEX responses(expires_at)
+```
 
-
-Non-stream 在完整 Responses response 转换成功后、发送成功 body 前提交。Stream 在 request-local
-state 中收集规范要求的 completed items，并在发送 `response.completed` 前提交；提交失败时不发送
-成功 terminal。已经发送的中间 events 不回滚，也不合成 `response.failed`。
+Chat bridge non-stream 在完整 Responses response 转换成功后、发送成功 body 前提交。Chat bridge
+stream 在 request-local state 中收集规范要求的 completed items，并在发送 `response.completed` 前
+提交；提交失败时不发送成功 terminal。已经发送的中间 events 不回滚，也不合成
+`response.failed`。
 
 ## 13. Model catalog
 
@@ -623,7 +678,7 @@ export interface CopilotModelCatalog {
   invalidate(accountId: AccountId): void;
   clear(): void;
 }
-
+```
 
 它隐藏：
 
@@ -638,10 +693,12 @@ export interface CopilotModelCatalog {
 - 使用 Undici 低层 `request`，不声明压缩编码且不自动解压响应；
 - 最多 10 次 redirect 及跨 host/effective-port secret header stripping；
 - 单个合法 `Retry-After`；
-- `/v1/models` 与 `/api/tags` 两个 serializer。
+- 不公开的 Responses routing metadata：`mode` 与 `supported_endpoints`；
+- `/v1/models` 的 OpenAI/Anthropic serializers 与 `/api/tags` serializer。
 
-两个公开 routes 始终读取同一 `CatalogSnapshot`，不维护静态模型表，不排序、不去重、不按名称推断
-能力。
+两个公开 routes 和三种 model serializers 始终读取同一 `CatalogSnapshot`，不维护静态模型表，
+不排序、不去重。Responses native capability 只读取固定 routing metadata，不按模型名称或 vendor
+推断。
 
 `CatalogSnapshot.fetchedAt` 在每次成功 fetch 时只读取一次 clock。`DEFAULT_MODEL_CREATED_AT_TIME` 在
 module 初始化时读取十进制环境值，缺失时使用 `1677610602`；该值只影响 `/v1/models` 的兼容字段，
@@ -670,7 +727,7 @@ export type GitHubEnvironment =
       readonly apiBaseUrl: `https://${string}/api/v3`;
       readonly clientId: "Ov23li8tweQw6odWQebz";
     };
-
+```
 
 | 概念 | github.com | GHES |
 | --- | --- | --- |
@@ -702,16 +759,20 @@ OAuth 和 GitHub REST URLs 使用 `URL` 构造，不做字符串拼接。CAPI mo
 对应 headers：
 
 ```http
-copilot-integration-id: vscode-cha
+copilot-integration-id: vscode-chat
 editor-version: vscode/1.110.1
 editor-plugin-version: copilot-chat/0.38.2
 user-agent: GitHubCopilotChat/0.38.2
 x-github-api-version: 2025-10-01
-
+```
 
 这些值集中定义在 Copilot backend module，不从客户端入站 headers 读取，也不允许管理页面单独修改。
 需要 vision header 时，由协议 request analysis 产生 typed flag，再由 backend 添加固定
 `Copilot-Vision-Request` header。
+
+Native Responses 另外添加 `openai-intent: conversation-panel`、每请求唯一 `x-request-id`、
+`x-vscode-user-agent-library-version: electron-fetch`、由 input 推导的 `x-initiator`，以及需要时的
+vision header。它仍使用上表的新 client identity versions，不继承 LiteLLM 固定提交中的旧版本值。
 
 ### 14.3 Token 与 endpoint 生命周期
 
@@ -749,14 +810,14 @@ OAuth token、Copilot token 和其他 secrets 不存入普通 settings table。S
 
 配置更新流程：
 
-```tex
+```text
 parse
   -> validate complete candidate
   -> SQLite transaction with revision check
-  -> build immutable runtime snapsho
+  -> build immutable runtime snapshot
   -> atomic snapshot swap
   -> invalidate only affected caches
-
+```
 
 失败时继续使用旧 snapshot，不能部分应用。Protocol stream 在开始时捕获 snapshot；请求进行中配置
 变化不改变其行为。
@@ -813,7 +874,7 @@ type GatewayFailure =
   | { kind: "upstream_stream_truncated"; cause: unknown }
   | { kind: "aborted" }
   | { kind: "internal"; cause: unknown };
-
+```
 
 它不是公开、稳定的 `BridgeError` DTO。每个 protocol endpoint 在自己的 module 内把失败映射为生产
 规范要求的 HTTP status、body 或 post-commit 行为。转换异常必须保留 `cause`，不能被 broad catch
@@ -834,7 +895,8 @@ OpenAI Chat 的宿主错误 contract 也不在现有四份规范中。对应 end
 - 超限显式失败，不截断、不返回部分成功。
 - 并发 streams 使用有界 semaphore；等待者响应客户端取消。
 - Stream pipeline 不预取，不保存 raw chunk 历史。
-- Responses 只保留生成 terminal response 与 history record 所需的聚合状态。
+- Responses Chat bridge 只保留生成 terminal response 与 history record 所需的聚合状态；native
+  stream 不缓存完整 response。
 - Model catalog cache 按账号有界；账号数量由本地配置约束。
 - Responses history 固定全库最多 512 条并有 TTL。
 - Metrics label 集合固定，不把 request ID、prompt、任意 model string 作为无界 label。
@@ -860,22 +922,26 @@ gateway 常驻内存。
 
 每个 protocol endpoint 使用同一生产 interface 测试：
 
-```tex
-Fetch Reques
-  -> endpoin
+```text
+Fetch Request
+  -> endpoint
   -> scripted Copilot backend
   -> Fetch Response bytes
+```
 
-
-Scripted backend 同时记录转换后的 Chat request，并返回固定 non-stream response 或可控制 byte spli
-的 stream，因此 request、response、stream 和 wire behavior 不需要通过 private methods 测试。
+Scripted backend 记录选择的 execution plan 及最终 upstream request，并返回固定 Chat/native
+Responses non-stream response 或可控制 byte split 的 stream，因此 request、response、stream 和
+wire behavior 不需要通过 private methods 测试。
 
 必须包含：
 
-- 四份生产规范要求的 differential/golden fixtures；
+- 五份生产规范要求的 differential/golden fixtures；
 - Ollama Go-compatible byte golden；
 - Anthropic Python JSON/SSE text golden；
 - Responses item lifecycle、ToolContext、sequence 和 history round-trip；
+- Responses native/bridge routing matrix、native item-ID normalization、usage 保留和 same-provider
+  no-fallback；
+- `anthropic-version` model-list shape、nullable limits 和不含 Anthropic-only filter；
 - 所有 UTF-8/SSE byte split points；
 - abort、timeout、post-commit failure 和零 upstream call；
 - missing/null/false/0/empty 与 object member order；
@@ -903,7 +969,7 @@ History tests 对 temporary SQLite 运行与 production 相同的 implementation
 
 ## 20. 建议目录
 
-```tex
+```text
 src/
   main.ts
   gateway/
@@ -921,6 +987,8 @@ src/
       wire.ts
     responses/
       endpoint.ts
+      routing.ts
+      native.ts
       bridge.ts
       stream.ts
       tool_context.ts
@@ -966,12 +1034,12 @@ tests/
   fixtures/
   contract/
   integration/
-
+```
 
 目录表示 module locality，不要求每个 type 或函数独立成文件。一个协议的小型 decoder、mapper 和
 validator 可以保留在同一文件；只有状态机或 serializer 足够复杂时才拆分。
 
-## 21. Composition roo
+## 21. Composition root
 
 `main.ts` 和 `create_gateway.ts` 是唯一 composition root，负责：
 
@@ -993,15 +1061,15 @@ Protocol modules 接收 dependencies，不自行读取 `process.env`、打开 da
 固定协议数量少，显式 routes 和 factories 比动态 registry 更易导航。少量 route wiring 重复换来更高
 locality；协议新增仍只需新增目录和一条注册语句。
 
-### 22.2 不保留 `BaseAdapter
+### 22.2 不保留 `BaseAdapter`
 
 现有 base class 要求所有协议共享 request、non-stream、raw stream parsing 和 state interface，
 但生产规范证明这些 lifecycle 不等价。删除继承层后，raw SSE 与 typed conversion 的 seam 更清楚。
 
 ### 22.3 不创建 canonical message model
 
-所有协议都转换到 Chat upstream 不代表它们共享一个可逆 domain model。Responses ToolContext、
-Anthropic block、Ollama ordered JSON 和协议特有损失必须留在各自 module。
+多个协议使用 Chat bridge 不代表它们共享一个可逆 domain model。Responses native path、
+Responses ToolContext、Anthropic block、Ollama ordered JSON 和协议特有损失必须留在各自 module。
 
 ### 22.4 不统一 stream terminal 与 serializer
 
@@ -1034,12 +1102,12 @@ Web Stream 集成，同时让 protocol modules 保持 Fetch-standard interface�
 
 1. strict TypeScript、Wire JSON 和 composition root；
 2. Copilot environment、credential 和 backend；
-3. model catalog 与 `/v1/models`、`/api/tags`；
+3. model catalog、Responses routing metadata、`/v1/models` 三种 serializers 和 `/api/tags`；
 4. raw SSE framing、cancellation 和 backpressure；
 5. OpenAI Chat raw path；
 6. Ollama endpoint；
 7. Anthropic endpoint；
-8. Responses endpoint 与 SQLite history；
+8. Responses native/bridge planner、native transport、Chat bridge 与 SQLite history；
 9. Admin API 和 Svelte UI；
 10. 删除旧 JavaScript adapters、callbacks 和重复配置。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,1047 @@
+# ghcp-gateway 目标架构
+
+## 1. 文档定位
+
+本文定义 ghcp-gateway 重构后的模块、接口、状态归属、路由、依赖方向和运行时技术栈。
+它不重复协议字段映射；以下生产规范仍是可观察行为的唯一来源：
+
+- [Ollama Chat → Chat Completions](./ollama_chat_to_chat_completions.md)
+- [Anthropic Messages → Chat Completions](./claude_messages_to_chat_completions.md)
+- [OpenAI Responses → Chat Completions](./codex_response_to_chat_completions.md)
+- [GitHub Copilot 模型列表](./github_copilot_model_listing_apis.md)
+
+`docs/cc-switch/` 和 `docs/litellm/` 是来源说明，不是运行时 profile。架构与生产规范冲突时，
+生产规范优先。
+
+## 2. 决策摘要
+
+| 范围 | 决策 |
+| --- | --- |
+| Runtime | Node.js 24 LTS，ESM |
+| 语言 | strict TypeScript |
+| HTTP framework | Hono + `@hono/node-server` |
+| 上游 HTTP | Undici；CAPI models 使用低层 `request`，其他请求按协议选择 `fetch`/`request` |
+| 管理前端 | Svelte 5 + Vite + TypeScript，静态构建 |
+| 持久化 | SQLite WAL + `better-sqlite3`，显式 SQL migration |
+| 流模型 | `AsyncIterable` + Web `ReadableStream`，pull-based backpressure |
+| JSON | 保留 object member 顺序和 number lexeme 的 wire JSON module |
+| 日志 | 结构化日志；固定容量的运行时日志和指标快照 |
+| 分发 | npm；运行时只有一个 Node.js 进程 |
+
+选择 Hono 的原因是它以 Web Standard `Request`/`Response` 为 interface，TypeScript 支持好，
+核心较小，并且不会要求协议 module 依赖 framework-specific context。Hono 只负责路由和
+middleware；协议精确字节输出不使用会改变序列化结果的便捷 JSON/SSE helper。
+
+管理前端不使用 SvelteKit server。Vite 构建后的静态文件由同一个 Hono app 提供，因此后台运行时
+没有第二个 JavaScript server。
+
+### 2.1 项目身份与命令
+
+- 项目名称：`ghcp-gateway`。
+- npm package：`@ljie-pi/ghcp-gateway`。
+- npm 只发布一个 executable：`ghcp-gateway`。
+- 新实现不保留 `ghcpo`、`ghcpo-server` 或同名 alias。
+- 配置、日志、PID/service metadata 和 user data directory 使用 `ghcp-gateway` namespace。
+
+CLI 使用一个 executable 和分组 subcommands：
+
+```tex
+ghcp-gateway serve
+ghcp-gateway status
+ghcp-gateway auth login
+ghcp-gateway auth logou
+ghcp-gateway auth status
+ghcp-gateway models lis
+ghcp-gateway models curren
+ghcp-gateway models set <model>
+ghcp-gateway admin open
+
+
+`serve` 在前台运行并处理 graceful shutdown。后台常驻由 systemd、launchd、Windows Service 或调用方
+process manager 管理，不再维护一个跨平台 PID-file `serverctl` executable。Web 管理页面是配置与
+监控的主要交互界面；CLI 只保留启动、诊断、认证和自动化需要的操作。
+
+旧 package、命令和 data path 的一次性迁移策略在实现阶段单独确定，不在运行时长期保留双名称。
+README 在代码、CLI 和迁移行为完成后统一更新，避免文档先于可运行行为。
+
+## 3. 设计目标
+
+1. 完整支持四份生产规范，不用公共抽象改写协议特有语义。
+2. raw HTTP/SSE、typed Chat chunks、协议状态机和 downstream wire serialization 各自有明确归属。
+3. 每个请求的状态独占；跨请求状态只能通过显式 interface 修改。
+4. 同一 GitHub Copilot Chat upstream 支撑 OpenAI Chat、Responses、Anthropic 和 Ollama。
+5. 协议代码按行为纵向聚合，避免 `controllers/services/repositories` 式横向跳转。
+6. 公共 interface 小而深，调用者不需要了解 tool、reasoning、terminal 或 serializer 内部状态。
+7. 缓存、history、日志、指标和流队列全部有界。
+8. GitHub.com 与 GHES 使用同一个 account model，但凭据、OAuth URL 和 REST URL 按环境正确派生。
+9. Web 配置与监控不绕过应用 module，也不读取或返回 secret。
+
+## 4. 非目标
+
+- 不实现运行时 protocol profile、capability switch 或 legacy compatibility branch。
+- 不创建会丢失信息的通用 message/canonical model。
+- 不提供动态 protocol plugin loader。
+- 不支持未被生产规范定义的 `/responses`、`/models` 或 compact aliases。
+- 不引入 Redis、PostgreSQL、ORM、消息队列或第二个后台进程。
+- 不把 Hono、SQLite driver 或 Undici 包装成没有第二个实现的通用 framework interface。
+- 不在 architecture layer 统一各协议的公开错误 DTO。
+- 首版不支持多进程或多实例共享可变状态。
+
+## 5. 公开路由
+
+### 5.1 推理与模型路由
+
+| Method | Route | 协议 | 行为 |
+| --- | --- | --- | --- |
+| `POST` | `/v1/chat/completions` | OpenAI Chat Completions | 原生 Chat 路径；stream 为 OpenAI SSE |
+| `POST` | `/v1/responses` | OpenAI Responses | 转换为 Chat；返回 Responses JSON/SSE |
+| `POST` | `/v1/messages` | Anthropic Messages | 转换为 Chat；返回 Anthropic JSON/SSE |
+| `GET` | `/v1/models` | OpenAI Models | 同一 Copilot model catalog 的 OpenAI 表示 |
+| `POST` | `/api/chat` | Ollama Chat | 转换为 Chat；返回 Ollama JSON/NDJSON |
+| `GET` | `/api/tags` | Ollama List Models | 同一 Copilot model catalog 的 Ollama 表示 |
+| `GET` | `/api/version` | Ollama probe | 只提供兼容版本信息，不参与模型转换 |
+
+路由一致性服从“协议事实标准优先”：
+
+- OpenAI 和 Anthropic-compatible routes 使用 `/v1/...`。
+- Ollama 官方协议使用 `/api/...`，不增加 `/v1/ollama/...` 这类非标准 alias。
+- 不注册 `/models`、`/responses`、`/openai/v1/responses`、`/claude/v1/messages`、
+  `/v1/responses/compact` 或尾斜杠 alias。
+- Query string 不参与 route 匹配；是否允许具体 query 由对应生产规范决定。
+- `/v1/*`、`/api/chat` 和 `/api/tags` 使用同一个 inference authentication middleware；
+  `/api/version`、`/healthz` 和 `/readyz` 不接收 inference credential。
+
+### 5.2 管理与运行状态路由
+
+| Method | Route | 用途 |
+| --- | --- | --- |
+| `GET` | `/admin/*` | Svelte 静态管理页面 |
+| `GET` | `/admin/api/v1/status` | 版本、uptime、认证状态、活动请求和资源概览 |
+| `GET/PUT` | `/admin/api/v1/config` | 读取和原子更新可公开配置 |
+| `GET/POST` | `/admin/api/v1/accounts` | 账号列表，以及启动 github.com/GHES device flow |
+| `DELETE` | `/admin/api/v1/accounts/:accountId` | 删除指定账号及其关联状态 |
+| `PUT` | `/admin/api/v1/accounts/default` | 原子切换默认账号 |
+| `POST` | `/admin/api/v1/models/refresh` | 显式失效指定账号的 model catalog |
+| `GET/DELETE` | `/admin/api/v1/history` | history 使用量和显式清理 |
+| `GET` | `/admin/api/v1/events` | 管理页面单向监控 SSE |
+| `GET` | `/healthz` | 进程存活 |
+| `GET` | `/readyz` | SQLite、配置和必要依赖是否完成初始化 |
+
+管理接口使用独立的 `/admin/api/v1` namespace，不能与兼容协议 route 混用 middleware 或错误
+envelope。
+
+## 6. 系统上下文
+
+```mermaid
+flowchart LR
+    Clients[OpenAI / Anthropic / Ollama clients]
+    AdminBrowser[Admin browser]
+    Host[Hono HTTP host]
+    Protocols[Protocol endpoint modules]
+    Catalog[Model catalog module]
+    Backend[Copilot backend module]
+    GitHub[GitHub.com or GHES]
+    CAPI[GitHub Copilot CAPI]
+    History[Responses history module]
+    State[(SQLite state.db)]
+    Admin[Admin module]
+
+    Clients --> Hos
+    Host --> Protocols
+    Host --> Catalog
+    Protocols --> Backend
+    Protocols --> History
+    Catalog --> Backend
+    Backend --> GitHub
+    Backend --> CAPI
+    History --> State
+    AdminBrowser --> Hos
+    Host --> Admin
+    Admin --> Catalog
+    Admin --> History
+    Admin --> State
+
+
+所有推理最终只调用 Chat Completions upstream。这里的 Chat DTO 是上游 wire pivot，不是把所有下游
+协议统一成同一种 domain model。
+
+## 7. 总体 module 设计
+
+采用“最小 Gateway interface + 显式协议纵向 modules”：
+
+```mermaid
+flowchart TD
+    Main[Composition root]
+    Gateway[Gateway module]
+    Http[Hono host]
+    OpenAI[OpenAI Chat module]
+    Responses[Responses module]
+    Anthropic[Anthropic module]
+    Ollama[Ollama module]
+    Models[Model catalog module]
+    Copilot[Copilot backend module]
+    Stream[Chat SSE framing module]
+    History[Responses history module]
+    Persistence[Persistence module]
+    Admin[Admin module]
+
+    Main --> Gateway
+    Gateway --> Http
+    Http --> OpenAI
+    Http --> Responses
+    Http --> Anthropic
+    Http --> Ollama
+    Http --> Models
+    Http --> Admin
+    OpenAI --> Copilo
+    Responses --> Copilo
+    Anthropic --> Copilo
+    Ollama --> Copilo
+    Responses --> History
+    Responses --> Models
+    Models --> Copilo
+    Copilot --> Stream
+    History --> Persistence
+    Admin --> Persistence
+
+
+依赖只能沿箭头方向。Protocol modules 不 import Hono、SQLite、`process.env` 或具体 HTTP client。
+
+### 7.1 Gateway module
+
+Gateway 是进程对外的深 module：
+
+```ts
+export interface Gateway {
+  fetch(request: Request): Promise<Response>;
+  close(): Promise<void>;
+}
+
+export async function createGateway(
+  config: Readonly<GatewayConfig>,
+): Promise<Gateway>;
+
+
+`fetch` 后隐藏：
+
+- 路由和 middleware；
+- request scope 与 cancellation；
+- account binding；
+- 所有协议转换和 stream state；
+- GitHub/Copilot transport；
+- history 与 catalog cache；
+- exact wire serialization；
+- 管理 API 和静态资源。
+
+`close()` 幂等。它停止接收新请求、取消在途 upstream、等待有界 grace period，然后关闭 HTTP pool、
+SQLite 和日志资源。
+
+### 7.2 Protocol endpoint modules
+
+每个公开推理协议只导出一个 endpoint factory：
+
+```ts
+export type ProtocolEndpoint = (
+  request: Request,
+  scope: Readonly<RequestScope>,
+) => Promise<Response>;
+
+
+```ts
+createOpenAiChatEndpoint(dependencies): ProtocolEndpoint;
+createResponsesEndpoint(dependencies): ProtocolEndpoint;
+createAnthropicMessagesEndpoint(dependencies): ProtocolEndpoint;
+createOllamaChatEndpoint(dependencies): ProtocolEndpoint;
+
+
+这四个 factories 具有相同调用形状，但不继承 `BaseAdapter`，也不要求内部实现同一组
+`convertRequest/parseResponse/parseStreamChunk` methods。统一调用形状来自 Fetch interface，
+不是人为统一协议语义。
+
+每个 endpoint module 内部隐藏：
+
+1. request decoding 和协议特有 validation；
+2. request → Chat conversion；
+3. non-stream Chat → protocol response；
+4. stream request-local state machine；
+5. protocol wire encoder；
+6. protocol公开错误映射；
+7. exact clock/UUID/token-counter 调用时机。
+
+Hono route 只做显式注册：
+
+```ts
+app.post("/v1/responses", (context) =>
+  responsesEndpoint(context.req.raw, createRequestScope(context)));
+
+
+固定 route 数量较少，显式注册比 protocol registry 更易读。增加第五种协议时新增一个纵向 module 和
+一条 route，不修改现有协议 implementation。
+
+### 7.3 Request scope
+
+```ts
+export interface RequestScope {
+  readonly requestId: string;
+  readonly principal: InferencePrincipal;
+  readonly signal: AbortSignal;
+}
+
+
+Scope 只包含所有请求都真正需要的宿主信息。Protocol-specific context、ToolContext、reasoning
+configuration、original request 和 stream cursors 留在对应 protocol module，不能加入
+`RequestScope`。
+
+### 7.4 Responses request planning
+
+Responses module 内部必须有一个明确的 request-planning seam；不能让 converter 自行读取 model
+catalog、默认模型或全局配置：
+
+```ts
+interface ResponsesRequestPlanner {
+  prepare(
+    request: Readonly<ResponsesRequest>,
+    boundCopilot: Readonly<BoundCopilot>,
+    catalog: Readonly<CatalogSnapshot>,
+    signal: AbortSignal,
+  ): Promise<PreparedResponsesRequest>;
+}
+
+interface PreparedResponsesRequest {
+  readonly chatRequest: ChatRequest;
+  readonly responseContext: ResponseContext;
+  readonly streamContext: StreamContext;
+}
+
+
+Planner 在 Responses module 内严格执行：
+
+1. 保存客户端显式 `prompt_cache_key`；
+2. 调用 Responses history enrichment；
+3. 根据已绑定账号的 catalog 选择 model，并同步写入 request 与 request context；
+4. 构造 immutable ToolContext；
+5. 从 provider/model 配置解析 ReasoningConfig；
+6. 调用纯 request converter；
+7. 根据已绑定 target 的 host/path 注入 prompt cache key。
+
+Request、response 和 stream contexts 保持协议规范规定的独立类型；不得合并成通用
+`ProviderContext` 或 `Capabilities`。
+
+## 8. Copilot backend module
+
+Copilot backend 是协议 modules 使用的唯一 remote seam：
+
+```ts
+export interface CopilotBackend {
+  bindDefault(signal: AbortSignal): Promise<BoundCopilot>;
+}
+
+export interface BoundCopilot {
+  readonly accountId: AccountId;
+  readonly target: Readonly<CopilotTarget>;
+
+  complete(request: Readonly<ChatRequest>): Promise<ChatResponse>;
+  openStream(request: Readonly<ChatRequest>): Promise<UpstreamByteStream>;
+}
+
+
+`bindDefault()` 在一次请求内只执行一次默认账号解析。返回的 `BoundCopilot` 固定 account、credential
+和 target；请求执行期间默认账号变化不能影响它。
+
+Production adapter 隐藏：
+
+- GitHub.com/GHES credential 选择；
+- Copilot token 刷新；
+- CAPI endpoint discovery 和 fallback；
+- 固定出站 headers；
+- timeout、redirect、取消和连接复用；
+- secret redaction；
+- `/chat/completions` URL 构造。
+
+Tests 使用 scripted adapter，直接返回 Chat JSON 或可按 byte boundary 控制的 upstream stream。
+
+Model catalog 通过独立、较窄的 source seam 获取 CAPI 数据，不扩大推理 interface：
+
+```ts
+interface CopilotModelsSource {
+  fetch(
+    accountId: AccountId,
+    signal: AbortSignal,
+  ): Promise<CapiModelsResponse>;
+}
+
+
+Production adapter 复用同一 credential provider 和 HTTP pool；tests 使用 scripted source。
+
+### 8.1 Credential provider internal seam
+
+模型目录规范要求的 credential interface 保留为 Copilot backend 的内部 seam，并补充取消参数：
+
+```ts
+interface CopilotCredentialProvider {
+  resolveDefaultAccountId(signal: AbortSignal): Promise<AccountId | null>;
+  getValidTokenForAccount(
+    accountId: AccountId,
+    signal: AbortSignal,
+  ): Promise<SecretToken>;
+  getApiEndpointForAccount(
+    accountId: AccountId,
+    signal: AbortSignal,
+  ): Promise<string>;
+}
+
+
+账号不存在、credential 无效、token endpoint 401、网络错误和 timeout 必须保持不同错误类别。
+Protocol modules 不知道 token 的存储方式。
+
+## 9. Streaming 架构
+
+### 9.1 Pipeline
+
+```tex
+upstream Uint8Array
+  -> incremental UTF-8 decoder
+  -> SSE framer
+  -> SSE even
+  -> Chat SSE decoder
+  -> ChatStreamFrame
+  -> protocol-local stream state
+  -> protocol-local wire encoder
+  -> downstream Uint8Array
+
+
+```ts
+export type ChatStreamFrame =
+  | { readonly kind: "chunk"; readonly chunk: ChatChunk }
+  | { readonly kind: "error"; readonly value: WireJson | string }
+  | { readonly kind: "done" };
+
+
+Async iterator 正常结束与 `kind:"done"` 是不同信号。这样可以同时表达：
+
+- Ollama 对 `[DONE]`、truncation 和唯一 terminal owner 的要求；
+- Anthropic 的 `start/consume/finish` lifecycle；
+- Responses 的 typed chunk iterator 与 item lifecycle；
+- OpenAI Chat 对 raw SSE 的低开销透传。
+
+Raw SSE module 只处理 bytes、UTF-8、BOM、换行、field、multi-data、error frame 和 `[DONE]`。
+它不生成 Ollama、Anthropic 或 Responses object。Typed converters 永远不读取 `data:` 或残余
+UTF-8 bytes。
+
+### 9.2 Backpressure 与取消
+
+所有 stage 使用 pull-based `AsyncIterable`，一次最多向前读取一个尚未消费的 item。将 iterator
+转换成 `ReadableStream` 时，`pull()` 才调用 `iterator.next()`；不创建无界 event queue。
+
+客户端断开时：
+
+1. abort request scope；
+2. 取消 upstream fetch；
+3. 调用当前 iterator 的 `return()`；
+4. 释放 decoder、protocol state 和 timer；
+5. 不再输出 error 或 success terminal。
+
+任何 module 都不能通过 callback 在 writer 未消费前继续积压 chunks。
+
+### 9.3 Response commi
+
+Stream writer 显式跟踪 `responseCommitted`：
+
+- 首个 downstream byte 前失败：返回该协议的普通 HTTP error。
+- 首个 byte 后失败：由对应 protocol module 决定是否追加协议内错误或直接关闭。
+- Client abort：所有协议都直接关闭，不追加任何 bytes。
+
+| 协议 | 已开始输出后的失败 |
+| --- | --- |
+| Ollama | 非 abort 时恰好追加一个安全 NDJSON error；不再输出 `done:true` |
+| Anthropic | 关闭连接；不合成 `event:error` 或 `message_stop` |
+| Responses | 关闭连接；不合成 `response.failed` |
+| OpenAI Chat | 关闭连接；不合成 `[DONE]` |
+
+### 9.4 Protocol-local terminal ownership
+
+- Ollama reducer 是 `Done` 的唯一消费者和 terminal owner。
+- Anthropic converter 维护 start、active block、pending finish/usage 和 exactly-once stop。
+- Responses converter 独立维护 response、reasoning、message、tool item、output index 和
+  `sequence_number`。
+- OpenAI Chat stream 采用 raw fast path；不为透传请求创建其他协议的状态机。
+
+这些状态机不能合并成通用 `StreamTransformer`。
+
+## 10. JSON 与 DTO
+
+### 10.1 Wire JSON
+
+普通 `JSON.parse()` 会重排 integer-like object keys，并把所有 JSON number 转为 JavaScrip
+`number`。这不足以满足 ordered arguments、canonical JSON 和 byte golden 要求。
+
+HTTP body reader 因此输出保留 member 顺序和 number lexeme 的语法 AST：
+
+```ts
+export type WireJson =
+  | null
+  | boolean
+  | string
+  | { readonly kind: "number"; readonly lexeme: string }
+  | { readonly kind: "array"; readonly items: readonly WireJson[] }
+  | {
+      readonly kind: "object";
+      readonly members: readonly Readonly<{
+        key: string;
+        value: WireJson;
+      }>[];
+    };
+
+
+Wire JSON module 是 in-process deep module，负责：
+
+- 有界解析；
+- source member order；
+- missing/null/false/0/empty 的区分；
+- compact JSON；
+- Unicode code-point canonical key sort；
+- ordered object serialization；
+- 将通过验证的值转换成 protocol DTO。
+
+它不是 protocol canonical model。Protocol modules 仍直接从自己的 request DTO 转到 Chat DTO。
+
+### 10.2 TypeScript 约束
+
+至少启用：
+
+```json
+{
+  "strict": true,
+  "noUncheckedIndexedAccess": true,
+  "exactOptionalPropertyTypes": true,
+  "useUnknownInCatchVariables": true,
+  "noImplicitOverride": true,
+  "verbatimModuleSyntax": true
+}
+
+
+- Event、frame、error category 和 state phase 使用 discriminated unions。
+- `unknown` 只允许出现在 HTTP、SQLite JSON 和 remote response seams。
+- 不使用 `as any` 或宽泛 coercion 绕过协议 validation。
+- 不用 Zod/TypeBox 的默认 coercion 替代规范中的精确转换规则。
+- 只有规范明确要求透传动态字段时使用 `Record<string, unknown>`。
+
+### 10.3 Serializer locality
+
+不同 wire behavior 留在协议 module：
+
+- Ollama：Go-compatible field order、`omitempty`、HTML escaping、RFC3339Nano 和每 object 一个 LF。
+- Anthropic：Python default `json.dumps` spacing、`ensure_ascii=true` 和精确 SSE event 文本。
+- Responses：Responses event envelope、managed IDs、item ordering 和严格递增 sequence。
+- OpenAI Chat：原生 JSON/SSE 和一个成功 `[DONE]`。
+
+不能用一个全局 `serializeResponse(protocol, value)` 条件矩阵实现这些差异。
+
+## 11. 协议 module 职责矩阵
+
+| Module | Request-local state | Shared state | Downstream wire |
+| --- | --- | --- | --- |
+| OpenAI Chat | stream passthrough 与 request metadata | 无 | JSON / OpenAI SSE |
+| Responses | original request、ToolContext、reasoning config、item states、IDs、sequence | Responses history | JSON / Responses SSE |
+| Anthropic | original model、active block、tool partial JSON、pending finish/usage、UUID | 无 | JSON / Anthropic SSE |
+| Ollama | original model、finish、usage、content/reasoning fragments、sparse tools、clock | 无 | JSON / NDJSON |
+| Model catalog | request-bound account、fetch generation | per-account catalog cache | OpenAI Models / Ollama Tags JSON |
+
+协议规范明确引用同一算法时才共享 helper，例如指定的 tool-result media extraction。名称相似但
+defaults、ordering、errors 或 bytes 不同的逻辑先保留在协议目录内。
+
+## 12. Responses history
+
+### 12.1 Interface
+
+```ts
+export interface ResponsesHistory {
+  enrich(
+    request: Readonly<ResponsesRequest>,
+    signal: AbortSignal,
+  ): Promise<ResponsesRequest>;
+
+  record(
+    record: Readonly<ResponsesHistoryRecord>,
+    signal: AbortSignal,
+  ): Promise<void>;
+}
+
+
+Admin 使用单独的 `ResponsesHistoryAdmin` interface 查询统计和清理，避免推理路径获得不需要的
+管理能力。
+
+### 12.2 持久化语义
+
+- SQLite 是 source of truth，重启后 history 仍可恢复。
+- 整个 store 最多 512 个 responses，按全局插入顺序淘汰。
+- TTL 可配置，初始默认 7 天；过期记录在 lookup 时视为不存在。
+- `previous_response_id` lookup 优先；call-ID fallback 只在全部未过期记录中唯一命中时使用。
+- Response、ordered call items 和 call-ID index 在一个 transaction 中写入。
+- 启动、lookup 和 record 时清理过期项；正确性不依赖后台 timer。
+- 不增加 read-through memory cache，除非 profiling 证明 SQLite lookup 是瓶颈。
+
+TTL 是此前确认的 gateway 产品要求，但当前 Responses 生产规范只定义 512 条插入淘汰。实施前必须把
+TTL、expiry lookup 和测试写入该生产规范；architecture 不能单方面成为协议行为来源。
+
+建议 schema：
+
+```tex
+responses(
+  response_id,
+  insertion_seq,
+  created_at,
+  expires_at,
+  PRIMARY KEY(response_id)
+)
+
+response_calls(
+  response_id,
+  ordinal,
+  call_id,
+  kind,
+  item_json,
+  PRIMARY KEY(response_id, ordinal)
+)
+
+INDEX response_calls(call_id)
+UNIQUE INDEX responses(insertion_seq)
+INDEX responses(expires_at)
+
+
+Non-stream 在完整 Responses response 转换成功后、发送成功 body 前提交。Stream 在 request-local
+state 中收集规范要求的 completed items，并在发送 `response.completed` 前提交；提交失败时不发送
+成功 terminal。已经发送的中间 events 不回滚，也不合成 `response.failed`。
+
+## 13. Model catalog
+
+Model catalog 是独立 deep module：
+
+```ts
+export interface CopilotModelCatalog {
+  get(accountId: AccountId, signal: AbortSignal): Promise<CatalogSnapshot>;
+  invalidate(accountId: AccountId): void;
+  clear(): void;
+}
+
+
+它隐藏：
+
+- 对 credential provider 返回的 endpoint 字面追加 `"/models"`，不在 catalog module 解析、清理或
+  规范化 endpoint；
+- CAPI `/models` 请求和严格解析；
+- account-scoped cache 与 generation；
+- 无 TTL、无 single-flight 的固定行为；
+- success-empty cache；
+- invalidation 后旧在途请求不得写回；
+- 30 秒 connect timeout、600 秒 total timeout；
+- 使用 Undici 低层 `request`，不声明压缩编码且不自动解压响应；
+- 最多 10 次 redirect 及跨 host/effective-port secret header stripping；
+- 单个合法 `Retry-After`；
+- `/v1/models` 与 `/api/tags` 两个 serializer。
+
+两个公开 routes 始终读取同一 `CatalogSnapshot`，不维护静态模型表，不排序、不去重、不按名称推断
+能力。
+
+`CatalogSnapshot.fetchedAt` 在每次成功 fetch 时只读取一次 clock。`DEFAULT_MODEL_CREATED_AT_TIME` 在
+module 初始化时读取十进制环境值，缺失时使用 `1677610602`；该值只影响 `/v1/models` 的兼容字段，
+不参与 cache key。
+
+## 14. GitHub.com 与 GHES 环境
+
+### 14.1 单一环境解析
+
+用户只配置 GitHub domain。其他 URL 和 OAuth client ID 由 `GitHubEnvironmentResolver` 一次性
+派生，避免多个环境变量互相矛盾：
+
+```ts
+export type GitHubEnvironment =
+  | {
+      readonly kind: "github.com";
+      readonly host: "github.com";
+      readonly webBaseUrl: "https://github.com";
+      readonly apiBaseUrl: "https://api.github.com";
+      readonly clientId: "Iv1.b507a08c87ecfe98";
+    }
+  | {
+      readonly kind: "ghes";
+      readonly host: string;
+      readonly webBaseUrl: `https://${string}`;
+      readonly apiBaseUrl: `https://${string}/api/v3`;
+      readonly clientId: "Ov23li8tweQw6odWQebz";
+    };
+
+
+| 概念 | github.com | GHES |
+| --- | --- | --- |
+| `GITHUB_HOST` | `github.com` | 用户配置的 `<domain>`，可包含显式 port |
+| `GITHUB_API_HOST` | `https://api.github.com` | `https://<domain>/api/v3` |
+| `CLIENT_ID` | `Iv1.b507a08c87ecfe98` | `Ov23li8tweQw6odWQebz` |
+| `DEVICE_CODE_ENDPOINT` | `https://github.com/login/device/code` | `https://<domain>/login/device/code` |
+| `ACCESS_TOKEN_ENDPOINT` | `https://github.com/login/oauth/access_token` | `https://<domain>/login/oauth/access_token` |
+
+`GITHUB_API_HOST` 表示 GitHub REST base URL，不是 Copilot CAPI endpoint。Copilot endpoint 仍按账号
+通过 `/copilot_internal/user` discovery；失败时使用生产规范规定的 github.com/GHES fallback。
+
+GHES input 只接受 domain 或 `domain:port`，不接受 path、query、fragment 或 embedded credentials。
+OAuth 和 GitHub REST URLs 使用 `URL` 构造，不做字符串拼接。CAPI models URL 是生产规范要求的例外，
+必须对已规范化 endpoint 字面追加 `"/models"`。
+
+### 14.2 固定 Copilot client identity
+
+访问 GitHub Copilot/CAPI 时使用以下固定 identity：
+
+| 配置 | 值 |
+| --- | --- |
+| `editorInfo.name` | `vscode` |
+| `editorInfo.version` | `1.110.1` |
+| `editorPluginInfo.name` | `copilot-chat` |
+| `editorPluginInfo.version` | `0.38.2` |
+| `copilotIntegrationId` | `vscode-chat` |
+
+对应 headers：
+
+```http
+copilot-integration-id: vscode-cha
+editor-version: vscode/1.110.1
+editor-plugin-version: copilot-chat/0.38.2
+user-agent: GitHubCopilotChat/0.38.2
+x-github-api-version: 2025-10-01
+
+
+这些值集中定义在 Copilot backend module，不从客户端入站 headers 读取，也不允许管理页面单独修改。
+需要 vision header 时，由协议 request analysis 产生 typed flag，再由 backend 添加固定
+`Copilot-Vision-Request` header。
+
+### 14.3 Token 与 endpoint 生命周期
+
+- github.com 使用有效 Copilot session token；剩余时间 `< 60s` 时按账号刷新，恰好 60 秒仍有效。
+- GHES 使用保存的 GitHub OAuth token，不执行 Copilot token exchange。
+- 同账号 token refresh 和 endpoint discovery 分别使用 mutex，并在锁内二次检查。
+- 不使用全局 30 秒 refresh interval；按需刷新减少后台工作和常驻状态。
+- endpoint discovery 的 cache/fallback 规则严格遵守模型目录生产规范。
+- 删除账号或全量退出时清除 credential、endpoint 和 model catalog。Responses history 当前为全局
+  store，只能通过 retention policy 或显式 history clear 删除。
+
+## 15. Persistence 与配置
+
+### 15.1 SQLite
+
+一个 `state.db` 保存：
+
+- schema migrations；
+- 非 secret account metadata；
+- 默认账号和模型 preference；
+- Web 可修改配置及 revision；
+- Responses history。
+
+使用 WAL、foreign keys、busy timeout 和短事务。不使用 ORM。`better-sqlite3` 直接位于 persistence
+implementation 内；不创建只有一个 adapter 的 `DatabasePort`。
+
+`node:sqlite` 达到 stable 前不作为 production dependency。若实测同步 SQLite 操作造成可见
+event-loop stall，可将同一个 history implementation 移入 worker thread；对 protocol module 的
+interface 不变。
+
+OAuth token、Copilot token 和其他 secrets 不存入普通 settings table。Secret storage 使用独立
+`CredentialStore` seam，production adapter 采用 OS credential vault；tests 使用 memory adapter。
+
+### 15.2 Runtime config
+
+配置更新流程：
+
+```tex
+parse
+  -> validate complete candidate
+  -> SQLite transaction with revision check
+  -> build immutable runtime snapsho
+  -> atomic snapshot swap
+  -> invalidate only affected caches
+
+
+失败时继续使用旧 snapshot，不能部分应用。Protocol stream 在开始时捕获 snapshot；请求进行中配置
+变化不改变其行为。
+
+## 16. 管理页面
+
+### 16.1 技术栈
+
+- Svelte 5；
+- TypeScript；
+- Vite；
+- 纯静态 SPA；
+- 不使用 SvelteKit server；
+- 页面较少时不增加 client router，以 tabs/state 切换视图。
+
+构建产物随 npm package 发布，由 Hono 提供 `/admin/*`。浏览器内存不计入 gateway daemon RSS；
+关闭页面后后台不保留前端 session。
+
+### 16.2 功能
+
+- GitHub.com/GHES device login；
+- 账号列表、默认账号切换和删除；
+- 默认模型和安全配置；
+- model catalog 查看和显式 refresh；
+- Responses history 数量、最旧/最新时间、TTL 和清理；
+- 活动请求、活动 streams、请求/错误计数和延迟；
+- 最近固定数量的脱敏日志。
+
+实时状态使用 `/admin/api/v1/events` SSE，不使用 WebSocket。事件只携带聚合状态，不携带 prompt、
+response body、Authorization、OAuth token、Copilot token 或完整 upstream endpoint。
+
+### 16.3 安全默认值
+
+- 默认只监听 `127.0.0.1`。
+- Public inference routes 使用同一个 inference authentication middleware。
+- Admin routes 使用独立 admin session 和 CSRF token。
+- 一旦允许非 loopback bind，必须配置 admin authentication；TLS 由内置配置或可信 reverse proxy
+  提供。
+- Static catch-all 只能位于 `/admin/*`，不能吞掉 `/v1/*`、`/api/*`、`/healthz` 或 `/readyz`。
+
+## 17. Error ownership
+
+Runtime 可以使用内部 discriminated union 分类失败：
+
+```ts
+type GatewayFailure =
+  | { kind: "invalid_request"; cause: unknown }
+  | { kind: "unsupported_semantics"; cause: unknown }
+  | { kind: "authentication"; cause: unknown }
+  | { kind: "upstream_http"; status: number; retryAfter?: string }
+  | { kind: "upstream_timeout"; cause: unknown }
+  | { kind: "upstream_network"; cause: unknown }
+  | { kind: "invalid_upstream_response"; cause: unknown }
+  | { kind: "upstream_stream_truncated"; cause: unknown }
+  | { kind: "aborted" }
+  | { kind: "internal"; cause: unknown };
+
+
+它不是公开、稳定的 `BridgeError` DTO。每个 protocol endpoint 在自己的 module 内把失败映射为生产
+规范要求的 HTTP status、body 或 post-commit 行为。转换异常必须保留 `cause`，不能被 broad catch
+改写成成功 response。
+
+Anthropic 和 Responses 转换规范把 pre-commit HTTP status、headers 与 error body 明确交给宿主，
+OpenAI Chat 的宿主错误 contract 也不在现有四份规范中。对应 endpoint 必须各自拥有
+`AnthropicHttpErrorPresenter`、`ResponsesHttpErrorPresenter` 和 `OpenAiHttpErrorPresenter`，但在
+实现前应先补充各 route 的 HTTP error contract。不能用 architecture 文档或一个通用 error envelope
+替代缺失的可观察行为规范。
+
+日志只记录分类、request ID、protocol、status 和脱敏 upstream host。不得记录 token、完整 headers、
+完整 request/response body 或非 2xx upstream body。
+
+## 18. 资源约束
+
+- JSON body、单个 SSE event、non-stream response 和 protocol accumulator 都有配置上限。
+- 超限显式失败，不截断、不返回部分成功。
+- 并发 streams 使用有界 semaphore；等待者响应客户端取消。
+- Stream pipeline 不预取，不保存 raw chunk 历史。
+- Responses 只保留生成 terminal response 与 history record 所需的聚合状态。
+- Model catalog cache 按账号有界；账号数量由本地配置约束。
+- Responses history 固定全库最多 512 条并有 TTL。
+- Metrics label 集合固定，不把 request ID、prompt、任意 model string 作为无界 label。
+- 管理日志 ring buffer 和监控订阅者数量有界。
+- Token 和 endpoint 采用按需刷新，不使用常驻 polling interval。
+- SQLite cleanup 在启动/read/write 时执行，初版不增加只为 cleanup 存在的 timer。
+
+实现进入迁移前需要使用真实 fixtures 建立 RSS benchmark，至少测量：
+
+1. idle；
+2. 单 stream；
+3. 少量并发 streams；
+4. 大量 stream 完成和 abort 后；
+5. history 从空到 512 条及 cleanup 后；
+6. 管理页面关闭与打开时。
+
+以进程 RSS/Private Bytes/PSS 为主要指标，不能把 V8 `heapUsed`、npm 磁盘大小或浏览器进程内存混为
+gateway 常驻内存。
+
+## 19. Testing architecture
+
+### 19.1 Protocol contracts
+
+每个 protocol endpoint 使用同一生产 interface 测试：
+
+```tex
+Fetch Reques
+  -> endpoin
+  -> scripted Copilot backend
+  -> Fetch Response bytes
+
+
+Scripted backend 同时记录转换后的 Chat request，并返回固定 non-stream response 或可控制 byte spli
+的 stream，因此 request、response、stream 和 wire behavior 不需要通过 private methods 测试。
+
+必须包含：
+
+- 四份生产规范要求的 differential/golden fixtures；
+- Ollama Go-compatible byte golden；
+- Anthropic Python JSON/SSE text golden；
+- Responses item lifecycle、ToolContext、sequence 和 history round-trip；
+- 所有 UTF-8/SSE byte split points；
+- abort、timeout、post-commit failure 和零 upstream call；
+- missing/null/false/0/empty 与 object member order；
+- deterministic clock 和 UUID。
+
+### 19.2 Ports 与 adapters
+
+| Seam | Production adapter | Test adapter |
+| --- | --- | --- |
+| Copilot backend | Fetch/Undici | Scripted in-process backend |
+| Credential store | OS credential vault | Memory store |
+| Responses history | SQLite WAL | SQLite temporary database |
+| Clock | System clock | Fixed/sequence clock |
+| UUID | `crypto.randomUUID()` | Sequence UUID |
+| Model metadata | Pinned metadata implementation | Fixed fixture map |
+
+History tests 对 temporary SQLite 运行与 production 相同的 implementation；不另写行为不同的 fake。
+
+### 19.3 Integration
+
+- Hono `app.request()` 覆盖 route、middleware、headers 和 buffered responses。
+- Loopback test server 覆盖 streaming、disconnect、redirect、timeout 和 exact bytes。
+- Windows、Linux、macOS CI 覆盖 npm package 与 native SQLite dependency。
+- Memory tests验证 repeated request/abort 后 active scope 归零且 RSS 达到稳定平台。
+
+## 20. 建议目录
+
+```tex
+src/
+  main.ts
+  gateway/
+    create_gateway.ts
+    request_scope.ts
+    hono_app.ts
+    stream_response.ts
+
+  protocols/
+    chat_completions/
+      types.ts
+      sse.ts
+    openai_chat/
+      endpoint.ts
+      wire.ts
+    responses/
+      endpoint.ts
+      bridge.ts
+      stream.ts
+      tool_context.ts
+      wire.ts
+    anthropic_messages/
+      endpoint.ts
+      bridge.ts
+      stream.ts
+      wire.ts
+    ollama_chat/
+      endpoint.ts
+      bridge.ts
+      stream.ts
+      wire.ts
+
+  copilot/
+    backend.ts
+    credentials.ts
+    environment.ts
+    model_catalog.ts
+    transport.ts
+
+  persistence/
+    database.ts
+    account_store.ts
+    responses_history.ts
+    migrations/
+
+  serialization/
+    wire_json.ts
+    canonical_json.ts
+
+  admin/
+    api.ts
+    auth.ts
+    metrics.ts
+
+web/
+  src/
+  vite.config.ts
+
+tests/
+  fixtures/
+  contract/
+  integration/
+
+
+目录表示 module locality，不要求每个 type 或函数独立成文件。一个协议的小型 decoder、mapper 和
+validator 可以保留在同一文件；只有状态机或 serializer 足够复杂时才拆分。
+
+## 21. Composition roo
+
+`main.ts` 和 `create_gateway.ts` 是唯一 composition root，负责：
+
+1. 读取并验证环境和持久配置；
+2. 打开 SQLite 并执行 migration；
+3. 创建 credential store、Copilot backend 和 model catalog；
+4. 创建 Responses history；
+5. 创建四个 protocol endpoints；
+6. 显式注册 public/admin routes；
+7. 加载静态 Web assets；
+8. 注册 graceful shutdown。
+
+Protocol modules 接收 dependencies，不自行读取 `process.env`、打开 database 或创建 HTTP client。
+
+## 22. 取舍与拒绝方案
+
+### 22.1 采用显式协议 modules
+
+固定协议数量少，显式 routes 和 factories 比动态 registry 更易导航。少量 route wiring 重复换来更高
+locality；协议新增仍只需新增目录和一条注册语句。
+
+### 22.2 不保留 `BaseAdapter
+
+现有 base class 要求所有协议共享 request、non-stream、raw stream parsing 和 state interface，
+但生产规范证明这些 lifecycle 不等价。删除继承层后，raw SSE 与 typed conversion 的 seam 更清楚。
+
+### 22.3 不创建 canonical message model
+
+所有协议都转换到 Chat upstream 不代表它们共享一个可逆 domain model。Responses ToolContext、
+Anthropic block、Ollama ordered JSON 和协议特有损失必须留在各自 module。
+
+### 22.4 不统一 stream terminal 与 serializer
+
+终止和 exact bytes 是公开行为。一个带大量 `if (protocol === ...)` 的通用 reducer/serializer 是
+shallow module，会降低可读性并扩大修改影响范围。
+
+### 22.5 选择 Hono 而不是更重 framework
+
+当前 routes 少，主要复杂度在协议而不是 controller ecosystem。Hono 提供足够的路由、middleware 和
+Web Stream 集成，同时让 protocol modules 保持 Fetch-standard interface。
+
+### 22.6 选择静态 Svelte 而不是 full-stack Web framework
+
+管理页面不需要 SSR、server actions 或独立部署。Svelte + Vite 足以提供 typed、可维护的配置与监控
+界面，运行时资源由浏览器承担。
+
+## 23. 实施边界
+
+### 23.1 分支与交付策略
+
+- 远端 `refactor` 是整个重构期间的 integration branch。
+- 每项改动从最新 `refactor` 创建独立 work branch，并通过 PR 合并回 `refactor`。
+- 不在 `main` 上直接 commit 或 push 重构改动。
+- 重构完成、协议 contracts 和 migration 验收通过后，再单独创建 `refactor -> main` 的最终 PR。
+- README 更新属于最后阶段的独立改动，与最终代码和命令行为一起进入 `refactor`。
+
+### 23.2 实施顺序
+
+建议按以下顺序实施，但每一步都以对应生产规范 tests 为完成条件：
+
+1. strict TypeScript、Wire JSON 和 composition root；
+2. Copilot environment、credential 和 backend；
+3. model catalog 与 `/v1/models`、`/api/tags`；
+4. raw SSE framing、cancellation 和 backpressure；
+5. OpenAI Chat raw path；
+6. Ollama endpoint；
+7. Anthropic endpoint；
+8. Responses endpoint 与 SQLite history；
+9. Admin API 和 Svelte UI；
+10. 删除旧 JavaScript adapters、callbacks 和重复配置。
+
+迁移期间不长期维护两套生产行为。一个 route 的新 contract tests 完成后整体切换该 route，并删除旧
+implementation。

--- a/docs/cc-switch/claude_messages_to_chat_completions.md
+++ b/docs/cc-switch/claude_messages_to_chat_completions.md
@@ -1,0 +1,1211 @@
+# Anthropic Messages API 与 OpenAI Chat Completions 桥接实现规范
+
+> 本文描述仓库在提交 `3217f72596f2d1c0f879f0a05f83803825d9809f`
+> 上的实际生产实现。它不是 Anthropic 或 OpenAI 官方协议的完整定义，而是一份可用于
+> 独立重写 CC Switch 现有桥接行为的兼容性规范。
+
+## 1. 结论与边界
+
+仓库已经实现完整的 Anthropic Messages -> OpenAI Chat Completions 请求转换，以及
+Chat Completions -> Anthropic Messages 成功响应转换：
+
+1. Claude/Claude Desktop 客户端向本地代理发送 `/v1/messages` 请求；
+2. provider 配置为 `openai_chat` 时，代理把 endpoint 和 JSON body 转为 Chat
+   Completions；
+3. 上游非流式 Chat response 被转成 Anthropic message；
+4. 上游 Chat SSE 被状态化转成 Anthropic SSE；
+5. `stream:false` 却收到 SSE 的非标准上游会先被聚合成 Chat JSON，再转 Anthropic JSON。
+
+这条链路支持：
+
+- system、text、image、tool_use、tool_result 和部分 thinking 历史；
+- Anthropic tool schema 和 tool_choice；
+- OpenAI reasoning effort 适配；
+- DeepSeek/MiMo 的 `reasoning_content` 历史重放；
+- tool result 图片迁移；
+- token/cache usage 守恒转换；
+- 并行流式 tool call；
+- GitHub Copilot 的无 `/v1` Chat endpoint；
+- OpenAI 兼容网关的重复 finish reason、usage-only 尾块和缺 `[DONE]` 流。
+
+HTTP 非 2xx 不进入 Chat -> Anthropic body 转换器：forwarder 在转换前把它包装为通用
+`UpstreamError` 并参与 failover/错误响应流程。本规范中的“响应转换”主要指 2xx 成功响应。
+
+## 2. 模块分工
+
+| 文件 | 职责 |
+| --- | --- |
+| `src-tauri/src/proxy/providers/claude.rs` | 识别 provider wire format，选择 openai_chat，决定 reasoning history 策略，调用请求转换 |
+| `src-tauri/src/proxy/providers/transform.rs` | Anthropic request <-> Chat response 的非流式核心转换 |
+| `src-tauri/src/proxy/providers/streaming.rs` | Chat Completions SSE -> Anthropic SSE 状态机 |
+| `src-tauri/src/proxy/forwarder.rs` | 模型映射、endpoint/query 改写、header 处理、请求转发、非 2xx 拦截 |
+| `src-tauri/src/proxy/handlers.rs` | 根据 JSON/SSE 和客户端 stream 语义选择响应转换器，伪流式聚合，响应头重建 |
+| `src-tauri/src/proxy/tool_media.rs` | tool result 中的图片抽取、文本占位和合成 user message |
+| `src-tauri/src/proxy/json_canonical.rs` | tool input/result 的稳定 JSON 序列化 |
+
+## 3. 启用条件
+
+### 3.1 Provider API format
+
+Claude provider 的 API format 按以下顺序解析：
+
+1. managed `codex_oauth` 或 `xai_oauth` 强制为 `openai_responses`，不走本文链路；
+2. `provider.meta.api_format`；
+3. legacy `provider.settings_config.api_format`；
+4. legacy `provider.settings_config.openrouter_compat_mode`；
+5. 默认 `anthropic`。
+
+`meta.api_format` 和 `settings_config.api_format` 只有以下精确值会被识别：
+
+```text
+openai_chat
+openai_responses
+gemini_native
+```
+
+其他值回退为 `anthropic`。`openrouter_compat_mode` 支持：
+
+- JSON `true`；
+- 非零 JSON number；
+- trim 后为 `"true"` 或 `"1"` 的字符串。
+
+该 legacy 开关为 true 时等价于 `openai_chat`。
+
+### 3.2 强制转换 Provider
+
+以下 provider 总是进入某种格式转换：
+
+- GitHub Copilot；
+- Codex OAuth；
+- xAI OAuth。
+
+其中 Codex/xAI OAuth 固定走 Responses，不属于本文链路。GitHub Copilot 会动态读取 model
+vendor：
+
+- model vendor 是 OpenAI -> `openai_responses`；
+- vendor 非 OpenAI、查不到、查询失败或没有 AppHandle -> `openai_chat`。
+
+普通 provider 只有最终 format 为 `openai_chat` 时才走本文链路。
+
+### 3.3 客户端入口
+
+主要入口：
+
+```text
+/v1/messages
+```
+
+Claude Desktop 入口会先去掉外层代理前缀，再复用相同 handler。endpoint 改写器也识别：
+
+```text
+/claude/v1/messages
+```
+
+非上述 Messages path 不会被改写。
+
+## 4. Endpoint、query 和 header
+
+### 4.1 Endpoint 改写
+
+普通 openai_chat provider：
+
+```text
+/v1/messages -> /v1/chat/completions
+```
+
+GitHub Copilot：
+
+```text
+/v1/messages -> /chat/completions
+```
+
+这是路径差异，不是 body 格式差异。
+
+原 query 中所有名字以精确小写 `beta=` 开头的参数会删除，其他参数按原顺序保留：
+
+```text
+/v1/messages?beta=true&x-id=1
+  -> /v1/chat/completions?x-id=1
+```
+
+当前过滤是区分大小写的，`Beta=` 不会被删除。
+
+URL builder 将 base URL 与改写后 endpoint 拼接，并重复把 `/v1/v1` 压缩成 `/v1`。因此：
+
+```text
+https://host.example/v1 + /v1/chat/completions
+  -> https://host.example/v1/chat/completions
+```
+
+### 4.2 请求 header
+
+转换链路沿用 forwarder 的通用 header 规则：
+
+- 重写 `Host` 为上游 host；
+- 去掉 `content-length`、`transfer-encoding`、转发/CDN/tracing header；
+- 客户端 `authorization`、`x-api-key`、`x-goog-api-key` 被 provider auth header 替换；
+- `anthropic-beta` 不发送给 openai_chat 上游；
+- `anthropic-version` 不发送给 openai_chat 上游；
+- `accept-encoding` 强制为 `identity`，缺失时补入；
+- GitHub Copilot 的客户端指纹 header 由 provider auth/fingerprint header 替换；
+- 其他 header 默认透传。
+
+强制 identity 是为了让后续 JSON/SSE 转换器直接读取未压缩 body。
+
+### 4.3 响应 header
+
+Anthropic SSE：
+
+```text
+Content-Type: text/event-stream
+Cache-Control: no-cache
+```
+
+非流式 Anthropic JSON：
+
+- 保留可安全透传的上游 header；
+- 删除旧实体相关和 hop-by-hop header；
+- 删除上游 Content-Type；
+- 设置唯一 `Content-Type: application/json`；
+- 保留上游成功 status。
+
+## 5. 总体转换流程
+
+```mermaid
+flowchart LR
+    A[Anthropic /v1/messages] --> B[provider and model mapping]
+    B --> C[endpoint/query rewrite]
+    C --> D[Anthropic request to Chat request]
+    D --> E[Chat Completions upstream]
+    E -->|2xx JSON| F[Chat response to Anthropic message]
+    E -->|2xx SSE| G[Chat SSE to Anthropic SSE]
+    E -->|stream:false fake SSE| H[aggregate to Chat JSON]
+    H --> F
+    E -->|non-2xx| I[generic upstream error/failover]
+```
+
+请求 body 的模型映射在结构转换前完成；核心转换器本身不改 model ID。
+
+## 6. Anthropic 请求转 Chat 请求
+
+抽象接口：
+
+```text
+anthropic_to_chat(
+    anthropic_body,
+    preserve_reasoning_content
+) -> chat_body | TransformError
+```
+
+### 6.1 顶层字段
+
+| Anthropic 输入 | Chat 输出 | 规则 |
+| --- | --- | --- |
+| `model` | `model` | 仅字符串时复制；此前通常已完成模型映射 |
+| `system` | `messages` 中 system | 见第 6.2 节 |
+| `messages` | `messages` | 见第 6.3 节 |
+| `max_tokens` | `max_tokens` 或 `max_completion_tokens` | o-series 使用后者 |
+| `temperature` | `temperature` | 原值复制 |
+| `top_p` | `top_p` | 原值复制 |
+| `stop_sequences` | `stop` | 原值复制 |
+| `stream` | `stream` | 原值复制 |
+| `thinking`/`output_config.effort` | `reasoning_effort` | 仅支持 reasoning 的 model，见第 8 节 |
+| `tools` | `tools` | 见第 7 节 |
+| `tool_choice` | `tool_choice` | 见第 7.3 节 |
+
+没有显式转换的 Anthropic 顶层字段不会进入 Chat body，例如：
+
+```text
+metadata
+service_tier
+container
+mcp_servers
+cache_control
+```
+
+`cache_control` 不会泄漏到 Chat system、message part 或 tool。
+
+### 6.2 System prompt
+
+`system` 支持：
+
+- 字符串：生成一条 Chat system message；
+- 数组：每个含字符串 `.text` 的 block 生成一条 system message；
+- 其他：忽略。
+
+每个 system 文本都先处理 Claude Code billing attribution。如果文本开头精确是：
+
+```text
+x-anthropic-billing-header:
+```
+
+则：
+
+1. 删除第一行；
+2. 同时删除紧随其后的最多一个 CRLF/LF/CR 空行；
+3. 保留后面的稳定 prompt；
+4. 如果整段只有 attribution 且没有换行，结果为空；
+5. 不删除文本中间或后部出现的同名字符串。
+
+转换完所有消息后规范化 system：
+
+- 没有 system：不处理；
+- 只有一条 system：移动到 `messages[0]`；
+- 多条 system：提取其字符串 content；若 content 是数组，则提取每个 part `.text`
+  并用 `\n` 拼接；再把各 system 内容用 `\n` 拼接成唯一首条 system；
+- 非 system message 的相对顺序不变；
+- 空 system 内容不进入合并结果。
+
+### 6.3 普通 message
+
+每个 Anthropic `messages[]`：
+
+- role 取 `.role` 字符串；
+- role 缺失时为 `user`；
+- role 不做枚举归一化，其他字符串也原样进入 Chat；
+- content 缺失 -> `{"role":role,"content":null}`；
+- content 是字符串 -> 原样 Chat message；
+- content 是数组 -> 按 content block 状态化转换；
+- content 为其他 JSON -> 原样放入 Chat `content`。
+
+### 6.4 Text 和 image block
+
+`{"type":"text","text":"..."}`：
+
+```json
+{"type":"text","text":"..."}
+```
+
+不会复制 block 上的 `cache_control` 或其他 Anthropic 私有字段。
+
+`{"type":"image",...}` 转为 Chat：
+
+```json
+{
+  "type": "image_url",
+  "image_url": {
+    "url": "..."
+  }
+}
+```
+
+支持至少：
+
+- Anthropic base64 source：
+  `source.type=="base64"` + `source.media_type` + `source.data`，
+  生成 `data:<media_type>;base64,<data>`；
+- Anthropic URL source：
+  `source.type=="url"` + `source.url`；
+- tool media helper 能识别的其他 image URL/MCP image 形态。
+
+`cache_control`、`prompt_cache_breakpoint` 等不复制。
+
+最终 message content：
+
+- 没有 text/image 且没有 tool call -> 不生成普通 message；
+- 只有一个 text part -> 简化为字符串；
+- 只有一个 image part -> 仍是 part 数组；
+- 多 part -> part 数组；
+- 有 tool_calls 但没有 text/image -> `content:null`。
+
+### 6.5 `tool_use`
+
+每个 Anthropic block：
+
+```json
+{
+  "type": "tool_use",
+  "id": "call_1",
+  "name": "f",
+  "input": {"x": 1}
+}
+```
+
+变为同一 Chat assistant message 的一个 `tool_calls[]`：
+
+```json
+{
+  "id": "call_1",
+  "type": "function",
+  "function": {
+    "name": "f",
+    "arguments": "{\"x\":1}"
+  }
+}
+```
+
+规则：
+
+- id/name 缺失时为空串；
+- input 缺失时为 `{}`；
+- input 用 canonical JSON 字符串序列化；
+- 同一 Anthropic message 内多个 tool_use 合并进一条 Chat message；
+- text/image part 和 tool_calls 可以共存。
+
+canonical JSON 要递归按字典序排序 object key、数组保序且不输出多余空白。
+
+### 6.6 `tool_result`
+
+每个 `tool_result` 立即产生一条独立 Chat tool message：
+
+```json
+{
+  "role": "tool",
+  "tool_call_id": "<tool_use_id or empty>",
+  "content": "<string>"
+}
+```
+
+content：
+
+- Anthropic content 是字符串 -> 原样保留，即使字符串自身看起来像 JSON；
+- 其他 JSON -> canonical JSON；
+- 缺失 -> 空串。
+
+注意这里与 Responses -> Chat bridge 不同：普通字符串不会尝试解析并 canonicalize。
+
+一个 Anthropic message 中同时含 `tool_result` 和普通 text/tool_use 时，输出顺序是：
+
+1. 每条 Chat tool message；
+2. 如有抽取媒体，合成 media user message；
+3. 该 Anthropic message 剩余 text/image/tool_use 形成的普通 Chat message。
+
+### 6.7 Tool result 图片迁移
+
+Chat tool message 只能安全携带文本。发现 tool_result content 中有媒体时：
+
+1. 从原 content 递归抽取媒体；
+2. 原位置替换为文本：
+   `[cc-switch: tool result media moved to the following user message]`；
+3. tool message 保留替换后的字符串或 canonical JSON；
+4. 在当前 Anthropic message 的全部并行 tool results 后插入一条合成 user message：
+
+```json
+{
+  "role": "user",
+  "content": [
+    {
+      "type": "text",
+      "text": "[cc-switch: media output of tool call <tool_use_id>]"
+    },
+    {
+      "type": "image_url",
+      "image_url": {"url":"..."}
+    }
+  ]
+}
+```
+
+多个 tool_result 的媒体合并进同一 user message；每组媒体前都有 call 标记。tool messages
+必须保持相邻，不能把 media user message 插入并行 tool results 中间。
+
+媒体扫描、data URL 阈值、递归深度和残留 base64 clamp 与
+`codex_response_to_chat_completions.md` 第 5.7 节相同，由共享 `tool_media.rs` 实现。
+本文路径在普通 message content 中只接受 image；tool result 媒体 helper 则可按共享
+`AllSupported` 范围提取当前支持的原生 Chat 媒体。
+
+### 6.8 Thinking history
+
+普通 openai_chat provider 默认不向 Chat request 添加非标准 `reasoning_content`。
+
+只有 provider/model 标识含以下关键词时才启用历史保留，比较前转小写：
+
+```text
+deepseek
+mimo
+xiaomimimo
+```
+
+检查来源：
+
+- 请求 body 的 model；
+- `env.ANTHROPIC_BASE_URL`；
+- `base_url`；
+- `baseURL`；
+- `apiEndpoint`。
+
+Moonshot/Kimi 当前明确不在此名单。
+
+启用保留且 Anthropic assistant message 含 tool_use 时：
+
+- 收集 `thinking` block 的非空 `.thinking`；
+- 多段用 `\n` 拼接；
+- `redacted_thinking` 添加占位 `[redacted thinking]`；
+- 没有可用 thinking 时添加占位 `tool call`；
+- 写入该 Chat assistant message 的顶层 `reasoning_content`。
+
+限制：
+
+- 只对 role 为 `assistant` 且含 tool_calls 的输出 message 写入；
+- thinking-only message 不会生成 Chat message；
+- 非保留模式下 thinking/redacted_thinking 均丢弃；
+- 这条路径不会把 thinking 当普通可见文本。
+
+## 7. Tool 声明与 tool_choice
+
+### 7.1 Tool 声明
+
+Anthropic：
+
+```json
+{
+  "name": "get_weather",
+  "description": "Get weather",
+  "input_schema": {}
+}
+```
+
+Chat：
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "get_weather",
+    "description": "Get weather",
+    "parameters": {}
+  }
+}
+```
+
+规则：
+
+- `type=="BatchTool"` 的 tool 被过滤；
+- 其他 tool 全部映射；
+- name 缺失 -> 空串；
+- description 直接使用原字段引用，缺失最终为 JSON null；
+- input_schema 缺失 -> `{}`；
+- 不复制 Anthropic tool `cache_control`；
+- 当前实现不映射 `strict`。
+
+如果过滤后工具列表为空，不输出 Chat `tools`。
+
+### 7.2 Schema 清理
+
+只对 schema root 做默认 object 补全：
+
+- root 是对象且完全缺少 `type` -> 添加 `type:"object"`；
+- 此时如果也缺 `properties` -> 添加 `properties:{}`；
+- root 已有 `type`，即使值为 null，也不会强制改成 object；
+- 非对象 schema 不会自动包成 object。
+
+递归清理：
+
+- 当前节点 `format=="uri"` 时删除 `format`；
+- 递归遍历 `properties` 的每个值；
+- 递归遍历 `items`；
+- 不主动遍历 `oneOf`、`anyOf`、`allOf` 等其他关键字。
+
+### 7.3 Tool choice
+
+| Anthropic 输入 | Chat 输出 |
+| --- | --- |
+| `"auto"` | `"auto"` |
+| `"any"` | `"required"` |
+| `"none"` | `"none"` |
+| `{"type":"auto"}` | `"auto"` |
+| `{"type":"any"}` | `"required"` |
+| `{"type":"none"}` | `"none"` |
+| `{"type":"tool","name":"f"}` | `{"type":"function","function":{"name":"f"}}` |
+| 其他 | 原样保留 |
+
+当前实现不会在全部 tools 被过滤后自动删除 tool_choice。
+
+## 8. Anthropic thinking 转 OpenAI reasoning effort
+
+只有 model 属于以下 family 时才添加 `reasoning_effort`：
+
+- o-series：名字以 `o` 开头，第二个字符是数字；
+- `gpt-5` 及以上当前匹配形式：小写 `gpt-` 后首字符是数字且 `>= '5'`；
+- `grok-4.5`；
+- `grok-4.5-*`；
+- `grok-build-*`。
+
+解析优先级：
+
+### 8.1 `output_config.effort`
+
+| Anthropic effort | Chat reasoning_effort |
+| --- | --- |
+| `low` | `low` |
+| `medium` | `medium` |
+| `high` | `high` |
+| `max` | `xhigh` |
+| 其他 | 不写 |
+
+只要该字段存在，就不再回退读取 `thinking`；未知值因此会抑制 fallback。
+
+### 8.2 `thinking`
+
+当没有 `output_config.effort` 时：
+
+| Anthropic thinking | Chat reasoning_effort |
+| --- | --- |
+| `{"type":"adaptive"}` | `xhigh` |
+| enabled，`budget_tokens < 4000` | `low` |
+| enabled，`4000 <= budget_tokens < 16000` | `medium` |
+| enabled，`budget_tokens >= 16000` | `high` |
+| enabled，缺 budget | `high` |
+| disabled/未知/缺失 | 不写 |
+
+原 `thinking` 和 `output_config` 本身不会透传到 Chat body。
+
+## 9. Prompt cache 与流式 usage 请求
+
+openai_chat 路径只在 `provider.meta.prompt_cache_key` 显式配置时写入：
+
+```json
+{"prompt_cache_key":"<configured value>"}
+```
+
+客户端 session ID、Anthropic metadata 和请求中的 cache_control 都不会自动生成 Chat
+prompt cache key。
+
+当转换后的 `stream == true` 时必须保证：
+
+```json
+{
+  "stream_options": {
+    "include_usage": true
+  }
+}
+```
+
+如果已有 object `stream_options`，保留其余键并覆盖 `include_usage=true`；否则创建该对象。
+非流式请求不添加 `stream_options`。
+
+## 10. 非流式 Chat 响应转 Anthropic message
+
+抽象接口：
+
+```text
+chat_response_to_anthropic(chat_body) -> anthropic_message | TransformError
+```
+
+### 10.1 输入校验
+
+只使用第一条 choice：
+
+- 缺 `choices` 数组 -> `No choices in response`；
+- 空数组 -> `Empty choices array`；
+- 第一项缺 `message` -> `No message in choice`。
+
+### 10.2 输出 envelope
+
+```json
+{
+  "id": "<chat id or empty>",
+  "type": "message",
+  "role": "assistant",
+  "content": [],
+  "model": "<chat model or empty>",
+  "stop_reason": null,
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 0,
+    "output_tokens": 0
+  }
+}
+```
+
+Chat ID 原样保留，不添加 `msg_` 前缀。这用于 usage 去重。
+
+### 10.3 Content block 顺序
+
+按以下顺序构造：
+
+1. `message.reasoning_content` -> thinking block；
+2. message 可见 content/refusal -> text blocks；
+3. tool_calls 或 legacy function_call -> tool_use blocks。
+
+`reasoning_content` 只有非空字符串才输出：
+
+```json
+{"type":"thinking","thinking":"..."}
+```
+
+当前非流转换器不识别 `message.reasoning`、`reasoning_details` 或 `<think>` 标签。
+
+Chat content：
+
+- 非空字符串 -> 单个 Anthropic text block；
+- 数组的 `type=="text"` 或 `type=="output_text"` -> text block；
+- 数组的 `type=="refusal"` -> 把 `.refusal` 当 text；
+- message 顶层非空 `refusal` -> 再追加一个 text block；
+- 未知 part、图片、音频等忽略；
+- 空内容允许最终 `content:[]`。
+
+### 10.4 Tool calls
+
+现代 `message.tool_calls[]`：
+
+```json
+{
+  "type": "tool_use",
+  "id": "<tool call id or empty>",
+  "name": "<function name or empty>",
+  "input": {}
+}
+```
+
+arguments 规则：
+
+- 仅接受字符串；
+- 缺失时按 `"{}"`；
+- 字符串能解析为任意 JSON Value时直接作为 input；
+- 解析失败 -> `{}`。
+
+如果 `tool_calls` 数组非空，设置“已有现代工具调用”，不再处理 legacy function_call。
+
+legacy `message.function_call`：
+
+- id/name 缺失 -> 空串；
+- arguments 是 JSON 字符串 -> 解析，失败为 `{}`；
+- arguments 是 object/array -> 原样；
+- 其他/缺失 -> `{}`；
+- 只有 name 非空或 arguments 字段存在时才生成 tool_use。
+
+当前非流转换不会过滤空名字的现代 tool call。
+
+### 10.5 Stop reason
+
+| Chat finish_reason | Anthropic stop_reason |
+| --- | --- |
+| `stop` | `end_turn` |
+| `length` | `max_tokens` |
+| `tool_calls` | `tool_use` |
+| `function_call` | `tool_use` |
+| `content_filter` | `end_turn` |
+| 未知非空值 | `end_turn`，并写 warning log |
+| 缺失且有 tool_use | `tool_use` |
+| 缺失且无 tool_use | null |
+
+### 10.6 Usage
+
+输入：
+
+```text
+prompt_tokens
+completion_tokens
+cache_read_input_tokens?
+cache_creation_input_tokens?
+prompt_tokens_details.cached_tokens?
+prompt_tokens_details.cache_write_tokens?
+input_tokens_details.cache_write_tokens?
+```
+
+cache read 优先级：
+
+1. 顶层 `cache_read_input_tokens`；
+2. `prompt_tokens_details.cached_tokens`；
+3. 0。
+
+cache creation 优先级：
+
+1. 顶层 `cache_creation_input_tokens`；
+2. `prompt_tokens_details.cache_write_tokens`；
+3. `input_tokens_details.cache_write_tokens`；
+4. 0。
+
+OpenAI `prompt_tokens` 被视为包含 fresh + cache read + cache creation。Anthropic：
+
+```text
+input_tokens =
+  saturating_sub(prompt_tokens, cache_read, cache_creation)
+output_tokens = completion_tokens
+```
+
+因此尽量保持：
+
+```text
+input_tokens + cache_read_input_tokens + cache_creation_input_tokens
+  == prompt_tokens
+```
+
+缓存数之和超过 prompt 时，input 钳到 0，不允许下溢。只有 cache 值大于 0 时才输出对应
+Anthropic cache 字段。缺 usage 时仍输出 input/output 两个零值。
+
+## 11. Chat SSE 转 Anthropic SSE
+
+### 11.1 输入数据模型
+
+流式转换器接受 OpenAI SSE data JSON，使用的字段：
+
+```text
+id: string, default ""
+model: string, default ""
+choices[]:
+  delta.content?: string
+  delta.reasoning?: string
+  delta.reasoning_content?: string  # serde alias
+  delta.tool_calls[]?:
+    index: usize                    # 当前实现要求存在
+    id?: string
+    type?: string
+    function.name?: string
+    function.arguments?: string
+  finish_reason?: string
+usage?:
+  prompt_tokens: u32
+  completion_tokens: u32
+  prompt_tokens_details.cached_tokens: u32
+  prompt_tokens_details.cache_write_tokens: u32
+  cache_read_input_tokens?: u32
+  cache_creation_input_tokens?: u32
+```
+
+边界：
+
+- 只使用 `choices[0]`；
+- `reasoning` 和 `reasoning_content` 都映射 thinking；
+- 不识别流式 `reasoning_details` 或 reasoning object；
+- tool call 缺 `index` 会让该整个 JSON data 无法反序列化并被忽略；
+- 非法 JSON、schema 不匹配的 data 被静默忽略；
+- 一个 SSE block 内的每条 `data:` 行独立解析，不做多行 data 拼接；
+- 支持 bytes 任意分片及跨分片 UTF-8；
+- 当前转换器不专门解析上游 JSON error event；底层 stream error 有明确转换。
+
+### 11.2 状态
+
+至少维护：
+
+```text
+message_id?                    # 第一个非空 id
+model?                         # 第一个非空 model
+next_content_index
+message_start_sent
+first_finish_seen
+pending_message_delta
+message_stop_sent
+latest_usage
+current_non_tool_block_type    # thinking | text | none
+current_non_tool_block_index
+tool_state_by_chat_index
+open_tool_block_indices
+stream_ended_with_error
+```
+
+每个 tool state：
+
+```text
+anthropic_content_index
+id
+name
+started
+pending_arguments
+consecutive_whitespace_count
+aborted
+```
+
+### 11.3 Message start
+
+第一次遇到含 choice 的合法 Chat chunk 时发送：
+
+```text
+event: message_start
+```
+
+```json
+{
+  "type": "message_start",
+  "message": {
+    "id": "<first non-empty chat id or empty>",
+    "type": "message",
+    "role": "assistant",
+    "model": "<first non-empty model or empty>",
+    "usage": {
+      "input_tokens": 0,
+      "output_tokens": 0
+    }
+  }
+}
+```
+
+如果首个 choice chunk 自带 usage，则 message_start usage 中：
+
+- input 按 fresh token 公式计算；
+- cache read/create 大于 0 时添加；
+- 不在 start 中写 completion_tokens，`output_tokens` 保持 0。
+
+usage-only chunk 不会单独触发 message_start，但会更新 latest usage。
+
+### 11.4 Thinking 和 text block
+
+reasoning delta：
+
+```text
+content_block_start(type=thinking, thinking="")
+content_block_delta(type=thinking_delta, thinking=<delta>)
+```
+
+text delta：
+
+```text
+content_block_start(type=text, text="")
+content_block_delta(type=text_delta, text=<delta>)
+```
+
+content 空串不产生 text 事件。
+
+thinking/text 共用一个“当前非工具 block”。类型切换时：
+
+1. 对旧 index 发 `content_block_stop`；
+2. 分配新的递增 content index；
+3. 发新类型 start；
+4. 发 delta。
+
+因此 thinking -> text -> thinking 会生成三个独立 content block，不会合并回第一个。
+
+### 11.5 流式 tool call
+
+看到非空 `delta.tool_calls` 前先关闭当前 thinking/text block。每个 Chat `tool_call.index`
+映射到独立 ToolBlockState，首次见到该 index 时立即分配 Anthropic content index。
+
+id/name：
+
+- 任何后续非缺失值都会写入 state，包括空字符串；
+- 只有 id 和 name 都非空时才发 start；
+- start 前收到的 arguments 累积到 `pending_args`；
+- start 后立即先发积累参数，再发当前参数。
+
+start：
+
+```json
+{
+  "type": "content_block_start",
+  "index": 1,
+  "content_block": {
+    "type": "tool_use",
+    "id": "call_1",
+    "name": "f"
+  }
+}
+```
+
+arguments delta：
+
+```json
+{
+  "type": "content_block_delta",
+  "index": 1,
+  "delta": {
+    "type": "input_json_delta",
+    "partial_json": "{\"x\":"
+  }
+}
+```
+
+转换器不解析或 canonicalize partial JSON，只按字符串原样转发。
+
+收到首次 finish reason 时，尚未 start 但已有任意 payload 的 tool state会被“晚启动”：
+
+- id 为空 -> `tool_call_<chat index>`；
+- name 为空 -> `unknown_tool`；
+- 按已分配的 Anthropic content index 排序后 start；
+- 再发送累积 arguments。
+
+随后所有 open tool block 按 Anthropic index 升序发 `content_block_stop`。
+
+### 11.6 无限空白保护
+
+每个 tool arguments 流跟踪连续 Unicode whitespace 字符数量：
+
+- 遇到非 whitespace 清零；
+- 连续数量达到 500 时，把该 tool state 标记 aborted；
+- 触发阈值的 delta 及其后续 delta 不再转发；
+- 已经 start 的 block 仍会在 finish reason 时正常 stop。
+
+这是 GitHub Copilot function arguments 无限换行问题的防护。
+
+### 11.7 Finish、usage 和终止事件
+
+第一次非空 finish reason：
+
+1. 映射 stop reason；
+2. 关闭当前 thinking/text；
+3. 晚启动未完整 identity 的 tool；
+4. 关闭所有 open tool blocks；
+5. 创建但暂不发送 `message_delta`；
+6. 标记已处理 finish。
+
+后续 finish reason 不改变首个 stop reason，只允许用更晚的 usage 更新 pending
+message_delta。usage-only chunk 同样会更新 pending usage。
+
+pending message_delta：
+
+```json
+{
+  "type": "message_delta",
+  "delta": {
+    "stop_reason": "end_turn",
+    "stop_sequence": null
+  },
+  "usage": {
+    "input_tokens": 0,
+    "output_tokens": 0
+  }
+}
+```
+
+usage 映射与非流式基本相同，但当前流式模型只读取
+`prompt_tokens_details`，不读取 `input_tokens_details.cache_write_tokens`。直接顶层 cache
+字段仍优先。所有 token 数内部按 u32 解析。
+
+`[DONE]`：
+
+1. 如果有 pending message_delta，先发送；
+2. 发送 `message_stop`：
+
+```json
+{"type":"message_stop"}
+```
+
+自然 EOF 且没有 `[DONE]`：
+
+- 若有 pending message_delta：发送它，再发送 message_stop；
+- 若从未看到 finish reason，pending 为空，不发送成功终止事件；
+- 即使此前已发 message_start/content delta，无 finish reason 也不能补造成功 terminal。
+
+底层 stream error：
+
+```text
+event: error
+```
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "stream_error",
+    "message": "Stream error: <error>"
+  }
+}
+```
+
+发生 stream error 后不能再发 message_delta/message_stop。
+
+### 11.8 Stop reason 映射
+
+与非流式一致：
+
+| Chat finish_reason | Anthropic stop_reason |
+| --- | --- |
+| `tool_calls` / `function_call` | `tool_use` |
+| `stop` | `end_turn` |
+| `length` | `max_tokens` |
+| `content_filter` | `end_turn` |
+| 其他 | `end_turn` |
+
+## 12. `stream:false` 收到 Chat SSE 的聚合
+
+响应处理选择流式路径的条件是：
+
+```text
+client requested stream
+OR upstream Content-Type indicates SSE
+OR special Codex Responses condition
+```
+
+因此 openai_chat 上游只要明确返回 SSE，就会使用第 11 节并向客户端返回 Anthropic SSE，
+即使请求 body 的 `stream` 是 false。
+
+另一个兼容分支处理“body 是 SSE，但 Content-Type 不是 SSE”的情况：
+
+1. 非流式 handler 读取 body；
+2. JSON parse 失败；
+3. body 嗅探像 SSE；
+4. 使用 Chat SSE 聚合器生成单个 `chat.completion`；
+5. 再调用第 10 节转换为 Anthropic JSON。
+
+聚合器的重要契约：
+
+- 支持 BOM、CRLF、尾 block 无空行；
+- 只聚合 choice index 0；
+- id/created/model 取第一个非空且非零占位值；
+- content/refusal 追加；
+- reasoning_content/reasoning/reasoning_details 通过共享提取器追加；
+- tool_calls 用稀疏有序 map 按 index 聚合；
+- id/name 非空时更新，arguments 分片拼接；
+- legacy function_call 转为 tool_calls；
+- finish_reason 首个非 null 值获胜；
+- usage 取最后一个非 null 值；
+- 完整 message snapshot 可覆盖此前 delta；
+- event:error 或带有效 error message 的 data 使聚合失败；
+- 从未见到 choice -> 失败；
+- 同时缺 finish reason 和 `[DONE]` -> 判为截断并失败；
+- 有 `[DONE]` 时可接受缺 finish reason；
+- 缺 id 时合成 UUID。
+
+聚合细节与 `codex_response_to_chat_completions.md` 第 11 节使用同一实现。
+
+## 13. HTTP 错误和转换错误
+
+### 13.1 上游非 2xx
+
+forwarder 在响应转换前：
+
+1. 读取有大小上限的错误 body；
+2. 按 `content-encoding` 尝试解压；
+3. 能 UTF-8 解码时保存文本；
+4. 返回 `ProxyError::UpstreamError {status, body}`；
+5. 按 provider/failover 策略决定是否重试其他 provider。
+
+它不会调用 `openai_to_anthropic`，因此没有本文专属的 OpenAI error JSON -> Anthropic
+error JSON 映射。
+
+### 13.2 2xx 但 body 不合法
+
+非流式成功响应：
+
+- JSON parse 失败且不像 SSE -> 带 content type/body classification 的 parse error；
+- 像 SSE但聚合失败 -> 聚合诊断 error；
+- Chat JSON 缺 choices/message -> TransformError；
+- 上游已经消耗 tokens、但结构转换失败时，handler 会尽可能先记录 raw usage 再返回错误。
+
+### 13.3 SSE 错误
+
+明确支持底层 stream transport error，输出 Anthropic `event:error`。当前 Chat SSE typed parser
+不会把普通 `data: {"error":...}` 或 `event:error` JSON 转成 Anthropic error；不符合
+`OpenAIStreamChunk` 的 data 会被忽略。这是重写兼容性测试应记录的现有边界。
+
+## 14. 与 Responses -> Chat 桥接的关键差异
+
+| 行为 | Anthropic -> Chat | Responses -> Chat |
+| --- | --- | --- |
+| 普通 endpoint | `/v1/chat/completions` | `/chat/completions` |
+| Copilot endpoint | `/chat/completions` | `/chat/completions` |
+| tool context 反向恢复 | 无 | 有 namespace/custom/tool_search context |
+| string tool output | 原样 | 可解析 JSON 时 canonicalize |
+| reasoning history | 仅 DeepSeek/MiMo 白名单 | 广泛、状态化归属 |
+| 无 reasoning 的 tool call | 仅白名单 provider补占位 | 所有 assistant tool-call history 补占位 |
+| schema root type 为 null | 保留 null | 强制 object |
+| 无 tools 时 tool_choice | 可能保留 | 删除 |
+| Chat SSE error JSON | typed parse 不处理 | 显式转 response.failed |
+| 缺 tool index | 整个 data chunk 忽略 | 有 fallback key 策略 |
+| 无名流式 tool | finish 时合成 unknown_tool | 丢弃，必要时 failed |
+| 非流无名 tool | 保留空 name | 丢弃，必要时 TransformError |
+| ID | Chat ID 原样作为 Anthropic ID | 统一 `resp_` |
+
+## 15. 推荐的重写边界
+
+建议至少拆分以下纯函数和状态组件：
+
+```text
+resolve_claude_wire_format(provider, model?) -> WireFormat
+rewrite_messages_endpoint(endpoint, wire_format, is_copilot) -> endpoint
+rewrite_headers(inbound_headers, provider_auth, wire_format) -> headers
+
+anthropic_request_to_chat(body, options) -> ChatRequest
+convert_anthropic_message(message, options) -> ChatMessage[]
+convert_anthropic_tools(tools) -> ChatTool[]
+resolve_reasoning_effort(body, model) -> effort?
+
+chat_response_to_anthropic(body) -> AnthropicMessage
+ChatSseToAnthropicState::consume(chunk) -> AnthropicEvent[]
+ChatSseToAnthropicState::finish() -> AnthropicEvent[]
+aggregate_chat_sse_to_json(body) -> ChatCompletion
+```
+
+请求主流程：
+
+```text
+format = resolve_claude_wire_format(provider, mapped_request.model)
+if format != openai_chat:
+    dispatch elsewhere
+
+preserve_reasoning =
+    model_or_provider_matches(deepseek | mimo | xiaomimimo)
+chat_body =
+    anthropic_request_to_chat(mapped_request, preserve_reasoning)
+if provider.meta.prompt_cache_key exists:
+    chat_body.prompt_cache_key = configured_key
+if chat_body.stream == true:
+    chat_body.stream_options.include_usage = true
+POST rewritten_chat_endpoint
+```
+
+响应主流程：
+
+```text
+if status is non-2xx:
+    return generic upstream error/failover
+
+if client_stream || upstream_is_sse:
+    return chat_sse_to_anthropic_sse(upstream_stream)
+
+bytes = read_and_decode(upstream)
+if bytes parse as JSON:
+    chat = parsed JSON
+else if bytes look like SSE:
+    chat = aggregate_chat_sse_to_json(bytes)
+else:
+    return parse error
+return chat_response_to_anthropic(chat)
+```
+
+## 16. 必须保持的实现不变量
+
+1. 模型映射先于 body 结构转换，转换器不擅自改 model。
+2. Messages endpoint 的 `beta=` query 不能发送到 Chat endpoint。
+3. Anthropic auth/version/beta header 不能按原协议发送到 openai_chat 上游。
+4. system 最终位于 Chat messages 首部，多 system 合并后不改变其他消息顺序。
+5. 只删除 system 开头的 billing attribution，不能删除用户正文中的同名文本。
+6. Anthropic `cache_control` 不得泄漏进 Chat body。
+7. tool input 必须 canonicalize，确保 prompt cache 稳定。
+8. 并行 tool_result 必须保持相邻，抽取媒体必须放在它们之后。
+9. DeepSeek/MiMo assistant tool-call history 必须有非空 reasoning_content。
+10. Kimi/Moonshot 当前不能启用 reasoning history 占位策略。
+11. reasoning effort 只对明确支持的 model family 输出。
+12. `output_config.effort` 存在时优先于 thinking，即使其值未知。
+13. 流式 message_delta 只能发送一次，首个 finish reason 决定 stop_reason。
+14. message_delta 要延迟到 `[DONE]` 或 EOF，以吸收 usage-only 尾块。
+15. 没有 finish reason 的截断流不能伪造 message_stop。
+16. stream error 后不能继续发成功 terminal 事件。
+17. OpenAI prompt_tokens 转 Anthropic input 时必须扣除 cache read/create，并使用饱和减法。
+18. Chat response ID 必须原样保留，供 usage 去重。
+19. `stream:false` + 未标记 SSE 必须聚合回 Anthropic JSON，不能把 Chat SSE body 当 JSON
+    直接报普通 parse error。
+20. 非 2xx 必须在转换前进入通用 upstream error/failover，不能假定其 body 有 choices。
+
+## 17. 最小验收测试矩阵
+
+| 类别 | 用例 | 预期 |
+| --- | --- | --- |
+| format | meta、legacy api_format、compat mode | 正确选择 openai_chat |
+| Copilot | OpenAI vendor/其他/查询失败 | Responses/Chat/Chat |
+| endpoint | 普通与 Copilot | `/v1/chat/completions` / `/chat/completions` |
+| query | beta + 普通参数 | 删除 beta，保留其他顺序 |
+| header | Anthropic beta/version/auth | beta/version 删除，auth 替换 |
+| system | 字符串、数组、多段、中途 system | 唯一首条 system |
+| billing | 单独 attribution、attribution+正文、正文中同名 | 删除/保留正文/不误删 |
+| text | 单 block、多 block | 字符串简化/part 数组 |
+| image | base64 和 URL source | image_url，无 Anthropic 私有字段 |
+| tool_use | 单个、并行、与 text 共存 | 一条 assistant + tool_calls |
+| tool input | key 顺序不同 | canonical arguments 一致 |
+| tool_result | string、array/object、缺 content | 原串/canonical/空串 |
+| tool media | 单个、并行、与普通 text 同 message | tool 相邻，media user 后置 |
+| reasoning history | DeepSeek/MiMo thinking + tool | reasoning_content |
+| redacted history | redacted_thinking + tool | `[redacted thinking]` |
+| missing history | 白名单 provider裸 tool | `tool call` |
+| generic/Kimi | thinking + tool | 不输出 reasoning_content |
+| schema | 缺 root type、空 schema、format:uri、nested items | 精确清理 |
+| BatchTool | 混合/全部 BatchTool | 过滤；空时无 tools |
+| tool_choice | any/auto/none/指定 tool | required/auto/none/function |
+| effort | 显式四档、adaptive、budget 边界、未知显式值 | 精确映射 |
+| prompt cache | meta 有/无 key | 仅显式 meta 注入 |
+| stream request | true/false | true 注入 include_usage |
+| non-stream text | reasoning_content + text + tools | thinking/text/tool_use 顺序 |
+| refusal | part 和 message-level | Anthropic text |
+| legacy call | string/object args | tool_use |
+| stop reason | stop/length/tool_calls/function_call/filter/未知/缺失 | 精确映射 |
+| usage | nested/direct cache、cache 超 prompt | fresh token 守恒且不下溢 |
+| SSE text | reasoning/text 切换 | block start/delta/stop 正确 |
+| SSE tools | 参数先于 id/name、并行 index | 延迟 start，不丢参数 |
+| SSE incomplete identity | finish 时缺 id/name | fallback id/unknown_tool |
+| SSE whitespace | 连续 500 空白 | 中止该 tool delta |
+| duplicate finish | 多 finish + usage-only 尾块 | 一个 message_delta，用最新 usage |
+| no DONE | 有 finish / 无 finish | 成功 terminal / 不伪造 terminal |
+| stream error | transport error | error event，无 message_stop |
+| fake SSE | stream:false + 错 Content-Type | 聚合成 Anthropic JSON |
+| malformed JSON | 非 SSE body | 明确 parse error |
+| HTTP error | 非 2xx Chat error | 通用 UpstreamError/failover，不进 choices 转换 |

--- a/docs/cc-switch/codex_response_to_chat_completions.md
+++ b/docs/cc-switch/codex_response_to_chat_completions.md
@@ -1,0 +1,1362 @@
+# Codex Responses API 与 Chat Completions 桥接实现规范
+
+> 本文描述仓库在提交 `3217f72596f2d1c0f879f0a05f83803825d9809f`
+> 上的实际实现，而不是 OpenAI 官方协议的完整定义。目标是让另一个 agent
+> 在不阅读原实现的前提下，能够重写并兼容这条桥接链路。
+
+## 1. 结论与范围
+
+仓库已经实现完整的双向桥接：
+
+1. 客户端向本地代理发送 OpenAI Responses API 请求；
+2. 代理把请求端点和 JSON body 转为 OpenAI Chat Completions 格式；
+3. 上游返回 Chat Completions JSON 或 SSE；
+4. 代理把成功响应、流式事件和错误重新转换为 Responses API 格式。
+
+这里的客户端入口是 `/responses` 或 `/v1/responses`。代码还允许
+`/responses/compact` 和 `/v1/responses/compact` 进入同一转换路径。上游目标端点固定为
+`/chat/completions`。
+
+本实现不只是字段改名，还包含：
+
+- Responses item 序列到 Chat `messages` 的状态化重组；
+- function、namespace、custom、tool_search 四类工具的双向映射；
+- reasoning 方言适配；
+- 工具结果中的图片、文件和音频迁移；
+- `previous_response_id` 驱动的跨请求工具调用历史恢复；
+- Chat SSE 到 Responses SSE 的事件状态机；
+- 非标准上游错误、伪流式响应和截断流处理；
+- token usage、缓存 token、ID 和完成状态归一化。
+
+## 2. 模块边界
+
+| 文件 | 职责 |
+| --- | --- |
+| `src-tauri/src/proxy/providers/codex.rs` | 判断 provider 是否使用 Chat 协议，解析 provider 配置，覆写上游模型，推导 reasoning 能力 |
+| `src-tauri/src/proxy/forwarder.rs` | 选择转换路径、恢复历史、改写端点、调用请求转换器、注入 prompt cache key |
+| `src-tauri/src/proxy/providers/transform_codex_chat.rs` | 非流式请求和响应的核心双向转换、工具上下文 |
+| `src-tauri/src/proxy/providers/streaming_codex_chat.rs` | Chat Completions SSE 到 Responses SSE 的状态机 |
+| `src-tauri/src/proxy/providers/codex_responses_sse.rs` | Responses SSE 事件的统一 wire builder |
+| `src-tauri/src/proxy/providers/codex_chat_common.rs` | reasoning 提取、`<think>` 分离、Responses tool item 构造 |
+| `src-tauri/src/proxy/providers/codex_chat_history.rs` | 跨请求缓存和恢复 function/custom/tool_search call item |
+| `src-tauri/src/proxy/handlers.rs` | 响应分流、错误转换、伪流式聚合、响应头重建 |
+| `src-tauri/src/proxy/tool_media.rs` | 从文本型 tool output 中抽取原生媒体并迁移到合成 user message |
+| `src-tauri/src/proxy/json_canonical.rs` | JSON 稳定序列化、工具参数规范化、长工具名哈希 |
+
+## 3. 启用条件与路由
+
+### 3.1 转换开关
+
+只有同时满足以下条件才启用 Responses -> Chat 桥接：
+
+1. 应用类型是 `Codex` 或 `GrokBuild`；
+2. 请求 path（忽略 query）属于：
+   - `/responses`
+   - `/v1/responses`
+   - `/responses/compact`
+   - `/v1/responses/compact`
+3. 当前 provider 被识别为 Chat Completions provider。
+
+provider 协议识别按以下优先级取第一个可用值：
+
+1. `provider.meta.api_format`
+2. `provider.settings_config.api_format`
+3. `provider.settings_config.apiFormat`
+4. `provider.settings_config.config` TOML 中当前 `model_provider` 对应的
+   `model_providers.<name>.wire_api`，否则顶层 `wire_api`
+5. `base_url` 或 TOML 中 `base_url` 是否以 `/chat/completions` 结尾
+
+以下 `api_format`/`wire_api` 值忽略大小写并视为 Chat：
+
+```text
+chat
+chat_completions
+chat-completions
+openai_chat
+openai-chat
+openai_chat_completions
+```
+
+### 3.2 URL 改写
+
+入口 path 一律改写为 `/chat/completions`，原 query 原样保留。例如：
+
+```text
+/v1/responses?beta=true
+  -> /chat/completions?beta=true
+```
+
+如果 provider `base_url` 已经以 `/chat/completions` 结尾，则把它视为完整 endpoint，
+即使 provider 没有显式设置 full URL，也不能再次拼接 endpoint。判断时：
+
+- 忽略首尾空白；
+- 忽略 query 和 fragment；
+- 忽略末尾 `/`；
+- path 后缀比较不区分大小写。
+
+### 3.3 总体数据流
+
+```mermaid
+flowchart LR
+    A[Responses request] --> B[model mapping]
+    B --> C[history enrichment]
+    C --> D[build tool context]
+    D --> E[Responses to Chat body]
+    E --> F[/chat/completions upstream]
+    F -->|JSON| G[Chat JSON to Responses JSON]
+    F -->|SSE| H[Chat SSE state machine]
+    F -->|HTTP error| I[Responses error normalization]
+    G --> J[history record]
+    H --> K[Responses SSE]
+    K --> L[stream history record]
+```
+
+## 4. 转换前上下文与预处理
+
+### 4.1 Tool context
+
+请求转换前必须从原始 Responses request 构建一个 `ToolContext`。它同时用于：
+
+- 产生 Chat `tools`；
+- 将 Responses namespace 名压平；
+- 记录压平名到原始 `{namespace, name}` 的反向映射；
+- 在响应方向恢复 custom/tool_search/namespace 类型。
+
+收集来源：
+
+1. 顶层 `tools[]`；
+2. 对整个 `input` 递归遍历，在任意 `tool_search_output.tools[]` 中发现的工具。
+
+上下文至少维护：
+
+```text
+chat_tools: ordered list
+seen_chat_names: set
+chat_name -> {kind, original_name, namespace?}
+(namespace, original_name) -> chat_name
+```
+
+空名字和重复 Chat 名字必须跳过，先出现的定义获胜。
+
+### 4.2 模型覆写
+
+转换前执行 provider 的上游模型选择：
+
+1. 如果请求 `model` 已存在于 `settings_config.modelCatalog.models[].model`，保留该值；
+2. 否则使用 provider 配置的默认上游 model；
+3. 然后再进行 Responses -> Chat body 转换。
+
+### 4.3 历史恢复
+
+在 body 转换前，用 `previous_response_id` 和 `input` 中的 `call_id` 恢复可能缺失的
+call item。详见第 10 节。
+
+### 4.4 Prompt cache key
+
+先保存客户端显式传入的顶层 `prompt_cache_key`，body 转换后再决定是否写入 Chat body。
+
+默认只有以下上游自动允许该字段：
+
+- host 为 `api.openai.com`；
+- host 为 `api.kimi.com`，且 path 是 `/coding` 或以 `/coding/` 开头。
+
+`provider.meta.prompt_cache_routing` 可强制控制：
+
+- `enabled`：允许；
+- `disabled`：禁止；
+- `auto` 或缺失：使用上述 host 规则。
+
+key 优先级：
+
+1. 非空的客户端显式 `prompt_cache_key`；
+2. 非空且确实由客户端提供的 session ID；
+3. 不写入。代理生成的逐请求 UUID 不能充当 cache key。
+
+## 5. Responses 请求转 Chat 请求
+
+核心函数的逻辑签名可抽象为：
+
+```text
+responses_to_chat(body, optional_reasoning_config) -> chat_body | TransformError
+```
+
+### 5.1 顶层字段
+
+| Responses 输入 | Chat 输出 | 规则 |
+| --- | --- | --- |
+| `model` | `model` | 原值复制；通常已在预处理阶段覆写 |
+| `instructions` | 首条 `system` message | 字符串直接使用；数组提取元素自身或元素 `.text`，过滤空串后用 `\n\n` 拼接 |
+| `input` | `messages` | 见第 5.2 节 |
+| `max_output_tokens` | `max_completion_tokens` 或 `max_tokens` | OpenAI o-series model 使用前者，否则使用后者 |
+| `max_tokens` | `max_tokens` | 原值复制，若同时存在会覆盖前一步同名值 |
+| `max_completion_tokens` | `max_completion_tokens` | 原值复制 |
+| `temperature` | 同名 | 原值复制 |
+| `top_p` | 同名 | 原值复制 |
+| `stream` | 同名 | 原值复制 |
+| `reasoning` | provider 方言字段 | 见第 7 节 |
+| `tools` | `tools` | 见第 6 节 |
+| `tool_choice` | `tool_choice` | 见第 6.6 节 |
+
+以下字段原样透传：
+
+```text
+frequency_penalty
+logit_bias
+logprobs
+metadata
+n
+parallel_tool_calls
+presence_penalty
+response_format
+seed
+service_tier
+stop
+stream_options
+top_logprobs
+user
+```
+
+未列出的 Responses 顶层字段默认不进入 Chat body，例如：
+
+```text
+previous_response_id
+store
+include
+truncation
+prompt_cache_key（由转换后专门注入）
+```
+
+如果最终没有非空 `tools`，必须删除 `tool_choice` 和 `parallel_tool_calls`，避免严格上游
+因“没有工具却指定工具策略”返回 400。
+
+当 `stream == true` 时，必须保证：
+
+```json
+{
+  "stream_options": {
+    "include_usage": true
+  }
+}
+```
+
+如果原 `stream_options` 是对象，保留其他键并覆盖 `include_usage=true`；否则替换为上述对象。
+非流式请求不能凭空添加 `stream_options`。
+
+### 5.2 `input` 到 `messages`
+
+`input` 可为：
+
+- 字符串：生成一条 `{"role":"user","content":<string>}`；
+- 对象：按单个 input item 处理；
+- 数组：按顺序处理每个 item；
+- 其他类型：不生成消息。
+
+角色归一化：
+
+| Responses role | Chat role |
+| --- | --- |
+| `system` | `system` |
+| `developer` | `system` |
+| `assistant` | `assistant` |
+| `tool` | `tool` |
+| `user` | `user` |
+| `latest_reminder` | `user` |
+| 未知或缺失 | `user` |
+
+全部 item 转完后，把所有 `system` message 的非空字符串 content 按原出现顺序用
+`\n\n` 合并，并移动到 `messages[0]`。非 system message 的相对顺序不能变化。
+
+这条约束是兼容 MiniMax 等只允许首条 system message 的上游。
+
+### 5.3 message/content item
+
+`type == "message"`，或 type 缺失但带 `role`/`content` 的对象，转换为普通 Chat message。
+未来未知 type 只要带 `role` 或 `content` 也按 message 处理。
+
+content 规则：
+
+1. `null` 或字符串：原样保留；
+2. 非数组、非字符串：原样保留；
+3. 数组：逐 part 转换。
+
+part 映射：
+
+| Responses part | Chat part |
+| --- | --- |
+| `input_text` / `output_text` / `text` | `{"type":"text","text":...}` |
+| `refusal` | 当普通 text part，文本取 `.refusal` |
+| `input_image` | `{"type":"image_url","image_url":...}`；字符串 URL 包成 `{"url":...}`，对象原样用 |
+| `input_file` | `{"type":"file","file":{...}}`；仅复制 `file_id`、`file_data`、`filename` |
+| `input_audio` | `{"type":"input_audio","input_audio":...}` |
+| 其他 | 丢弃 |
+
+如果转换结果没有任何非文本 part，则不要返回 part 数组，而要把所有 text 用单个 `\n`
+连接成 Chat 字符串。只要存在 image/file/audio，则保留整个 part 数组。
+
+顶层 `type` 为 `input_text`、`input_image`、`input_file`、`input_audio` 的 item，
+视为只有一个 part 的独立 message；role 仍按上表处理，缺失时为 user。
+
+`input_file` 只有 `file_id` 或 `file_data` 至少存在一个时才有效；仅有 URL 的文件 part 被丢弃。
+
+### 5.4 call item 和 call output
+
+连续的 call item 必须先缓存为一个批次，最终生成一条：
+
+```json
+{
+  "role": "assistant",
+  "content": null,
+  "tool_calls": []
+}
+```
+
+批次在遇到 output、普通 message、特定边界 item 或 input 结束时 flush。
+
+`function_call`：
+
+```text
+id = call_id，缺失时回退 item.id，再缺失为空串
+function.name = namespace 映射后的 Chat 名
+function.arguments = 规范化后的 JSON 字符串
+```
+
+`custom_tool_call`：
+
+```text
+id = call_id -> item.id -> ""
+function.name = item.name -> ""
+function.arguments = canonical JSON {"input": item.input 或 ""}
+```
+
+`tool_search_call`：
+
+```text
+id = call_id -> item.id -> ""
+function.name = "tool_search"
+function.arguments = item.arguments 的 canonical JSON；缺失为 "{}"
+```
+
+`function_call_output` 生成：
+
+```json
+{
+  "role": "tool",
+  "tool_call_id": "<call_id-or-empty>",
+  "content": "<string>"
+}
+```
+
+content 规则：
+
+- output 是字符串且能解析为 JSON：解析后按 canonical JSON 重新序列化；
+- output 是普通字符串：原样保留；
+- output 是其他 JSON：canonical JSON；
+- output 缺失：空串。
+
+`custom_tool_call_output` 和 `tool_search_output` 也生成 tool message，但 content 是整个原始
+item 的 canonical JSON，而不只是 `.output`。媒体迁移时使用替换过媒体的整个 item。
+
+### 5.5 JSON canonicalization
+
+canonical JSON 必须：
+
+- 对象 key 按字典序排序；
+- 数组保序；
+- 不添加多余空白；
+- 递归处理嵌套对象。
+
+工具 `arguments` 额外遵循：
+
+- 缺失、空串或纯空白串 -> `"{}"`；
+- JSON 字符串 -> 解析并 canonicalize；
+- 无法解析的普通字符串 -> 原样保留；
+- object/array/scalar -> canonical JSON 字符串。
+
+### 5.6 Reasoning 在历史 message 中的归属
+
+Responses 历史可能把 reasoning 单独作为 item，也可能把它嵌在 message/call item 内。
+Chat 历史则要求它成为 assistant message 的 `reasoning_content`。
+
+reasoning 文本提取优先级：
+
+1. 非空 `reasoning_content` 字符串；
+2. 非空 `reasoning` 字符串；
+3. `reasoning.content`、`reasoning.text`、`reasoning.summary`；
+4. `reasoning_details`：
+   - 字符串；
+   - 对象的 `text`、`content`、`summary`；
+   - 数组或对象 `parts[]`，各段用 `\n\n` 连接。
+
+独立 `type=="reasoning"` item 的提取规则稍有不同：
+
+1. `reasoning_content`、`content`、`text`；
+2. `summary` 字符串；
+3. `summary[]` 中 part 的 `.text`、`.content` 或 part 自身字符串，用 `\n\n` 连接。
+
+归属状态机：
+
+1. 独立 reasoning 先进入 `pending_reasoning`；
+2. 后续 assistant message 或 call 批次优先消费 pending reasoning；
+3. 多段 reasoning 用 `\n\n` 追加；
+4. call item 自带的 reasoning 只在 pending 中尚未包含相同文本时追加；
+5. 到 user 等非 assistant 回合边界，尚未消费的 reasoning 回填到上一条 assistant，
+   然后清空，禁止跨 user 回合泄漏；
+6. input 结束时剩余 reasoning 同样回填到上一条 assistant；
+7. assistant message 同时有 embedded 和 trailing reasoning 时，以 `\n\n` 拼接；
+8. 每条带非空 `tool_calls` 但没有非空 reasoning 的 assistant message，最后补
+   `reasoning_content: "tool call"`。
+
+第 8 条是 Kimi/Moonshot、DeepSeek thinking 模型兼容要求，不能省略。
+
+### 5.7 Tool output 媒体迁移
+
+Chat tool message 是文本，但 Responses tool output 可能含图片、文件或音频。实现必须：
+
+1. 递归扫描 tool output，最大深度 32；
+2. 把识别出的媒体块替换为：
+   `[cc-switch: tool result media moved to the following user message]`；
+3. 保留 tool message 的文本/JSON 骨架；
+4. 把媒体按 call 顺序积累；
+5. 在当前并行 tool outputs 全部发完后，插入合成 user message：
+
+```json
+{
+  "role": "user",
+  "content": [
+    {
+      "type": "text",
+      "text": "[cc-switch: media output of tool call <call_id>]"
+    },
+    "<native Chat media parts...>"
+  ]
+}
+```
+
+多个并行 tool output 的媒体合并进同一条 user message，但每个 call 前都要有对应标记。
+媒体必须在下一批 assistant tool_calls 或真实 user message 之前 flush。
+
+支持的媒体输出至少包括：
+
+- Responses/Chat image URL 形态；
+- Anthropic `{"type":"image","source":{"media_type":...,"data":...}}`；
+- MCP `{"type":"image","mimeType":...,"data":...}`；
+- `input_file`，且含 `file_id` 或 `file_data`；
+- `input_audio.input_audio`；
+- 整个字符串就是图片 data URL，且 trim 后至少 8 KiB；
+- JSON 编码字符串中的上述结构。
+
+不能把嵌在 HTML/CSS/SVG 文本中的 data URL 当媒体，也不能把小 data URL 自动迁移。
+只有确定发现媒体后，才把残留的超长 data/base64-like 字符串替换为：
+
+```text
+[cc-switch: omitted <byte_len> bytes]
+```
+
+无媒体的输出必须保持既有字符串/canonical JSON 语义，不得额外包一层 JSON 引号。
+
+## 6. 工具声明和选择
+
+### 6.1 普通 function
+
+兼容两种 Responses 声明：
+
+```json
+{"type":"function","name":"f","description":"...","parameters":{},"strict":true}
+```
+
+```json
+{"type":"function","function":{"name":"f","description":"...","parameters":{}},"strict":true}
+```
+
+统一输出：
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "f",
+    "description": "...",
+    "parameters": {},
+    "strict": true
+  }
+}
+```
+
+`parameters` 必须是 object schema：
+
+- 缺失、null、非对象 -> `{"type":"object","properties":{}}`；
+- 对象但 `.type` 不是字符串 `"object"` -> 保留其他键并强制 `.type="object"`；
+- 顶层 `oneOf` 等其他 schema 键必须保留。
+
+嵌套 function 中已有 `strict` 优先；否则从 tool 顶层补入。
+
+### 6.2 Namespace tool
+
+Responses namespace：
+
+```json
+{
+  "type": "namespace",
+  "name": "ns",
+  "tools": [{"type":"function","name":"f"}]
+}
+```
+
+也接受 child 数组键 `children`。只处理其中 `type=="function"` 的 child。
+
+Chat function name：
+
+```text
+ns + "__" + f
+```
+
+如果 UTF-8 字节长度不超过 64，直接使用。如果超过 64：
+
+1. 对完整名字做 SHA-256；
+2. 取 digest 前 8 字节，编码为 16 个小写 hex 字符；
+3. suffix 为 `"__" + hex`；
+4. 从原名取不切断 UTF-8 字符的最长前缀，使 `prefix + suffix` 总字节数不超过 64。
+
+反向响应转换必须依赖 ToolContext 恢复原始 `namespace` 和 `name`，不能尝试仅靠
+`__` 拆字符串，因为名字可能含 `__` 或已被哈希截断。
+
+### 6.3 Custom tool
+
+字符串形式的 tool 名也视为 custom tool。custom tool 被包装成 Chat function：
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "<custom name>",
+    "description": "Original tool definition:\n```json\n<canonical original tool JSON>\n```",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "input": {
+          "type": "string",
+          "description": "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description."
+        }
+      },
+      "required": ["input"]
+    }
+  }
+}
+```
+
+原始 custom tool 的 description、format、grammar 等元数据通过 description 中的 canonical
+JSON 完整保留。
+
+### 6.4 Tool search
+
+Responses `{"type":"tool_search"}` 固定包装为名为 `tool_search` 的 Chat function，
+参数 schema：
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": {"type":"string"},
+    "limit": {"type":"integer"}
+  },
+  "required": ["query"]
+}
+```
+
+### 6.5 Tool context 的反向类型恢复
+
+Chat tool call 的 function name 查 ToolContext：
+
+| Context kind | Responses 输出 |
+| --- | --- |
+| function | `function_call` |
+| namespace | 带原始 `namespace` 的 `function_call` |
+| custom | `custom_tool_call` |
+| tool_search | `tool_search_call` |
+| 未找到 | 普通 `function_call`，name 保留 Chat name |
+
+### 6.6 `tool_choice`
+
+| Responses choice | Chat choice |
+| --- | --- |
+| `{"type":"function","name":"f","namespace":"ns"?}` | `{"type":"function","function":{"name":"<mapped name>"}}` |
+| `{"type":"tool_search"}` | 指定 `tool_search` function |
+| `{"type":"custom","name":"x"}` | 指定名为 `x` 的 function |
+| 其他字符串/对象 | 原样复制 |
+
+如果最终没有工具，整个 `tool_choice` 会被删除，包括字符串 `"none"`。
+
+## 7. Reasoning 请求方言
+
+reasoning 配置结构：
+
+```text
+supportsThinking?: bool
+supportsEffort?: bool
+thinkingParam?: "thinking" | "enable_thinking" | "reasoning_split" | "none"
+effortParam?: "reasoning_effort" | "reasoning.effort" | "none"
+effortValueMode?: "passthrough" | "deepseek" | "low_high" | "openrouter" | "zen"
+outputFormat?: descriptive only
+effort_levels?: runtime-only model-specific list
+```
+
+`outputFormat` 当前不参与响应提取；响应侧始终穷举已知字段。
+
+### 7.1 是否请求 reasoning
+
+- `reasoning.effort` 是 `none`、`off`、`disabled`（忽略大小写和空白）-> 显式 false；
+- 存在其他字符串 effort -> true；
+- 否则，存在 `reasoning` 键时，值非 null -> true，null -> false；
+- 完全没有 `reasoning` -> 未指定，不能主动添加 reasoning 字段。
+
+### 7.2 Thinking 开关
+
+如果 provider 支持 thinking：
+
+| `thinkingParam` | true | false |
+| --- | --- | --- |
+| `thinking` | `{"thinking":{"type":"enabled"}}` | `{"thinking":{"type":"disabled"}}` |
+| `enable_thinking` | `{"enable_thinking":true}` | `{"enable_thinking":false}` |
+| `reasoning_split` | `{"reasoning_split":true}` | `{"reasoning_split":false}` |
+| 其他/none | 不写 |
+
+`supportsEffort=true` 且 `supportsThinking` 缺失时，按支持 thinking 处理。
+
+### 7.3 Effort 映射
+
+只有显式启用 reasoning 且 provider 支持 effort 时才映射。
+
+| mode | 映射 |
+| --- | --- |
+| `passthrough` | 仅接受 `minimal/low/medium/high/xhigh/max/ultra`，原值输出 |
+| `deepseek` | `max/xhigh/ultra -> max`；其他可识别请求统一 `high` |
+| `low_high` | `minimal/low -> low`；其他可识别请求统一 `high` |
+| `openrouter` | `max/xhigh/ultra -> xhigh`；其余只接受 `high/medium/low/minimal` |
+| `zen` | 使用模型 `reasoningLevels`；选择“不低于请求档位的最近合法档”，超过最高则选最高；无表或未知请求值则不写 |
+
+档位排序：
+
+```text
+minimal < low < medium < high < xhigh < max < ultra
+```
+
+输出位置：
+
+- `effortParam=="reasoning_effort"` -> 顶层 `reasoning_effort`；
+- `effortParam=="reasoning.effort"` -> `{"reasoning":{"effort":...}}`。
+
+显式关闭时，只有 `reasoning.effort` 方言要输出：
+
+```json
+{"reasoning":{"effort":"none"}}
+```
+
+顶层 `reasoning_effort` 方言不输出 `none`，只走 thinking 关闭开关。
+
+若没有 provider reasoning 配置，则只对内置判断为支持 effort 的 model，把
+`reasoning.effort` 原样复制到顶层 `reasoning_effort`。
+
+### 7.4 自动推导
+
+显式 `provider.meta.codexChatReasoning` 优先。否则先按平台 name/base URL 推导，再按
+provider/model 关键词推导。平台规则必须优先于模型厂商规则：
+
+| 平台/模型 | thinking 字段 | effort | 响应字段提示 |
+| --- | --- | --- | --- |
+| OpenRouter | 无 | `reasoning.effort`, mode=openrouter | auto |
+| SiliconFlow | `enable_thinking` | 不支持 | `reasoning_content` |
+| ModelScope | `enable_thinking` | 不支持 | `reasoning_content` |
+| opencode.ai Zen | 无 | `reasoning_effort`, mode=zen | `reasoning_content` |
+| DeepSeek | `thinking` | `reasoning_effort`, mode=deepseek | `reasoning_content` |
+| StepFun | 无开关 | 部分模型支持，2603 用 low_high，3.7 用 passthrough | `reasoning` |
+| Kimi/Moonshot | `thinking` | 不支持 | `reasoning_content` |
+| GLM/Zhipu/z.ai | `thinking` | 不支持 | `reasoning_content` |
+| Qwen/DashScope/Bailian | `enable_thinking` | 不支持 | `reasoning_content` |
+| MiniMax | `reasoning_split` | 不支持 | `reasoning_details` |
+| MiMo | `thinking` | 不支持 | `reasoning_content` |
+
+## 8. 非流式 Chat 响应转 Responses 响应
+
+抽象签名：
+
+```text
+chat_completion_to_response(chat_body, tool_context) -> responses_body | TransformError
+```
+
+### 8.1 输入校验
+
+必须存在非空 `choices` 数组，并使用第一项：
+
+- 缺 `choices` -> `No choices in chat response`；
+- 空数组 -> `Empty choices in chat response`；
+- 第一项缺 `message` -> `No message in chat choice`。
+
+这里只支持单选择语义，其他 choice 被忽略。
+
+### 8.2 顶层 envelope
+
+```json
+{
+  "id": "<normalized>",
+  "object": "response",
+  "created_at": 0,
+  "status": "completed",
+  "model": "",
+  "output": [],
+  "usage": {}
+}
+```
+
+字段规则：
+
+- `id`：Chat ID 以 `resp_` 开头则原样使用，否则前缀 `resp_`；缺失时为
+  `resp_ccswitch`；
+- `created_at`：取 Chat `created` 的无符号整数，缺失为 0；
+- `model`：取 Chat `model` 字符串，缺失为空串；
+- `status`：仅 `finish_reason=="length"` 映射为 `incomplete`，其他值和缺失都为
+  `completed`；
+- incomplete 时添加：
+  `{"incomplete_details":{"reason":"max_output_tokens"}}`。
+
+### 8.3 `output` 顺序
+
+固定按以下顺序追加：
+
+1. reasoning item（若有）；
+2. assistant message item（若有可见 content/refusal）；
+3. tool call items（按 Chat 数组顺序）。
+
+reasoning item：
+
+```json
+{
+  "id": "rs_<response_id>",
+  "type": "reasoning",
+  "summary": [{"type":"summary_text","text":"..."}]
+}
+```
+
+非流式完成 reasoning item 没有 `status`。
+
+assistant message item：
+
+```json
+{
+  "id": "<response_id>_msg",
+  "type": "message",
+  "status": "completed",
+  "role": "assistant",
+  "content": []
+}
+```
+
+content 映射：
+
+- Chat 字符串 content -> 一个 `output_text`；
+- Chat content 数组中的 `text`/`output_text` -> `output_text`；
+- 数组中的 `refusal` -> Responses `refusal`；
+- message 顶层非空 `refusal` -> 再追加一个 Responses `refusal`；
+- `output_text` 固定带 `annotations: []`；
+- 没有任何有效 part 时不生成 message item。
+
+### 8.4 Reasoning 响应提取
+
+先按第 5.6 节的 alias 优先级从 Chat message 提取。若没有，再检查字符串 content 是否
+以可选空白加 `<think>` 开头，并且存在 `</think>`：
+
+```text
+<think>reasoning</think>answer
+```
+
+- 中间内容 trim 后成为 reasoning summary；
+- 结束标签后的开头空白被剥掉，剩余成为 assistant answer；
+- 标签本身不得泄漏到 Responses 输出；
+- 没有完整结束标签时，非流式转换不把它拆成 reasoning。
+
+### 8.5 Tool call 响应
+
+支持现代 `message.tool_calls[]` 和 legacy `message.function_call`。
+
+普通 function/namespace：
+
+```json
+{
+  "id": "fc_<call_id>",
+  "type": "function_call",
+  "status": "completed",
+  "call_id": "<call_id>",
+  "name": "<restored name>",
+  "namespace": "<only when namespace>",
+  "arguments": "<canonical JSON or original non-JSON string>",
+  "reasoning_content": "<optional>"
+}
+```
+
+custom：
+
+```json
+{
+  "id": "ctc_<call_id>",
+  "type": "custom_tool_call",
+  "status": "completed",
+  "call_id": "<call_id>",
+  "name": "<original custom name>",
+  "input": "<decoded input>",
+  "reasoning_content": "<optional>"
+}
+```
+
+custom input 解码：
+
+- arguments 为空 -> 空串；
+- arguments 是 JSON object 且 `.input` 是字符串 -> 取 `.input`；
+- 否则返回原始 arguments 字符串。
+
+tool_search：
+
+```json
+{
+  "type": "tool_search_call",
+  "call_id": "<call_id>",
+  "status": "completed",
+  "execution": "client",
+  "arguments": {},
+  "reasoning_content": "<optional>"
+}
+```
+
+tool_search arguments：
+
+- 空串 -> `{}`；
+- 能解析且结果为 object -> 该 object；
+- 否则 -> `{"query":"<raw arguments>"}`。
+
+Chat call ID 缺失时，现代数组按 index 合成 `call_<index>`，legacy 使用 `call_0`。
+
+函数名缺失或 trim 后为空时丢弃该 call。若：
+
+- 本轮 status 本应是 `completed`；
+- 至少丢弃一个无合法名字的 call；
+- 最终一个合法 tool call 都没有；
+
+则整个非流式转换失败，错误说明上游返回无函数名的 tool call。若仍有至少一个合法 call，
+只丢弃坏 call；若 `finish_reason=="length"`，保持 incomplete 而不报该错误。
+
+### 8.6 Usage
+
+缺 usage 时也必须返回全零对象：
+
+```json
+{
+  "input_tokens": 0,
+  "input_tokens_details": {"cached_tokens": 0},
+  "output_tokens": 0,
+  "total_tokens": 0,
+  "output_tokens_details": {"reasoning_tokens": 0}
+}
+```
+
+基础映射：
+
+| Chat usage | Responses usage |
+| --- | --- |
+| `prompt_tokens`，回退 `input_tokens` | `input_tokens` |
+| `completion_tokens`，回退 `output_tokens` | `output_tokens` |
+| `total_tokens` | `total_tokens`；缺失则 input + output |
+
+cache read 优先级：
+
+1. 顶层 `cache_read_input_tokens`
+2. `prompt_tokens_details.cached_tokens`
+3. `input_tokens_details.cached_tokens`
+4. DeepSeek `prompt_cache_hit_tokens`
+5. 0
+
+cache write 优先级：
+
+1. `prompt_tokens_details.cache_write_tokens`
+2. `input_tokens_details.cache_write_tokens`
+3. 顶层 `cache_creation_input_tokens`
+4. 0
+
+输出总是有 `input_tokens_details.cached_tokens`。cache write 大于 0 时同时写
+`input_tokens_details.cache_write_tokens` 和顶层 `cache_creation_input_tokens`。
+如果输入直接带 `cache_read_input_tokens`，输出也保留该顶层字段。
+
+`completion_tokens_details` 是对象时整体复制，并在缺失时补
+`reasoning_tokens: 0`；否则创建只含该零值的对象。
+
+## 9. Chat SSE 转 Responses SSE
+
+### 9.1 输入解析
+
+输入按 SSE block 解析：
+
+- 支持任意 bytes 分片和跨分片 UTF-8；
+- 一个 block 中多个 `data:` 行用 `\n` 连接；
+- `event:` 可选；
+- 空 block 和无 data block 忽略；
+- `data: [DONE]` 触发 finalize；
+- 无法解析为 JSON 的普通 data block直接忽略；
+- `event:error` 或 chunk 中存在 `error` 键时转为 `response.failed` 并终止。
+
+每个 Chat chunk：
+
+1. 若有 `id`，归一化为 Responses ID；
+2. 若有非空 `model`，覆盖当前 model；
+3. 若有无符号 `created`，覆盖当前 created_at；
+4. 确保先发 response 生命周期起始事件；
+5. 非 null usage 覆盖 `latest_usage`；
+6. 只处理 `choices[0]`；
+7. delta 的 reasoning、content、tool_calls 依次处理；
+8. 非空 `finish_reason` 保存为最终原因。
+
+### 9.2 Response 起始和结束
+
+第一次处理有效 JSON chunk 时依次发：
+
+```text
+response.created
+response.in_progress
+```
+
+两者 data 形状分别为：
+
+```json
+{"type":"response.created","response":{...}}
+{"type":"response.in_progress","response":{...}}
+```
+
+此时 response：
+
+```json
+{
+  "id": "<current response id>",
+  "object": "response",
+  "created_at": 0,
+  "status": "in_progress",
+  "model": "",
+  "output": [],
+  "usage": "<latest usage or zero usage>"
+}
+```
+
+正常结束只发一个 `response.completed`，其 `response.output` 包含所有已完成 item，并按
+`output_index` 排序。即使 response status 是 `incomplete`，SSE event 名仍是
+`response.completed`。
+
+失败只发 `response.failed`，response `status=="failed"` 且带：
+
+```json
+{"error":{"message":"...","type":"<optional>"}}
+```
+
+失败后不能再发 `response.completed`。
+
+### 9.3 文本事件序列
+
+首段可见文本：
+
+```text
+response.output_item.added
+response.content_part.added
+response.output_text.delta  (每个增量)
+```
+
+added item：
+
+```json
+{
+  "id": "<response_id>_msg",
+  "type": "message",
+  "status": "in_progress",
+  "role": "assistant",
+  "content": []
+}
+```
+
+content part 固定：
+
+```json
+{"type":"output_text","text":"","annotations":[]}
+```
+
+结束时：
+
+```text
+response.output_text.done
+response.content_part.done
+response.output_item.done
+```
+
+done item 与非流式 message item 相同，包含完整累计文本。
+
+### 9.4 Reasoning 事件序列
+
+reasoning delta 使用与非流式相同的 alias 提取。首段：
+
+```text
+response.output_item.added
+response.reasoning_summary_part.added
+response.reasoning_summary_text.delta
+```
+
+added reasoning item：
+
+```json
+{
+  "id": "rs_<response_id>",
+  "type": "reasoning",
+  "status": "in_progress",
+  "summary": []
+}
+```
+
+summary part：
+
+```json
+{"type":"summary_text","text":""}
+```
+
+结束时：
+
+```text
+response.reasoning_summary_text.done
+response.reasoning_summary_part.done
+response.output_item.done
+```
+
+最终 reasoning item 不带 status。
+
+如果 content 流以可选空白加 `<think>` 开头，流式状态机先缓冲，直到能判断：
+
+- 是 `<think>` 前缀：标签内 content 转 reasoning；
+- 确认不是此前缀：全部转普通文本；
+- 收到 `</think>`：关闭 reasoning，标签后内容转文本；
+- 流结束或工具边界前仍未闭合：剥开头 `<think>` 后把剩余缓冲当 reasoning。
+
+显式 reasoning delta 会被同时附到当前尚未 done 的 tool call，保留工具调用历史思考。
+
+### 9.5 Tool call 流状态
+
+每个 Chat tool index 维护：
+
+```text
+output_index?
+item_id
+call_id
+name
+arguments accumulator
+reasoning_content
+added
+done
+```
+
+索引规则：
+
+- 有 `tool_call.index`：使用该整数；
+- 无 index 但 id 与已有 call 匹配：使用已有 key；
+- 无 index且出现新的非空 id：在最后 key 后分配新 key；
+- 无 index、无 id：归入最后 key，空 map 时为 0；
+- key 加一溢出时归入最后 key；
+- 稀疏 index 必须支持，不能用按 index 扩容的稠密数组。
+
+空 id/name continuation delta 不能覆盖已保存的非空 identity。arguments 字符串按到达顺序拼接。
+
+为了防止晚到的早期 call name 导致并行工具重排，只有从
+`next_tool_index_to_add` 开始连续、且 call_id/name 都已具备的 call 才提前发 added。
+finalize 时仍必须处理非连续的稀疏 key。
+
+普通 function 首次可发：
+
+```text
+response.output_item.added
+response.function_call_arguments.delta  (0..N)
+```
+
+结束：
+
+```text
+response.function_call_arguments.done
+response.output_item.done
+```
+
+custom tool 不发送 function arguments 事件。结束时从累计 arguments 解包 `.input`，发送：
+
+```text
+response.custom_tool_call_input.delta  (仅 input 非空时)
+response.custom_tool_call_input.done
+response.output_item.done
+```
+
+工具 arguments 在 done item 和 done event 中必须 canonicalize。
+
+无合法函数名的 call 在 finalize 时丢弃。与非流式相同：
+
+- completed 回合中所有 call 都因无名字被丢弃 -> `response.failed`，
+  type=`upstream_tool_call_dropped`；
+- 仍有合法 call -> 只丢弃坏 call；
+- length/incomplete -> 不转为该失败。
+
+### 9.6 流终止判定
+
+1. 收到 `[DONE]`：finalize；
+2. 字节流自然结束且已经 completed，或已见 `finish_reason`：finalize/不重复 finalize；
+3. 自然结束、无 finish reason、但已有实质输出：强制按 `length` finalize，返回
+   incomplete + `max_output_tokens`；
+4. 自然结束、无 finish reason、且无任何实质输出：`response.failed`，
+   type=`stream_truncated`；
+5. 底层 stream error：`response.failed`，type=`stream_error`；
+6. SSE error event：提取 `.error.message`/`.error.detail` 或顶层对应字段，type 优先
+   `.type`，回退 `.code`。
+
+## 10. 跨请求工具历史
+
+### 10.1 必要性
+
+Codex 后续请求可能只发送：
+
+```json
+{
+  "previous_response_id": "resp_x",
+  "input": [{
+    "type": "function_call_output",
+    "call_id": "call_1",
+    "output": "..."
+  }]
+}
+```
+
+Chat thinking provider 通常要求 tool output 之前存在原 assistant tool call，且保留
+`reasoning_content`。因此代理必须缓存上一响应的 call item 并在下次请求补回。
+
+### 10.2 缓存模型
+
+- 最多缓存 512 个 response；
+- 按 response 插入顺序淘汰最旧 response；
+- 每个 response 保存 `call_id -> item` 和原 call 顺序；
+- 全局维护 `call_id -> response_id 列表`；
+- 只缓存：
+  - `function_call`
+  - `custom_tool_call`
+  - `tool_search_call`
+- call ID 提取优先 `call_id`，回退 `id`，trim 后必须非空。
+
+非流式转换成功后，从完整 Responses response 记录。
+流式路径监听已转换后的 `response.output_item.done` 和 `response.completed` 事件记录。
+
+### 10.3 请求 enrich
+
+只处理 object/array 形式的 `input`；字符串等原样保留。
+
+lookup 顺序：
+
+1. `previous_response_id` 对应 response；
+2. 对该 response 未命中的请求 call_id，只有全局缓存中恰好唯一匹配一个 response 时，
+   才允许 fallback；
+3. 同一 call_id 对应多个 response 时禁止猜测。
+
+恢复规则：
+
+- output 前缺失对应 call item：在第一条 call output 前按原 call 顺序插入整个匹配组；
+- 后续单独遇到未恢复的 output：在它前面插入对应 cached call；
+- 请求已带 call item：不重复插入；
+- 请求已有 call item 但部分字段为空，从缓存补以下字段：
+  `name`、`namespace`、`arguments`、`input`、`status`、`execution`、
+  `reasoning_content`、`reasoning`；
+- 请求中的非空字段永远优先，缓存不能覆盖。
+
+如果原 `input` 是单对象且没有发生恢复/补全，保持对象形态；发生变化后可转成数组。
+
+## 11. 非流请求收到 SSE 的兼容聚合
+
+如果客户端 `stream:false`，但上游 body 无法解析为 JSON且内容看起来像 SSE，handler 会先
+把 Chat SSE 聚合为一个 `chat.completion`，再走第 8 节。
+
+聚合必须：
+
+- 剥离开头 UTF-8 BOM；
+- 支持 CRLF、最后 block 无空行、多 data 行；
+- 只聚合 choice index 0；
+- id/created/model 取首个“有意义”值，null、空串和数值 0/0.0 不算；
+- usage 取最后一个非 null 值；
+- finish_reason 取第一个非 null 值；
+- content/refusal 追加；
+- reasoning 使用统一 alias 提取器追加；
+- tool_calls 用稀疏有序 map 按 index 聚合，id/name 非空时覆盖，arguments 分片追加；
+- arguments 为 object/array 时序列化后追加；
+- legacy `function_call` 转为 index 0 的 synthetic tool call；
+- 如果存在非空 `message` 快照且 `delta` 为空，用 message 覆盖此前累计内容；
+- `event:error` 无条件失败；
+- 普通 chunk 的 `error` 只有能提取出非空消息时才失败，null/空占位不能误杀；
+- 完全没见到 choice -> 失败；
+- 同时缺 finish_reason 和 `[DONE]` -> 判定截断并失败；
+- 有 `[DONE]` 时可以接受缺 finish_reason；
+- 缺响应 id 时生成 UUID；
+- 未结束的残余 JSON block 可忽略，不能推翻此前已完成响应。
+
+这条 fallback 聚合与真正流式状态机是两个独立实现；重写时必须为二者保留一致的
+reasoning、tool call 和截断语义。
+
+## 12. 错误转换与 HTTP 响应
+
+上游非 2xx Chat 响应保留原 HTTP status，但 body 统一为：
+
+```json
+{
+  "error": {
+    "message": "...",
+    "type": "...",
+    "code": null,
+    "param": null
+  }
+}
+```
+
+输入兼容：
+
+1. 标准 `{"error":{...}}`；
+2. 顶层错误对象；
+3. MiniMax `base_resp.status_code/status_msg`；
+4. 顶层 `message`、`detail`、`status_msg`；
+5. JSON 字符串；
+6. 非 JSON/HTML/纯文本；
+7. 空 body。
+
+提取：
+
+- message：`message -> detail -> status_msg -> base_resp.status_msg -> source 字符串 ->
+  整个 source JSON 字符串`；
+- type：`type`，缺失为 `upstream_error`；
+- code：`code -> base_resp.status_code -> null`；
+- param：`param -> null`；
+- 空 body message：`Upstream returned an empty error response`。
+
+非 JSON HTTP 错误最多保留 1024 bytes 的 UTF-8 lossily decoded 文本，按字符边界截断并加
+`…(truncated)`。
+
+重建 JSON 响应时：
+
+- 保留原 status；
+- 移除旧实体相关 header 和 hop-by-hop header；
+- 移除上游 `Content-Type`，设置唯一
+  `Content-Type: application/json`。
+
+流式成功响应设置：
+
+```text
+Content-Type: text/event-stream
+Cache-Control: no-cache
+```
+
+非流式成功响应保留可安全透传的上游 header，并把 Content-Type 重建为
+`application/json`。
+
+## 13. 重写建议的内部接口
+
+为避免逻辑互相污染，建议至少保留以下组件边界：
+
+```text
+detect_bridge(provider, app_type, endpoint) -> bool
+rewrite_endpoint(endpoint, base_url) -> url
+
+build_tool_context(responses_request) -> ToolContext
+enrich_request_from_history(request, HistoryStore) -> mutation_count
+responses_request_to_chat(request, ToolContext, ReasoningConfig?) -> ChatRequest
+
+chat_response_to_responses(response, ToolContext) -> ResponsesResponse
+chat_sse_to_responses(stream, ToolContext) -> ResponsesEventStream
+chat_error_to_responses(status, headers, body) -> HttpResponse
+
+record_response_history(response)
+record_response_event_history(event)
+```
+
+请求方向伪代码：
+
+```text
+if bridge_enabled:
+    explicit_cache_key = request.prompt_cache_key
+    history.enrich(request)
+    apply_upstream_model(request)
+    reasoning_config = resolve_reasoning_config(provider, request.model)
+    tool_context = build_tool_context(request)
+    chat_request = convert_request(request, tool_context, reasoning_config)
+    maybe_inject_prompt_cache_key(chat_request, explicit_cache_key, client_session_id)
+    POST rewritten_chat_url with chat_request
+```
+
+响应方向伪代码：
+
+```text
+if upstream_status is not 2xx:
+    return normalize_chat_error(upstream_status, upstream_headers, upstream_body)
+
+if client_requested_stream or upstream_is_sse:
+    responses_stream = convert_chat_sse(upstream_stream, tool_context)
+    return record_history_while_passthrough(responses_stream)
+
+chat_json = parse_json(upstream_body)
+if parse_failed and body_looks_like_sse:
+    chat_json = aggregate_chat_sse(upstream_body)
+responses_json = convert_chat_json(chat_json, tool_context)
+history.record(responses_json)
+return responses_json
+```
+
+## 14. 必须保持的实现不变量
+
+1. ToolContext 必须从请求产生，并同时传给请求和响应转换；否则 namespace/custom/tool_search
+   无法无损恢复。
+2. tool arguments 和 tool outputs 的 canonical JSON 必须稳定，否则会破坏 prompt cache。
+3. system message 最终只能位于 `messages[0]`。
+4. assistant tool-call history最终必须有非空 `reasoning_content`。
+5. tool output 必须紧跟对应 assistant tool_calls；迁移出的媒体不能插在并行 tool outputs
+   之间。
+6. namespace Chat name 必须不超过 64 UTF-8 bytes，长名映射必须确定性。
+7. 无 tools 时不能保留 `tool_choice` 或 `parallel_tool_calls`。
+8. 流式 output index 必须按逻辑产出顺序单调分配，最终 output 按该 index 排序。
+9. SSE 只能终结一次；failed 后不能 completed。
+10. `finish_reason=length` 必须表示 incomplete，不能被无名工具调用错误覆盖。
+11. completed 回合如果所有工具调用都因无名字被丢弃，必须显式失败，不能返回“成功空壳”。
+12. 缺 usage 仍输出完整全零 usage schema，但消费记录层应跳过全零 usage。
+13. 历史 fallback 只能使用全局唯一 call_id，不能在歧义时猜测。
+14. 未知 Responses input item 只有带 role/content 时才按 message 保留；否则不能生成幽灵消息。
+15. 非流式入口遇到伪 SSE 时必须聚合，不能直接把 Chat SSE 透传给 Responses 客户端。
+
+## 15. 最小验收测试矩阵
+
+重写实现至少应覆盖以下契约测试：
+
+| 类别 | 用例 | 预期 |
+| --- | --- | --- |
+| 路由 | 四种 Responses path + query | 都转 `/chat/completions` 且 query 保留 |
+| provider 检测 | 每种 api_format alias | 启用桥接 |
+| 基础请求 | instructions + string input | system + user |
+| 角色 | developer/latest_reminder/未知 | system/user/user |
+| system | 中途多个 developer | 合并到首条，其他消息保序 |
+| 多模态 | text + image + file + audio | Chat part 数组正确 |
+| token limit | o-series 与普通 model | 分别使用 max_completion_tokens/max_tokens |
+| streaming request | 原 stream_options 存在/不存在 | 合并 include_usage=true |
+| 无工具 | 有 tool_choice/parallel_tool_calls | 两字段删除 |
+| function schema | null/missing/non-object type/oneOf | 强制 object 且保留其他键 |
+| namespace | 短名、超过 64 bytes、多字节字符 | 确定性压平和反向恢复 |
+| custom | grammar 元数据、freeform input | 描述保留原定义，input 往返无损 |
+| tool_search | 加载 namespace 后调用 | 恢复 tool_search 和 namespace |
+| reasoning history | 前置、尾随、embedded+尾随、跨 user 边界 | 归属正确且不泄漏 |
+| reasoning placeholder | 裸 assistant tool_calls | `"tool call"` |
+| tool history | previous_response_id + output only | 自动插入原 call 和 reasoning |
+| history fallback | 唯一/歧义 call_id | 仅唯一时恢复 |
+| tool media | 单个、并行、下一批 call、真实 user 边界 | tool outputs 相邻，媒体位置正确 |
+| non-stream text | reasoning + answer + calls | output 顺序 reasoning/message/calls |
+| inline think | `<think>...</think>answer` | 标签消失，reasoning/answer 分离 |
+| usage | cache read/write 四种别名 | 按优先级归一化 |
+| finish reason | stop/tool_calls/length | completed/completed/incomplete |
+| malformed call | 仅无名、混合、length 截断 | error/保留合法/incomplete |
+| SSE text | 多 delta + usage-only final chunk | 完整生命周期和 usage |
+| SSE tools | identity/arguments 分帧、并行、稀疏/缺 index | 不重排、不丢参数、不稠密扩容 |
+| SSE custom | arguments 中 input 分片 | custom input delta/done |
+| SSE truncation | 有输出无 finish、无输出无 finish | incomplete / failed |
+| SSE error | event:error、transport error | failed 且不再 completed |
+| fake SSE | stream:false 返回 message snapshot | 聚合后返回 Responses JSON |
+| HTTP error | OpenAI、MiniMax、纯文本、HTML、空 body | 标准 Responses error，status 保留 |

--- a/docs/claude_messages_to_chat_completions.md
+++ b/docs/claude_messages_to_chat_completions.md
@@ -1,0 +1,722 @@
+# Anthropic Messages → Chat Completions 桥接规范
+
+> 状态：唯一生产行为规范；不保留目标仓库旧实现兼容分支
+>
+> 固定来源：请求转换采用 cc-switch
+> `3217f72596f2d1c0f879f0a05f83803825d9809f`；非流式响应与流式 event fields采用
+> LiteLLM `ae7e50f096a8722bad14d63b6a0d4634d59bf475`；stream terminal closure按第 8.6 节
+
+## 1. 范围与优先级
+
+本文只定义：
+
+1. 已解析 Anthropic Messages request object → Chat Completions request object；
+2. 已解析 Chat Completions response object → Anthropic Message object；
+3. typed Chat Completions chunk sequence → Anthropic event sequence。
+
+实现只有一个生产 profile：
+
+| 方向 | 规范来源 | 冲突处理 |
+|---|---|---|
+| request/input | cc-switch | 与 LiteLLM 不同时采用 cc-switch |
+| nonstream response | LiteLLM | 采用 LiteLLM |
+| streaming response | LiteLLM + 第 8.6 节 | 采用 LiteLLM event fields与本文 terminal closure |
+
+`docs/cc-switch/claude_messages_to_chat_completions.md` 和
+`docs/litellm/claude_messages_to_chat_completions.md` 只作为来源说明，不是可选运行时 profile。
+固定源码提交与说明文档冲突时，以固定源码提交为准。
+
+目标仓库已有 adapter、HTTP helper、错误类型和测试不参与行为选择。与本文冲突的旧实现必须替换。
+
+本文转换核心不解析 HTTP body 或原始 SSE bytes。宿主负责 JSON/SSE framing、解压、body limit、
+认证、重试和路由；转换核心接收本节规定的已解析值。
+
+## 2. 逻辑接口
+
+```text
+convertAnthropicRequest(
+  request: JsonObject,
+  provider: ProviderContext
+) -> ChatRequest | TransformError
+
+convertChatResponse(
+  response: ChatResponse
+) -> AnthropicMessage | TransformError
+
+AnthropicStreamConverter.start(
+  model: string
+) -> AnthropicEvent
+
+AnthropicStreamConverter.consume(
+  chunk: ChatChunk
+) -> AnthropicEvent[]
+
+AnthropicStreamConverter.finish()
+  -> AnthropicEvent[]
+```
+
+```text
+ProviderContext {
+  anthropicBaseUrl?: string
+  baseUrl?: string
+  baseURL?: string
+  apiEndpoint?: string
+  promptCacheKey?: string
+}
+```
+
+`ProviderContext` 只承载 cc-switch request 转换实际读取的 provider 信息。不得加入由目标仓库旧实现
+推导的 capability、lineage、response ID 或 diagnostic。
+
+request 转换不截断 tool name，因此 response 转换使用空的 tool-name reverse map；tool name 原样进入
+LiteLLM response 算法。
+
+## 3. Request 顶层转换
+
+### 3.1 字段表
+
+转换器只构造下表中的 Chat 字段。未知或未列出的 Anthropic 顶层字段被丢弃。
+
+| Anthropic request | Chat request | 规则 |
+|---|---|---|
+| `model` | `model` | 仅 string 时复制 |
+| `system` | system message | 见第 4.1 节 |
+| `messages` | `messages` | 见第 4 节 |
+| `max_tokens` | `max_tokens` / `max_completion_tokens` | o-series 使用后者 |
+| `temperature` | `temperature` | 字段存在时原值复制 |
+| `top_p` | `top_p` | 字段存在时原值复制 |
+| `stop_sequences` | `stop` | 字段存在时原值复制 |
+| `stream` | `stream` | 字段存在时原值复制 |
+| `thinking` / `output_config.effort` | `reasoning_effort` | 见第 6 节 |
+| `tools` | `tools` | 见第 5 节 |
+| `tool_choice` | `tool_choice` | 见第 5.3 节 |
+
+以下字段不进入 Chat request：
+
+```text
+top_k
+metadata
+service_tier
+container
+mcp_servers
+cache_control
+output_format
+output_config.format
+context_management
+```
+
+转换器不提供 strict unknown-field error；已知字段的值除本文明确转换外不做额外类型或范围校验。
+
+### 3.2 max token 字段
+
+直接检查 raw model string；满足以下条件时使用 `max_completion_tokens`：
+
+```text
+model[0] == lowercase ASCII "o"
+and model[1] is ASCII digit
+```
+
+其他 model 使用 `max_tokens`。model 缺失、非 string 或长度不足时也使用 `max_tokens`。
+
+### 3.3 stream usage
+
+转换结果的 `stream === true` 时：
+
+```json
+{
+  "stream_options": {
+    "include_usage": true
+  }
+}
+```
+
+若 provider 预处理已经在转换结果中放入 object `stream_options`，保留其他键并覆盖
+`include_usage:true`；其他类型替换为上述 object。非流式不添加 `stream_options`。
+
+`ProviderContext` 自有 property `promptCacheKey` 时写入该 string，包括 empty string；property 缺失时
+不写入。存在但非 string 属于调用方 context 错误。不得从 Anthropic metadata、session ID 或
+`cache_control` 推导该值。
+
+## 4. system、messages 与历史
+
+### 4.1 system
+
+`system`：
+
+- string：去除 billing attribution 后，非空时生成一条 system message；
+- array：每个具有 string `.text` 的 block 独立生成 system message；
+- 其他：忽略。
+
+Billing attribution 只在文本以以下字面量开头时处理：
+
+```text
+x-anthropic-billing-header:
+```
+
+处理顺序：
+
+1. 删除第一行；
+2. 删除其后最多一个 CRLF、LF 或 CR 空行；
+3. 保留其余文本；
+4. header 不在开头时不处理。
+
+扫描完全部 Anthropic messages 后：
+
+- 没有 system message：不处理；
+- 恰好一条：把该 message 原 shape 移到 `messages[0]`，不做 parts 提取或 string 合并；
+- 多条：提取每条 system string content；parts array 提取其中 string `.text`；丢弃空结果；
+  使用单个 `\n` 连接为唯一首条 system message；
+- 非 system message 相对顺序保持不变。
+
+### 4.2 普通 message
+
+每个 `messages[]`：
+
+- `role` 为 string 时原样使用，否则默认 `"user"`；
+- content 缺失时生成 `{"role":role,"content":null}`；
+- content 为 string 时原样使用；
+- content 为 array 时按本节转换 blocks；
+- 其他 JSON 值原样写入 `content`。
+
+Text block：
+
+```json
+{"type":"text","text":"..."}
+```
+
+只复制 `type` 和 `text`，不复制 `cache_control`。
+
+Image block 转为：
+
+```json
+{
+  "type": "image_url",
+  "image_url": {"url": "<resolved URL>"}
+}
+```
+
+支持：
+
+- `source.type=="base64"`：`data:<media_type>;base64,<data>`；
+- `source.type=="url"`：使用 `source.url`；
+- cc-switch media helper 已识别的 MCP/image URL shape。
+
+无法识别的 image 和所有普通 `document` block 被忽略。
+
+最终普通 message：
+
+- 没有 text/image 且没有 tool call：不生成；
+- 仅一个 text part：简化为 string；
+- 一个 image 或多个 parts：保持 parts array；
+- 只有 tool calls：`content:null`；
+- text/image 与 tool calls 可以共存。
+
+### 4.3 `tool_use`
+
+每个 `tool_use` 合并到当前 assistant Chat message 的 `tool_calls[]`：
+
+```json
+{
+  "id": "<id or empty string>",
+  "type": "function",
+  "function": {
+    "name": "<name or empty string>",
+    "arguments": "<canonical JSON>"
+  }
+}
+```
+
+`input` 缺失时使用 `{}`。同一 message 的多个 `tool_use` 保持输入顺序。
+
+Canonical JSON：
+
+1. object key 在每一层按 Unicode code point 升序；
+2. array 保持顺序；
+3. 使用 compact JSON，不写无意义空白；
+4. string escaping、number 和 null/bool 输出匹配 `serde_json::Value` serializer。
+
+### 4.4 `tool_result`
+
+每个 `tool_result` 立即生成独立 Chat tool message：
+
+```json
+{
+  "role": "tool",
+  "tool_call_id": "<tool_use_id or empty string>",
+  "content": "<string>"
+}
+```
+
+- content 为 string：原样保留；
+- content 缺失：空 string；
+- 其他 JSON：使用第 4.3 节 canonical JSON；
+- `is_error` 被忽略。
+
+一个 Anthropic message 同时含 tool results 和普通内容时，Chat message 顺序为：
+
+1. 全部 tool messages；
+2. 可选 synthetic media user message；
+3. 剩余 text/image/tool_use 形成的普通 message。
+
+Tool-result media 必须加载并严格应用
+`docs/cc-switch/codex_response_to_chat_completions.md` 的 tool-result media extraction 规则：
+
+```text
+[cc-switch: tool result media moved to the following user message]
+[cc-switch: media output of tool call <tool_use_id>]
+```
+
+多个并行 tool result 的媒体合入同一 synthetic user message，且不得插入连续 tool messages 中间。
+
+### 4.5 thinking history
+
+以下任一字符串转小写后包含 `deepseek`、`mimo` 或 `xiaomimimo` 时启用历史保留：
+
+- request model；
+- `provider.anthropicBaseUrl`；
+- `provider.baseUrl`；
+- `provider.baseURL`；
+- `provider.apiEndpoint`。
+
+仅当 assistant message 含 tool calls 时：
+
+- 收集 thinking block 的非空 `.thinking`，用 `\n` 连接；
+- `redacted_thinking` 记为 `[redacted thinking]`；
+- 没有可用 thinking 时使用 `tool call`；
+- 写入 Chat assistant message 顶层 `reasoning_content`。
+
+其他情况下 thinking/redacted-thinking 被丢弃。Thinking-only message 不生成 Chat message。
+
+## 5. Tools 与 schema
+
+### 5.1 Tool declarations
+
+- 过滤 `type=="BatchTool"`；
+- 其他项全部转换为 Chat function tool；
+- name 缺失时为空 string；
+- description 缺失时为 JSON null；
+- input_schema 缺失时使用 `{}`；
+- `strict` 和 `cache_control` 不复制；
+- 过滤后为空时不输出 `tools`。
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "get_weather",
+    "description": "Get weather",
+    "parameters": {
+      "type": "object",
+      "properties": {}
+    }
+  }
+}
+```
+
+### 5.2 Schema cleanup
+
+1. root 是 object 且缺 `type` 时添加 `"type":"object"`；
+2. 此时若也缺 `properties`，添加 `"properties":{}`；
+3. root 已含 `type` 时不改写；
+4. 非 object schema 不包裹；
+5. 当前 node 的 `format=="uri"` 时删除 `format`；
+6. 递归遍历 `properties` values 和 `items`；
+7. 不遍历 `oneOf`、`anyOf`、`allOf`、`$defs` 或 `definitions`。
+
+Tool name 不截断，不建立 reverse map，不识别 LiteLLM hosted/native tool。Web-search tool 按普通
+function tool 处理。
+
+### 5.3 Tool choice
+
+| Anthropic input | Chat output |
+|---|---|
+| `"auto"` / `{"type":"auto"}` | `"auto"` |
+| `"any"` / `{"type":"any"}` | `"required"` |
+| `"none"` / `{"type":"none"}` | `"none"` |
+| `{"type":"tool","name":"f"}` | `{"type":"function","function":{"name":"f"}}` |
+| 其他 | 原样保留 |
+
+过滤 tools 后不自动删除 `tool_choice`。`disable_parallel_tool_use` 不映射。
+
+## 6. Reasoning request
+
+只有 model 属于下列 family 时才添加 `reasoning_effort`：
+
+- o-series：小写 model 以 `o` 开头，第二个字符是 ASCII digit；
+- 小写 model 以 `gpt-` 开头，下一字符是 digit 且 `>= "5"`；
+- `grok-4.5`、`grok-4.5-*` 或 `grok-build-*`。
+
+优先读取 string `output_config.effort`：
+
+| input | output |
+|---|---|
+| `low` / `medium` / `high` | 原值 |
+| `max` | `xhigh` |
+| 其他 | 不输出 |
+
+只有该字段是 string 时才抑制 `thinking` fallback；未知 string 不输出且不 fallback。字段为
+non-string 时忽略并继续读取 `thinking`。
+
+否则读取 `thinking`：
+
+| input | `reasoning_effort` |
+|---|---|
+| `type:"adaptive"` | `xhigh` |
+| enabled 且 `budget_tokens < 4000` | `low` |
+| enabled 且 `4000 <= budget_tokens < 16000` | `medium` |
+| enabled 且 `budget_tokens >= 16000` | `high` |
+| enabled 且缺 budget | `high` |
+| disabled、未知或缺失 | 不输出 |
+
+`budget_tokens` 只有能表示为 unsigned integer 时参与区间判断；negative、float、bool、string 和超出
+unsigned range 的值按缺失处理，因此 enabled thinking 映射为 `high`。
+
+原 `thinking`、`output_config` 和 structured-output fields 均不透传。
+
+## 7. 非流式 Chat response
+
+### 7.1 Envelope 与 choices
+
+输出：
+
+```json
+{
+  "id": "<chat response id>",
+  "type": "message",
+  "role": "assistant",
+  "model": "<chat response model or unknown-model>",
+  "content": [],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 0,
+    "output_tokens": 0
+  }
+}
+```
+
+- `id` 原样使用，不添加 `msg_`；
+- `choices` 必须至少有一项；空数组在读取首项 stop reason 时抛出转换错误，不返回部分对象；
+- content 遍历并追加**所有** choices；
+- 总 `stop_reason` 只读取 `choices[0].finish_reason`；
+- 不执行 context-management/compaction polyfill。
+
+每个 choice 按以下顺序追加 blocks：
+
+1. truthy `thinking_blocks`；
+2. 当 `thinking_blocks` 缺失、null 或 empty list 时的 `reasoning_content` fallback；
+3. text；
+4. tool calls。
+
+Truthy `thinking_blocks`：
+
+- `thinking` → `{"type":"thinking","thinking":"...","signature":"..."}`；
+- `redacted_thinking` → `{"type":"redacted_thinking","data":"..."}`；
+- regular thinking 的 `.thinking` 不是 non-whitespace string 时删除；
+- redacted block 即使 data empty 也保留；
+- nonempty list 即使最终只含被删除的 regular blocks，也抑制 `reasoning_content` fallback。
+
+没有 `thinking_blocks` 且 `reasoning_content` 非空时：
+
+```json
+{"type":"thinking","thinking":"...","signature":null}
+```
+
+`message.content !== null` 时生成一个 text block；空 string 也生成。输入必须已是 typed Chat response
+要求的 string，不在此展平 assistant multimodal parts。
+
+### 7.2 Tool calls
+
+每个 typed Chat tool call：
+
+```json
+{
+  "type": "tool_use",
+  "id": "<normalized id>",
+  "name": "<original name>",
+  "input": {}
+}
+```
+
+ID 规则：
+
+1. 在第一个 `__thought__` separator 处截断；
+2. 把不属于 `[a-zA-Z0-9_-]` 的每个字符替换为 `_`；
+3. 结果为空时使用 `tool_use_id`。
+
+Arguments parser：
+
+1. null、空或全 whitespace → `{}`；
+2. 先执行标准 JSON parse，允许任意 JSON value；
+3. 失败后扫描 string，忽略 quoted string 内字符，记录未闭合 `{`/`[`；
+4. 删除尾部逗号，按逆序补齐 `}`/`]`，再次 parse；
+5. 无未闭合 opener 或修复后仍失败时抛出 `ValueError`。
+
+先选择 provider-specific container：tool-call 外层 object truthy 时使用它，否则使用 function-level
+object。选中的 container 内 `thought_signature` 为 truthy 时，tool-use block 加入：
+
+```json
+{"provider_specific_fields":{"signature":"<signature>"}}
+```
+
+### 7.3 Stop reason
+
+| Chat finish_reason | Anthropic stop_reason |
+|---|---|
+| `stop` | `end_turn` |
+| `length` | `max_tokens` |
+| `tool_calls` | `tool_use` |
+| 其他或 null | `end_turn` |
+
+`stop_sequence` 固定为 null。
+
+### 7.4 Usage
+
+Cache read 优先级：
+
+1. `cache_read_input_tokens`；
+2. `_cache_read_input_tokens`；
+3. `prompt_tokens_details.cached_tokens`。
+
+Cache creation 优先级：
+
+1. `cache_creation_input_tokens`；
+2. `_cache_creation_input_tokens`；
+3. `prompt_tokens_details.cache_creation_tokens`；
+4. `prompt_tokens_details.cache_write_tokens`。
+
+只接受正 integer，或数值为正整数的 float；bool、负数、零和小数按 0。
+
+```text
+input_tokens =
+  max(0, prompt_tokens - cache_read - cache_creation)
+output_tokens = completion_tokens
+```
+
+Cache 值大于 0 时才输出相应 Anthropic 字段。Web-search request count 优先采用 LiteLLM helper
+已计算值，否则读取正整数 `prompt_tokens_details.web_search_requests`。
+
+`prompt_tokens` 与 `completion_tokens` 来自 typed Chat usage，缺失时按 0。Cache/web-search helper
+只接受正 integer，或数值为正整数的 float；bool、负数、0 和有小数部分的 float 按 0。
+
+## 8. Streaming Chat response
+
+### 8.1 输入边界与 framing
+
+转换器接收宿主已经解析为 typed `ChatChunk` 的序列，不接收 `data:` 行或 `[DONE]`。宿主的正常
+iterator exhaustion 调用 `finish()`。
+
+每个 `AnthropicEvent` 的 SSE 表示使用 Python 3 default `json.dumps`：
+
+```text
+event: <event.type>
+data: <default-json-dumps event>
+
+```
+
+因此 separators 默认包含 `", "` 和 `": "`，`ensure_ascii=true`，不是 compact JSON。
+
+### 8.2 `message_start`
+
+`start(model)` 恰好生成一次：
+
+```json
+{
+  "type": "message_start",
+  "message": {
+    "id": "msg_<uuid4>",
+    "type": "message",
+    "role": "assistant",
+    "content": [],
+    "model": "<provider-local model>",
+    "stop_reason": null,
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0
+    }
+  }
+}
+```
+
+UUID4 使用小写 hex 和标准 hyphen。不得复用 Chat stream ID。
+
+### 8.3 Chunk normalization
+
+任意 nonempty choices chunk 的 `choices[0]` 同时含 content payload 和 finish reason 时先拆为：
+
+1. content-only chunk：删除 finish reason 和 usage；
+2. finish-only chunk：清空 content/tool/reasoning/thinking，保留 finish reason 和 usage。
+
+单 choice chunk 同时含多种 payload 时按顺序拆为：
+
+```text
+reasoning or thinking
+text
+tool calls
+```
+
+只有 payload-kind 拆分要求 choices 数量恰好为 1。该拆分过程中，signature-less
+`thinking_blocks` 才会规范化为 `reasoning_content`；single-payload chunk 不做该规范化。以下情况
+不按 payload kind 拆分：
+
+- choices 数量不是 1；
+- tool call 只有 arguments continuation、没有 function name；
+- 只有一种 payload kind。
+
+### 8.4 Content blocks
+
+第一个非空 payload 打开 block：
+
+| Chat delta | Anthropic block |
+|---|---|
+| `content` | `text` |
+| 新 tool call name/ID | `tool_use` |
+| `thinking_blocks` | thinking |
+| `reasoning_content` | `thinking` |
+
+Role-only、空 content、空 reasoning 和空 thinking 不打开 block。
+
+Payload type 改变时必须依次输出：
+
+1. previous `content_block_stop`；
+2. new `content_block_start`；
+3. 当前 chunk 的非空 `content_block_delta`。
+
+Block index 从 0 开始，每次 start 后递增。
+
+Delta 映射：
+
+| Chat delta | Anthropic delta |
+|---|---|
+| content | `text_delta` |
+| tool arguments | `input_json_delta` |
+| thinking text | `thinking_delta` |
+| thinking signature | `signature_delta` |
+
+Streaming 不生成 `redacted_thinking` block。Signed thinking 的 block start 保留该 chunk 中完整
+thinking 和 signature，随后该 chunk 只输出 `signature_delta`；同一 chunk 的 thinking text 不再作为
+`thinking_delta` 输出。多个 choices 的 text/reasoning 按 choice 顺序拼接。Tool arguments 不跨
+choices 拼接：遇到每个 tool-bearing choice 时重置 `partial_json`；最终使用最后一个 tool-bearing
+choice，并只把该 choice 内的 calls 按数组顺序拼接。
+
+新的 function name 表示新的 tool block：先关闭前一个，再打开下一个。只有 arguments continuation
+时继续当前 tool block。
+
+新 tool call 的 ID 缺失时生成 UUID4，再按第 7.2 节 ID 规则归一化。原 ID 含
+`__thought__<signature>` 时，separator 前部分作为 ID，后部分作为 tool block 的
+`provider_specific_fields.signature`。
+
+### 8.5 Event schemas
+
+除第 8.2 节 `message_start` 外，事件 object 固定为：
+
+```text
+content_block_start {
+  type: "content_block_start"
+  index: integer
+  content_block:
+    | {type:"text", text:""}
+    | {
+        type:"tool_use",
+        id:string,
+        name:string,
+        input:{},
+        provider_specific_fields?:{signature:string}
+      }
+    | {type:"thinking", thinking:string, signature:string}
+}
+
+content_block_delta {
+  type: "content_block_delta"
+  index: integer
+  delta:
+    | {type:"text_delta", text:string}
+    | {type:"input_json_delta", partial_json:string}
+    | {type:"thinking_delta", thinking:string}
+    | {type:"signature_delta", signature:string}
+}
+
+content_block_stop {
+  type: "content_block_stop"
+  index: integer
+}
+
+message_delta {
+  type: "message_delta"
+  delta: {stop_reason:"end_turn"|"max_tokens"|"tool_use"}
+  usage: AnthropicUsage
+}
+
+message_stop {
+  type: "message_stop"
+}
+```
+
+Unknown extra event fields不得由目标实现自行加入。
+
+### 8.6 Finish 与 usage
+
+Finish chunk 生成待发送：
+
+```json
+{
+  "type": "message_delta",
+  "delta": {"stop_reason":"end_turn|max_tokens|tool_use"},
+  "usage": {"input_tokens":0,"output_tokens":0}
+}
+```
+
+转换器暂存该事件：
+
+- 后续 usage-only chunk 到达时，按第 7.4 节合并 usage，再发送；
+- iterator 正常结束但没有 usage-only chunk 时，以 finish chunk 已有 usage或
+  `{"input_tokens":0,"output_tokens":0}` 发送；
+- 发送顺序固定为：
+
+```text
+content_block_stop
+message_delta
+message_stop
+```
+
+`message_stop` 恰好一次。Final message delta 发出后忽略后续 provider chunks。
+
+没有任何 finish reason 而自然 exhaustion 时，先对 active content block发送一次
+`content_block_stop`，再发送 `message_stop`；不合成 `message_delta`。没有 active block 时只发送
+`message_stop`。首个 chunk 只有 finish reason、没有 payload 时，先打开并关闭 empty text block，再
+发送 `message_delta` 与 `message_stop`。
+
+目标实现采用 LiteLLM async iterator 语义：provider/转换异常传播给宿主，不合成 cc-switch
+`event:error`，也不在异常后补成功 `message_stop`。
+
+## 9. 测试与完成标准
+
+必须使用固定输入和完整期望输出测试：
+
+| 类别 | 必测 |
+|---|---|
+| Request fields | unknown drop、raw `o1`/`O1` max token、stop、stream usage、present empty prompt cache key |
+| System | billing header、CR/LF/CRLF、空 system、单条原 shape、多条合并、单 `\n` |
+| Messages | missing/string/array content、text/image/document、空 parts |
+| Tool history | 并行 tool_use、tool_result string/JSON/media、thinking whitelist |
+| Tools | BatchTool、schema defaults、URI cleanup、组合关键字不递归、unknown tool choice |
+| Reasoning | model families、string/non-string effort precedence、unknown string、budget boundaries |
+| Nonstream | 多 choices、truthy/empty thinking blocks、redacted empty data、ID normalization、argument repair/failure |
+| Usage | 每个 alias、bool/float/integer约束、cache subtraction、web-search count |
+| Stream | first-choice finish split、多-choice payload、block switching、signed thinking、无 redacted stream |
+| Terminal | finish-first empty block、usage-only、missing usage zero fields、no-finish active/empty exhaustion、exception propagation |
+
+完成必须同时满足：
+
+1. request object 与 cc-switch 固定提交的转换结果深度等值；
+2. nonstream response 与 LiteLLM 固定提交的转换结果深度等值；
+3. stream 的 Anthropic event type、payload和顺序与 LiteLLM async wrapper 等值；
+4. 目标仓库旧 adapter 行为不影响任何断言；
+5. request 不出现 LiteLLM-only hosted tools、name truncation、structured output 或 context management；
+6. response 不出现 cc-switch-only legacy fallback、SSE parser 或重复 `[DONE]` 行为。
+
+Golden harness 必须注入 deterministic UUID4；SSE expected text必须使用 Python default
+`json.dumps` spacing/escaping，而不是只做 JSON parse 后深度等值。

--- a/docs/codex_response_to_chat_completions.md
+++ b/docs/codex_response_to_chat_completions.md
@@ -9,6 +9,10 @@
 
 ## 1. 范围与固定优先级
 
+本文只定义
+[OpenAI Responses 上游路由规范](./openai_responses_routing.md) 选择 `ChatBridgePlan` 后的行为。
+`NativeResponsesPlan` 不调用本文 converters，也不读写本文 HistoryStore。
+
 本文定义：
 
 1. 已解析 Responses request object → Chat Completions request object；
@@ -102,7 +106,8 @@ effortValueMode = "passthrough"
 
 1. 保存客户端显式 `prompt_cache_key`；
 2. 用 `previous_response_id` 和 input call IDs 做历史 enrichment；
-3. 由 provider 选择上游 model，并同时写入 request 与 `RequestContext.resolvedModel`；
+3. 应用 [上游路由规范](./openai_responses_routing.md) planning 前唯一解析的 upstream model，并同时
+   写入 request 与 `RequestContext.resolvedModel`；
 4. 从顶层 `tools[]` 和 `tool_search_output.tools[]` 构造 request-side `ToolContext`；
 5. 接收调用方已经解析完成的 `ReasoningConfig | null`；
 6. 转换 request body；
@@ -134,10 +139,11 @@ response 分别从同一个 immutable original request 构造等价 context；�
 
 ### 3.2 Model 与 prompt cache key
 
-上游 model 选择：
+`ChatBridgePlan` 只消费
+[上游路由规范](./openai_responses_routing.md) planning 前得到的唯一 `ResolvedModel`：
 
-1. request model 已在 provider model catalog 时保留；
-2. 否则使用 provider 默认上游 model；
+1. 不再次查询 catalog 或默认 model；
+2. 将 `ResolvedModel.upstreamModel` 写入 request 与 `RequestContext.resolvedModel`；
 3. 再执行 request 转换。
 
 默认允许 `prompt_cache_key` 的上游：

--- a/docs/codex_response_to_chat_completions.md
+++ b/docs/codex_response_to_chat_completions.md
@@ -1,0 +1,1021 @@
+# OpenAI Responses API → Chat Completions 桥接规范
+
+> 状态：唯一生产行为规范；不保留目标仓库旧实现兼容分支
+>
+> 固定来源：request/input/history 采用 cc-switch
+> `3217f72596f2d1c0f879f0a05f83803825d9809f`；response envelope、content、usage 与
+> managed ID 采用 LiteLLM `ae7e50f096a8722bad14d63b6a0d4634d59bf475`；response tool
+> restoration 与 stream item lifecycle 采用上述 cc-switch 提交
+
+## 1. 范围与固定优先级
+
+本文定义：
+
+1. 已解析 Responses request object → Chat Completions request object；
+2. Chat Completions response object → Responses response object；
+3. typed Chat Completions async chunk sequence → Responses event sequence；
+4. cc-switch request-side tool history enrichment。
+
+实现只有一个生产 profile：
+
+| 方向 | 规范来源 | 冲突处理 |
+|---|---|---|
+| request/input/tools/history | cc-switch | 与 LiteLLM 不同时采用 cc-switch |
+| nonstream response | LiteLLM + cc-switch | LiteLLM envelope/content/usage/ID；cc-switch ToolContext restoration |
+| streaming response | LiteLLM + cc-switch | LiteLLM response events；cc-switch ToolContext 与独立 item lifecycle |
+
+`docs/cc-switch/codex_response_to_chat_completions.md` 和
+`docs/litellm/codex_response_to_chat_completions.md` 是来源说明，不是运行时 profile。来源说明与固定
+提交冲突时，以固定提交为准。
+
+目标仓库已有 adapter、ID、error、SSE parser 和测试不参与行为选择；冲突的旧实现必须替换。
+
+转换核心不接收原始 HTTP body 或 SSE bytes。宿主负责 JSON/SSE framing、压缩、body limit、
+认证、重试和路由。本文 stream converter 接收上游已经解析的 typed Chat chunks。
+
+## 2. 逻辑接口与上下文
+
+```text
+enrichResponsesHistory(
+  request: ResponsesRequest,
+  history: HistoryStore
+) -> ResponsesRequest
+
+convertResponsesRequest(
+  request: ResponsesRequest,
+  context: RequestContext
+) -> ChatRequest | TransformError
+
+convertChatResponse(
+  response: ModelResponse | JsonObject,
+  context: ResponseContext
+) -> ResponsesResponse | TransformError
+
+LiteLLMAsyncResponseStream(
+  chunks: AsyncIterator<ChatChunk>,
+  context: StreamContext
+) -> AsyncIterator<ResponsesEvent>
+```
+
+```text
+RequestContext {
+  resolvedModel: string
+  reasoningConfig: ReasoningConfig | null
+  upstreamHost?: string
+  upstreamPath?: string
+  promptCacheRouting?: "enabled" | "disabled" | "auto"
+  clientSessionId?: string
+}
+
+StreamContext {
+  originalRequest: ResponsesRequest
+  toolContext: RequestToolContext
+  model: string
+  customLlmProvider?: string
+  modelId?: string
+}
+
+ResponseContext {
+  originalRequest: ResponsesRequest
+  toolContext: RequestToolContext
+  customLlmProvider?: string
+  modelId?: string
+}
+```
+
+Defaults：
+
+```text
+thinkingParam   = "thinking"
+effortParam     = "reasoning_effort"
+effortValueMode = "passthrough"
+```
+
+不存在通用 `Capabilities`、`ConversionOptions.behavior_profile`、`Diagnostic` 或稳定
+`BridgeError` DTO。请求和响应各自使用其来源实现实际需要的状态，不强制共享一个 context。
+进入 `convertResponsesRequest` 前必须完成 model selection；`request.model` 与
+`RequestContext.resolvedModel` 必须相同。转换器不读取 provider catalog 或默认 model。
+
+## 3. Request 预处理
+
+执行顺序：
+
+1. 保存客户端显式 `prompt_cache_key`；
+2. 用 `previous_response_id` 和 input call IDs 做历史 enrichment；
+3. 由 provider 选择上游 model，并同时写入 request 与 `RequestContext.resolvedModel`；
+4. 从顶层 `tools[]` 和 `tool_search_output.tools[]` 构造 request-side `ToolContext`；
+5. 接收调用方已经解析完成的 `ReasoningConfig | null`；
+6. 转换 request body；
+7. 按本节规则注入 prompt cache key。
+
+### 3.1 ToolContext
+
+```text
+RequestToolContext {
+  chatTools: ChatTool[]
+  seenChatNames: Set<string>
+  chatNameToBinding: Map<string, {
+    kind: "function" | "namespace" | "custom" | "tool_search"
+    originalName: string
+    namespace?: string
+  }>
+  sourceNameToChatName: Map<(namespace?, originalName), string>
+}
+```
+
+收集来源：
+
+1. request 顶层 `tools[]`；
+2. 递归遍历整个 `input`，收集任意 `tool_search_output.tools[]`。
+
+Function/custom/namespace child name 在判断前执行 `trim()`；空 name 和重复最终 Chat name 被跳过，
+先出现的定义获胜。Namespace 自身 name 保持 source string。Request、nonstream response 和 stream
+response 分别从同一个 immutable original request 构造等价 context；不要求复用同一 object instance。
+
+### 3.2 Model 与 prompt cache key
+
+上游 model 选择：
+
+1. request model 已在 provider model catalog 时保留；
+2. 否则使用 provider 默认上游 model；
+3. 再执行 request 转换。
+
+默认允许 `prompt_cache_key` 的上游：
+
+- host 为 `api.openai.com`；
+- host 为 `api.kimi.com`，且 path 为 `/coding` 或以 `/coding/` 开头。
+
+`promptCacheRouting`：
+
+- `enabled`：允许；
+- `disabled`：禁止；
+- `auto` 或缺失：使用 host/path 规则。
+
+允许时 key 优先级：
+
+1. 客户端显式 `prompt_cache_key` 执行 `trim()` 后的非空值；
+2. 客户端提供的 `clientSessionId` 执行 `trim()` 后的非空值；
+3. 不写入。
+
+代理生成的逐请求 UUID 不能作为 cache key。
+
+## 4. Request 顶层字段
+
+### 4.1 映射
+
+| Responses request | Chat request | 规则 |
+|---|---|---|
+| `model` | `model` | 预处理后的值 |
+| `instructions` | 首条 system message | 见第 4.2 节 |
+| `input` | `messages` | 见第 5 节 |
+| `max_output_tokens` | `max_completion_tokens` / `max_tokens` | raw model 以小写 `o` 开头且第二字符是 ASCII digit 时使用前者 |
+| `max_tokens` | `max_tokens` | 原值；覆盖前一步同名值 |
+| `max_completion_tokens` | `max_completion_tokens` | 原值 |
+| `temperature` | 同名 | 原值 |
+| `top_p` | 同名 | 原值 |
+| `stream` | 同名 | 原值 |
+| `reasoning` | provider 方言字段 | 第 7 节 |
+| `tools` | `tools` | 第 6 节 |
+| `tool_choice` | `tool_choice` | 第 6.5 节 |
+
+以下字段原值透传：
+
+```text
+frequency_penalty
+logit_bias
+logprobs
+metadata
+n
+parallel_tool_calls
+presence_penalty
+response_format
+seed
+service_tier
+stop
+stream_options
+top_logprobs
+user
+```
+
+未列出的字段被丢弃，包括：
+
+```text
+previous_response_id
+store
+include
+truncation
+text
+prompt_cache_key
+```
+
+`text.format`、`text.verbosity` 和 structured-output shortcut 均不转换。客户端显式顶层
+`response_format` 仍按透传表进入 Chat request。
+
+最终没有非空 tools 时删除 `tool_choice` 和 `parallel_tool_calls`。
+
+只有 `stream` 为 JSON boolean `true` 时才保证：
+
+```json
+{"stream_options":{"include_usage":true}}
+```
+
+原 `stream_options` 为 object 时保留其他键并覆盖 `include_usage:true`；其他类型替换为上述 object。
+
+### 4.2 Instructions 与 system
+
+`instructions`：
+
+- string：直接生成 system message；
+- array：每项若为 string 则取自身，否则取 string `.text`；过滤空 string 后用 `\n\n` 连接；
+- 其他：不生成。
+
+全部 input 转换完成后，把所有 system message 的非空 string content 按原出现顺序用 `\n\n`
+连接并移动到 `messages[0]`。其他消息相对顺序不变。
+
+## 5. `input` → `messages`
+
+### 5.1 Input shape 与 role
+
+`input`：
+
+- string → 单条 user message；
+- object → 单个 input item；
+- array → 按顺序处理；
+- 其他 → 不生成 message。
+
+| Responses role | Chat role |
+|---|---|
+| `system` / `developer` | `system` |
+| `assistant` | `assistant` |
+| `tool` | `tool` |
+| `user` / `latest_reminder` | `user` |
+| 其他或缺失 | `user` |
+
+### 5.2 Message 与 content parts
+
+`type=="message"`，或 type 缺失但有 `role`/`content` 的 object，按普通 message 转换。未知 type
+只要有 `role` 或 `content` 也按 message 处理。
+
+Content：
+
+- null 或 string：原样；
+- 非 array、非 string：原样；
+- array：逐 part 转换。
+
+| Responses part | Chat part |
+|---|---|
+| `input_text` / `output_text` / `text` | `.text` 为非空 string 时生成 `{"type":"text","text":...}`，否则丢弃 |
+| `refusal` | `.refusal` 为非空 string 时按 text part 处理，否则丢弃 |
+| `input_image` | `{"type":"image_url","image_url":...}` |
+| `input_file` | `{"type":"file","file":{...}}` |
+| `input_audio` | `{"type":"input_audio","input_audio":...}` |
+| 其他 | 丢弃 |
+
+Image：
+
+- `image_url` 为 object 时原样复制；
+- 其他值变为 `{"url": <string-or-empty>}`。
+
+File 只复制 `file_id`、`file_data`、`filename`；必须至少有 `file_id` 或 `file_data`，URL-only file
+被丢弃。Audio 只在 `input_audio` 存在时复制。
+
+没有任何非文本 part 时，把 text 使用单个 `\n` 连接为 string；有 image/file/audio 时保留 parts
+array。
+
+顶层 `input_text`、`input_image`、`input_file`、`input_audio` item 视为单 part message。
+
+### 5.3 Call batching
+
+连续 call items 合并为一条：
+
+```json
+{"role":"assistant","content":null,"tool_calls":[]}
+```
+
+request-side tool call 不写 `index`。
+
+`function_call`：
+
+```text
+id = call_id -> item.id -> ""
+function.name = RequestToolContext 映射后的 name
+function.arguments = normalized JSON string
+```
+
+`custom_tool_call`：
+
+```text
+id = call_id -> item.id -> ""
+function.name = item.name -> ""
+function.arguments = canonical JSON {"input": item.input or ""}
+```
+
+`tool_search_call`：
+
+```text
+id = call_id -> item.id -> ""
+function.name = "tool_search"
+function.arguments = canonical JSON of item.arguments; missing -> "{}"
+```
+
+`function_call_output` 生成 tool message，content 规则：
+
+- string 且可 JSON parse：parse 后 canonicalize；
+- 其他 string：原样；
+- 其他 JSON：canonical JSON；
+- 缺失：空 string。
+
+`custom_tool_call_output` 和 `tool_search_output` 的 content 是替换媒体后的**完整原始 item**
+canonical JSON，不只是 `.output`。
+
+### 5.4 Canonical JSON
+
+1. object key 在每层按字典序；
+2. array 保序；
+3. compact JSON，无多余 whitespace；
+4. 递归处理；
+5. string/number/null/bool 输出匹配 `serde_json::Value` serializer。
+
+Arguments normalization：
+
+- missing、空或全 whitespace string → `"{}"`；
+- 可 parse 的 JSON string → parse 后 canonicalize；
+- 无法 parse 的 string → 原样；
+- object/array/scalar → canonical JSON string。
+
+### 5.5 Reasoning history
+
+普通或 call item reasoning 提取优先级：
+
+1. 非空 `reasoning_content` string；
+2. 非空 `reasoning` string；
+3. `reasoning.content`、`.text`、`.summary`；
+4. `reasoning_details` string/object/parts，parts 用 `\n\n` 连接。
+
+独立 `type=="reasoning"` item：
+
+1. `reasoning_content`、`content`、`text`；
+2. `summary` string；
+3. `summary[]` 中 `.text`、`.content` 或 string part，用 `\n\n` 连接。
+
+状态：
+
+1. 独立 reasoning 进入 pending；
+2. 后续 assistant message/call batch 消费；
+3. 多段用 `\n\n` 连接；
+4. call 自带重复文本不再次追加；
+5. user 等非-assistant 边界前，把 pending 回填到上一 assistant；
+6. input 结束同样回填；
+7. 有 tool calls 但无非空 reasoning 的 assistant 最终补 `reasoning_content:"tool call"`。
+
+### 5.6 Tool-output media
+
+递归扫描最大深度 32。媒体位置替换为：
+
+```text
+[cc-switch: tool result media moved to the following user message]
+```
+
+并在当前并行 outputs 后生成 synthetic user message，每个 call 的媒体前加入：
+
+```text
+[cc-switch: media output of tool call <call_id>]
+```
+
+支持：
+
+- Responses/Chat image URL；
+- Anthropic base64 image；
+- MCP image；
+- 含 `file_id` 或 `file_data` 的 `input_file`；
+- `input_audio.input_audio`；
+- trim 后至少 8 KiB、整个 string 都是 image data URL；
+- JSON 编码 string 内的上述结构。
+
+不扫描 HTML/CSS/SVG 内嵌 data URL。只有确实找到媒体后，残留超长 data/base64-like string
+替换为：
+
+```text
+[cc-switch: omitted <byte_len> bytes]
+```
+
+## 6. Tool declarations
+
+### 6.1 Function
+
+接受平铺或嵌套 function shape，统一为 Chat function tool。Parameters：
+
+- missing、null、非-object → `{"type":"object","properties":{}}`；
+- object 且 `.type` 不是 string `"object"` → 保留其他 keys，强制 `type:"object"`；
+- 保留顶层 `oneOf` 等其他 schema keys；
+- 嵌套 function 的 `strict` 优先，否则使用 tool 顶层 `strict`。
+
+### 6.2 Namespace
+
+Namespace child 数组接受 `tools` 或 `children`，只处理 `type=="function"` child。
+
+最终 Chat name：
+
+```text
+namespace + "__" + childName
+```
+
+若 UTF-8 长度超过 64 bytes：
+
+1. SHA-256 完整 name；
+2. 取 digest 前 8 bytes，编码 16 个小写 hex；
+3. suffix 为 `"__" + hex`；
+4. 取不切断 UTF-8 code point 的最长前缀，使总长度不超过 64 bytes。
+
+### 6.3 Custom 与 tool search
+
+String tool declaration 也视为 custom。Custom 固定转换为：
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "<trimmed-name>",
+    "description": "Original tool definition:\n```json\n<canonical-original-tool>\n```",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "input": {
+          "type": "string",
+          "description": "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description."
+        }
+      },
+      "required": ["input"]
+    }
+  }
+}
+```
+
+Tool search 固定降级为 name `tool_search` 的 function：
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type":"string",
+      "description":"Search query for tools or connectors to load."
+    },
+    "limit": {
+      "type":"integer",
+      "description":"Maximum number of tool groups to return."
+    }
+  },
+  "required": ["query"]
+}
+```
+
+Tool-search function description 固定为：
+
+```text
+Search and load Codex tools, plugins, connectors, and MCP namespaces for the current task.
+```
+
+只转换 function、namespace、custom 和 tool_search；其他 tool type 被忽略。
+
+### 6.4 Collision
+
+所有最终 Chat names 共用一个 first-wins set。后来的重复 name 被跳过。Namespace tool choice 使用
+RequestToolContext 中实际生成的 name，不能重新计算另一个 hash。
+
+### 6.5 `tool_choice`
+
+| Responses value | Chat value |
+|---|---|
+| `{"type":"function","name":"f","namespace":"ns"?}` | 指定映射后的 function |
+| `{"type":"tool_search"}` | 指定 `tool_search` function |
+| `{"type":"custom","name":"x"}` | 指定 `x` function |
+| 其他 string/object | 原样 |
+
+最终 tools 为空时删除整个 `tool_choice`，包括 string `"none"`。
+
+## 7. Reasoning request
+
+```text
+ReasoningConfig {
+  supportsThinking?: bool
+  supportsEffort?: bool
+  thinkingParam?: "thinking" | "enable_thinking" | "reasoning_split" | "none"
+  effortParam?: "reasoning_effort" | "reasoning.effort" | "none"
+  effortValueMode?: "passthrough" | "deepseek" | "low_high" | "openrouter" | "zen"
+  effortLevels?: string[]
+}
+```
+
+Requested state：
+
+- `reasoning.effort` trim/lowercase 为 `none`、`off`、`disabled` → false；
+- 其他 string effort → true；
+- 否则有 `reasoning` key 时，非-null → true，null → false；
+- 无 `reasoning` key → unspecified。
+
+Thinking switch：
+
+| `thinkingParam` | true | false |
+|---|---|---|
+| `thinking` | `{"thinking":{"type":"enabled"}}` | `{"thinking":{"type":"disabled"}}` |
+| `enable_thinking` | `true` | `false` |
+| `reasoning_split` | `true` | `false` |
+| none/其他 | 不写 | 不写 |
+
+`supportsEffort=true` 时始终视为支持 thinking，即使 `supportsThinking` 明确为 false。
+
+只有 requested=true 且支持 effort 时映射：
+
+| mode | 映射 |
+|---|---|
+| `passthrough` | 仅 `minimal/low/medium/high/xhigh/max/ultra` |
+| `deepseek` | `max/xhigh/ultra -> max`；其他任何非 disabled string → `high` |
+| `low_high` | `minimal/low -> low`；其他任何非 disabled string → `high` |
+| `openrouter` | `max/xhigh/ultra -> xhigh`；其他只接受 `high/medium/low/minimal` |
+| `zen` | 在 `effortLevels` 选择不低于请求的最近值；超过最高取最高 |
+
+档位顺序：
+
+```text
+minimal < low < medium < high < xhigh < max < ultra
+```
+
+`effortParam=="reasoning_effort"` 写顶层；`"reasoning.effort"` 写 nested object。显式关闭时只有
+nested 方言写 `{"reasoning":{"effort":"none"}}`。
+
+无 provider config 时，只对 cc-switch 内置判断支持 effort 的 model，把
+`reasoning.effort` 原值写到顶层 `reasoning_effort`。`reasoning.summary` 被忽略。
+
+Provider/model → `ReasoningConfig` 的推导属于 model routing，不属于协议转换器。调用方必须在每次
+request 进入转换器前解析成 explicit config 或 null；转换器不得再次读取 provider name、base URL、
+model catalog 或目标仓库全局配置。
+
+## 8. Request history
+
+HistoryStore：
+
+- 最多 512 个 response，按插入顺序淘汰；
+- 每个 response 保存有序 call items 和 `call_id -> item`；
+- 全局保存 `call_id -> response IDs`；
+- 只缓存 `function_call`、`custom_tool_call`、`tool_search_call`；
+- call ID 取 trim 后非空 `call_id`，否则 `id`。
+
+Lookup：
+
+1. 先查 `previous_response_id`；
+2. 未命中的 call ID 仅在全局恰好匹配一个 response 时 fallback；
+3. 多个 response 有同一 call ID 时不猜。
+
+Enrichment：
+
+- output 前缺 call item：按原顺序插入匹配组；
+- 后续单个 output 缺 call：在其前插入 cached call；
+- 已有 call 不重复；
+- 已有 call 的空字段可从 cache 补 `name`、`namespace`、`arguments`、`input`、`status`、
+  `execution`、`reasoning_content`、`reasoning`；
+- request 非空字段始终优先。
+
+原 input 是单 object 且未变化时保持 object；发生恢复后可变为 array。
+
+非流成功后从完整 Responses response 记录。流式路径从已转换的
+`response.output_item.done`/`response.completed` 记录。由于响应采用 LiteLLM，能记录的类型受
+第 12 节组合损失限制。
+
+## 9. 非流式 Chat response
+
+### 9.1 输入、envelope 与 status
+
+接受 LiteLLM `ModelResponse` 或可构造成该类型的 object。空 choices 不报错：finish reason 为
+null，status 为 completed，output 为空。
+
+| Chat/source | Responses field | 规则 |
+|---|---|---|
+| `id` | `id` | 先复制，再由 managed-ID helper 编码 |
+| `created` | `created_at` | 原值 |
+| `model` | `model` | 原值 |
+| fixed | `object` | `"response"` |
+| `error` | `error` | 存在时复制，否则 null |
+| `incomplete_details` | `incomplete_details` | 存在时复制，否则 null |
+| `instructions` | `instructions` | 存在时复制，否则 null |
+| `metadata` | `metadata` | 存在时复制，否则 `{}` |
+| `parallel_tool_calls` | `parallel_tool_calls` | 存在时复制，否则 false |
+| `temperature` | `temperature` | 存在时复制，否则 0 |
+| `tool_choice` | `tool_choice` | 存在时复制，否则 `"auto"` |
+| `tools` | `tools` | 存在时复制，否则 `[]` |
+| `top_p` | `top_p` | 存在时复制，否则 null |
+| `max_output_tokens` | `max_output_tokens` | 存在时复制，否则 null |
+| `previous_response_id` | `previous_response_id` | 存在时复制，否则 null |
+| fixed | `reasoning` | null |
+| fixed | `text` | `{}` |
+| `truncation` | `truncation` | 存在时复制，否则 null |
+| `user` | `user` | 存在时复制，否则 null |
+| `usage` | `usage` | 第 10 节 |
+
+顶层 status 只取 first choice：
+
+| finish_reason | status |
+|---|---|
+| `stop` / `tool_calls` / `function_call` / null | `completed` |
+| `length` / `content_filter` / `refusal` | `incomplete` |
+| 其他 | `completed` |
+
+`length` 不生成 synthesized `incomplete_details`。
+
+### 9.2 Output 顺序与 IDs
+
+1. 最多一个 reasoning item；
+2. 每个 choice 的 message item或 image-generation items；
+3. 所有 choices 的 function/custom call items；
+4. provider server-side tool result 可替换同 call ID function item。
+
+IDs：
+
+| Item | ID |
+|---|---|
+| message | `msg_` + UUID4 |
+| reasoning | `rs_` + UUID4 |
+| image generation | `ig_` + UUID4 |
+| function/custom call | Chat tool-call ID 同时作为 `id`、`call_id` |
+
+UUID4 使用小写 hex 与标准 hyphen，每次转换新生成。Nonstream response 构造完成后调用第 11.1 节
+managed-ID helper；missing ID 与已是 managed ID 的值保持不变。
+
+### 9.3 Reasoning、message、annotations
+
+只检查第一个有 reasoning 的 choice，生成最多一个 reasoning item：
+
+- 明文只读 `message.reasoning_content`；
+- 带 `signature` 或 `data` 的 thinking blocks compact-JSON 编码到 `encrypted_content`；
+- 没有明文但有可保留 block 时 content 为空 array；
+- item status 由该 choice finish reason 映射。
+
+每个没有 `message.images` 的 choice 生成一个 message item：
+
+```json
+{
+  "type": "message",
+  "id": "msg_<uuid4>",
+  "status": "<mapped>",
+  "role": "<Chat message role>",
+  "content": [{
+    "type": "output_text",
+    "text": "<message.content>",
+    "annotations": []
+  }]
+}
+```
+
+只转换 message-level annotation `type=="url_citation"`，复制
+`start_index`、`end_index`、`url`、`title`。其他 annotations 删除。Refusal parts、
+`<think>` tag、`message.reasoning` 和 legacy `function_call` 不转换。
+
+### 9.4 Tool calls
+
+收集所有 choices 的 typed `message.tool_calls[]`。对每个 call，先按 Chat function name 查询
+`ResponseContext.toolContext.chatNameToBinding`。
+
+未命中或 kind=`function` 时生成普通 call：
+
+```json
+{
+  "type": "function_call",
+  "id": "<Chat call id>",
+  "call_id": "<Chat call id>",
+  "name": "<Chat function name>",
+  "arguments": "<raw arguments string>",
+  "status": "<function status or completed>"
+}
+```
+
+不 canonicalize arguments，不生成缺失 call ID，不要求 name 非空。
+
+Kind=`namespace` 时生成普通 `function_call`，`name=binding.originalName`，并写入
+`namespace=binding.namespace`。
+
+Kind=`custom` 时生成：
+
+```text
+id      = Chat call ID
+call_id = Chat call ID
+type    = "custom_tool_call"
+name    = binding.originalName
+status  = function.status or "completed"
+input:
+  arguments trim 后为空                -> ""
+  arguments parse 为 object 且 input 是 string -> object.input
+  其他                                  -> 原 arguments string
+```
+
+Kind=`tool_search` 时生成：
+
+```text
+type      = "tool_search_call"
+call_id   = Chat call ID
+status    = function.status or "completed"
+execution = "client"
+arguments:
+  空 string                    -> {}
+  可 parse 为 JSON object       -> parsed object
+  其他                          -> {"query": <raw arguments>}
+```
+
+只有普通 function call 附加 `provider_specific_fields`；custom call 不附加。优先使用 tool-call
+外层 truthy 值，缺失或 falsy 时再使用 function 内层 truthy 值。Provider
+`code_interpreter_results` 可按 call ID 替换普通 function item。
+
+### 9.5 Images
+
+Choice message 有 `images` 时，该 choice 不生成 text message；每个有效 image：
+
+```json
+{
+  "type": "image_generation_call",
+  "id": "ig_<uuid4>",
+  "status": "completed|incomplete|failed",
+  "result": "<base64>"
+}
+```
+
+任意 nonempty string 以 `data:` 开头时，在第一个 comma 处分割并取后半；没有 comma 时丢弃该
+image。非 `data:` string 原样作为 result，不验证是否为 base64。
+
+| finish reason | image status |
+|---|---|
+| `stop` | completed |
+| `length` | incomplete |
+| `content_filter` / `error` | failed |
+| 其他 | completed |
+
+## 10. Usage 与 provider fields
+
+| Chat usage | Responses usage |
+|---|---|
+| `prompt_tokens` | `input_tokens` |
+| `completion_tokens` | `output_tokens` |
+| `total_tokens` | `total_tokens` |
+| `cost` | dynamic `cost` |
+
+Usage 缺失时三个 token count 均为 0。
+
+`prompt_tokens_details` 存在时创建 `input_tokens_details`：
+
+- `cached_tokens`，缺失补 0；
+- `text_tokens`；
+- `audio_tokens`；
+- `cache_write_tokens` 为 truthy 时使用；否则（包括 0）用 `cache_creation_tokens` fallback。
+
+`completion_tokens_details` 存在时创建 `output_tokens_details`：
+
+- `reasoning_tokens`，缺失补 0；
+- `audio_tokens`；
+- `text_tokens`；
+- `image_tokens`。
+
+Chat `_hidden_params` 整体复制。若其中有 `provider_specific_fields`，还暴露同名顶层动态字段。
+
+## 11. Streaming Chat response
+
+### 11.1 Boundary 与 initial response
+
+只定义 LiteLLM async iterator。它接收 typed Chat chunks；raw `data:`、`[DONE]`、malformed JSON、
+UTF-8 residual 和 transport framing 都由宿主处理。
+
+发出 `response.created` 前先读取字面上的第一个 non-null chunk：
+
+- 有 string chunk ID：缓存为原始 response ID；
+- iterator 先结束：生成 `resp_<uuid4>`。
+
+该 chunk 被 buffer，并在初始 response events 发出后进入正常语义转换。Output item 必须等到第一个 nonempty
+reasoning/text delta 或具有可用 call ID/name 的 tool delta 才创建。Role-only、blank 和
+usage-only chunk 不创建 output item。
+
+Response-level stream ID 编码：
+
+```text
+resp_<base64(
+  "litellm:custom_llm_provider:<provider>;"
+  + "model_id:<model-id>;"
+  + "response_id:<original-id>"
+)>
+```
+
+使用 UTF-8 与普通 RFC 4648 padded Base64，不使用 URL-safe alphabet。`model-id` 来自
+`StreamContext.modelId`；`provider` 或 `model-id` 缺失时按 Python `str(None)` 写成
+`"None"`。已经可解码为 LiteLLM managed ID 时不重复编码。`response.created`、`response.in_progress` 和
+`response.completed` 使用编码 ID。Nonstream core 构造 response 后，public converter 对同一对象调用
+该 helper；response ID missing 时 helper 原样返回。
+
+本转换 seam 把 LiteLLM metadata 限定为 `modelId`，不启用
+`encrypted_content_affinity_enabled`，也不执行 container-ID rewrite；这些属于 LiteLLM router/
+container framework，而不是本协议转换。
+
+`response.created.response` 初始字段：
+
+```text
+id                 cached raw ID, then encoded in event
+object             "response"
+created_at         current Unix seconds
+status             "in_progress"
+error              null
+incomplete_details null
+instructions       original request value or null
+max_output_tokens  null
+model              StreamContext.model
+output             []
+parallel_tool_calls true
+previous_response_id null
+reasoning          {effort:null, summary:null}
+store              true
+tool_choice        transformed original value or "auto"
+tools              original request tools or []
+top_p              original value or 1.0
+```
+
+存在时还复制 original request 的 `temperature`、`text`、`truncation`、`user`、`metadata`。
+
+最先依次发送：
+
+```text
+response.created
+response.in_progress
+```
+
+### 11.2 Text
+
+第一个 nonempty text delta 创建 message item与 content part。普通 text 事件：
+
+```text
+response.output_item.added
+response.content_part.added
+response.output_text.delta repeated
+response.output_text.done
+response.content_part.done
+response.output_item.done
+response.completed
+```
+
+Message 使用分配到的 `output_index`、`content_index=0`，ID 为本次 stream 缓存的
+`msg_<uuid4>`。Incremental text 只读取 first choice `delta.content`。Reasoning 已结束后首次出现
+text 时必须先发送 message `output_item.added` 和 `content_part.added`。
+
+Stream 维护 `next_output_index=0`。每个 reasoning、message 或 tool 首次 added 时取得当前值并将其
+递增；同一 item 后续所有 events复用该 index。
+
+### 11.3 Reasoning
+
+首个 nonempty `reasoning_content` 打开独立 `rs_<uuid4>` reasoning item并分配 output index。每段发：
+
+```text
+response.reasoning_summary_part.added  // 仅 item 首次打开时
+response.reasoning_summary_text.delta
+```
+
+首次看到普通 content、function/tool call 或非-null finish reason 时依次发：
+
+```text
+response.reasoning_summary_text.done
+response.reasoning_summary_part.done
+response.output_item.done
+```
+
+Reasoning 文本为所有已见 `reasoning_content` 直接拼接。
+
+### 11.4 Tools
+
+Tool state 同时具有 nonempty call ID 与 nonempty name 时发送：
+
+```text
+response.output_item.added
+```
+
+每个 tool call 独立分配 output index。后续 ID 缺失时可用
+`tool_call.index` 恢复；同一 index 曾映射多个 call ID 后，该 index 标为 ambiguous，后续无 ID delta
+被跳过。
+
+Item kind、name 和 namespace 使用 `StreamContext.toolContext`，规则同第 9.4 节。
+
+Function、namespace 与 tool-search arguments delta 按**最多 10 characters**切片，每片发送：
+
+```text
+response.function_call_arguments.delta
+```
+
+Stream 结束时，function、namespace 与 tool-search call 依次发送：
+
+```text
+response.function_call_arguments.done
+response.output_item.done
+```
+
+Custom call 不发送 `response.function_call_arguments.*`。结束时按第 9.4 节解包 input：
+
+```text
+response.custom_tool_call_input.delta  // input 非空时
+response.custom_tool_call_input.done
+response.output_item.done
+```
+
+只在最终完整 response 出现的 tool call，必须先补发 `output_item.added`，再发对应 delta/done。
+
+### 11.5 Annotations 与 provider fields
+
+只在第一次看到 `delta.annotations` 时，为可转换 URL citations 排队
+`response.output_text.annotation.added`。
+
+Chunk 顶层及 `choice[0].delta.provider_specific_fields` 累积，same key last-value-wins；list 也覆盖，
+不追加。终态写入完整 ModelResponse `_hidden_params.provider_specific_fields`。
+
+### 11.6 Completion
+
+Message、reasoning 和每个 tool 维护独立的 added/done state。Finalize：
+
+1. 关闭每个已 added 且未 done 的 item；
+2. 最终完整 response 中首次出现的 late tool 先发送 added，再发送 delta/done；
+3. tool-only stream 不创建 message item；
+4. `response.completed.response.output` 只包含已 added 且已 done 的 items；
+5. output 按 `output_index` 升序；
+6. 中间公布的 item ID 原样写入 completed snapshot。
+
+每个 emitted event 都必须包含 `sequence_number`。首个 event 为 1；每发送一个 event 加 1；值在
+同一 response stream 内严格单调递增且不重复。
+
+上游或 converter 异常把 iterator 标为 finished 后原样传播；不生成 `response.failed`。
+
+## 12. ToolContext 生命周期
+
+1. 每个 request 构造一个 `RequestToolContext`；
+2. request conversion、nonstream response 和 stream response 从同一 immutable request 构造
+   等价 snapshot；
+3. response 不从 original request 重新推导 name ownership；
+4. custom、namespace、dynamic namespace、tool-search 与 collision ownership 只读取该 context；
+5. context 在 response terminal 或 error 后释放；
+6. history store 记录恢复后的 item type、name、namespace、call ID 和 arguments/input。
+
+## 13. Error boundary
+
+Request converter 使用 cc-switch `TransformError` 语义。Response converter 与 async stream 使用
+LiteLLM 行为：
+
+- ModelResponse/object 构造失败：异常传播；
+- empty choices：返回 completed、empty output response；
+- provider completion 异常：原样传播；
+- stream converter 内部异常：标记 finished 后原样传播；
+- nonstream response 顶层 `error` 字段进入 Responses model；
+- 不创建统一 stable error code；
+- 不合成 `response.failed`；
+- 不注入 `_bridge_diagnostics`。
+
+HTTP status、error body、raw SSE error event 和 credential redaction 由宿主决定，不属于转换核心。
+
+## 14. 测试与完成标准
+
+### 14.1 Request differential
+
+每个 fixture 必须与 cc-switch 固定提交深度等值：
+
+| 类别 | 必测 |
+|---|---|
+| Top-level | passthrough/drop、boolean stream、stream_options、max token |
+| Instructions | string/array、空值、多 system `\n\n`、raw `o1` 与 `O1` |
+| Input | object/string/array、role、null/scalar/parts content、empty text/refusal drop |
+| Media | image object/string、URL-only file、audio |
+| Calls | batching、无 request index、arguments canonicalization |
+| Reasoning history | pending、turn boundary、tool-call fallback |
+| Tool output media | depth 32、8 KiB threshold、parallel flush |
+| Tools | trimmed names、function schema、namespace hash、custom/tool-search精确description、collision |
+| Reasoning config | null/defaults、explicit disable、supportsEffort override、unknown effort、五种 mode |
+| History | 512 eviction、scoped lookup、unique global fallback、ambiguous call ID |
+
+### 14.2 Response differential
+
+按字段来源分别断言：
+
+- 与 LiteLLM 固定提交等值：nonstream envelope/defaults、empty choices、copied fields、
+  all-choice content、first-choice status、message/reasoning/image IDs、annotations、usage、
+  provider fields、managed response ID、argument 10-character slicing和异常传播；
+- 与 cc-switch 固定提交等值：ToolContext derivation、custom input、namespace/tool-search restoration、
+  first-wins ownership、semantic item opening、独立 item state、added-before-done、tool-only无空 message、
+  completed output ownership；
+- 每个 event 的 `sequence_number` 从 1 开始严格单调递增；
+- 不对完整 response/event stream做单一项目的整体深度等值断言。
+
+Golden harness 必须注入 deterministic UUID4 和 clock，并显式固定
+`customLlmProvider`、`StreamContext.modelId`。不比较随机值或运行时墙钟的模糊 pattern；
+每个 expected object 必须完整列出字段。
+
+### 14.3 Cross-direction fixtures
+
+Custom、hashed/dynamic namespace、tool-search 和 collision fixtures 必须覆盖 request→Chat→response
+完整往返。
+
+实现完成必须同时满足：
+
+1. request/input/history 与 cc-switch fixed commit 等值；
+2. nonstream response envelope、message、reasoning、image、usage 与 LiteLLM public response等值；
+3. tool item restoration 与 cc-switch ToolContext等值；
+4. stream response-level fields与 LiteLLM async iterator等值，item lifecycle与 cc-switch等值，
+   所有 events使用第 11.6 节 sequence规则；
+5. 不存在运行时 behavior profile；
+6. 不存在目标仓库 legacy compatibility branch；
+7. 不实现 strict adapter、diagnostics、stable error 或 normalized SSE parser。

--- a/docs/github_copilot_model_listing_apis.md
+++ b/docs/github_copilot_model_listing_apis.md
@@ -12,13 +12,14 @@
 
 1. GitHub Copilot CAPI 账号、token、动态 endpoint、模型获取和模型缓存采用
    cc-switch 的 GitHub Copilot provider 行为。
-2. `GET /v1/models` 的成功 envelope 和 model object 采用 LiteLLM 的
-   OpenAI-compatible Models 行为。
+2. `GET /v1/models` 的默认成功 envelope 和 model object 采用 LiteLLM 的
+   OpenAI-compatible Models 行为；请求存在 `anthropic-version` header 时采用 LiteLLM 的
+   Anthropic-compatible Models 行为。
 3. `GET /api/tags` 的字段结构采用 Ollama 官方协议；CAPI 没有对应值的字段使用
    第 10.2 节明文规定的固定占位值。
 
 发生冲突时，账号、credential、CAPI request、endpoint、transport、解析、过滤和缓存以
-cc-switch 为准；OpenAI `/v1/models` response 以 LiteLLM 为准；Ollama `/api/tags`
+cc-switch 为准；OpenAI/Anthropic `/v1/models` response 以 LiteLLM 为准；Ollama `/api/tags`
 response 以 Ollama 官方结构和第 10 节映射为准。不存在运行时 profile 选项。
 
 当前仓库已有的模型、认证、HTTP helper、CLI 或错误处理代码不是行为来源。若已有
@@ -37,7 +38,8 @@ GET /api/tags
 
 两个接口都列出默认 GitHub Copilot 账号在 CAPI `/models` 中可见且允许显示的模型：
 
-- `/v1/models` 输出 OpenAI Models 格式。
+- `/v1/models` 默认输出 OpenAI Models 格式；存在 `anthropic-version` header 时输出 Anthropic
+  Models 格式。
 - `/api/tags` 输出 Ollama List Models 格式。
 - 两个接口使用同一份 Copilot 模型目录。
 - 不维护第二份静态模型表。
@@ -70,7 +72,7 @@ CopilotCatalogModel {
 }
 ```
 
-该类型只包含 CAPI 模型目录中参与两个公开接口转换的字段。
+该类型只包含 CAPI 模型目录中参与公开模型表示转换的字段。
 
 不把 `version`、`preview`、`capabilities` 或 `supported_endpoints` 加入公开目录
 类型；这些字段不参与本规范的模型枚举。
@@ -97,6 +99,7 @@ getModelInfo(modelId)
        mode?: JsonValue
        max_input_tokens?: JsonValue
        max_output_tokens?: JsonValue
+       supported_endpoints?: JsonValue
      }
      | null
      | throws
@@ -104,7 +107,10 @@ getModelInfo(modelId)
 
 Lookup null 或异常时不添加 metadata fields。`llm_router` 固定为 null。
 
-`mode` 仅在值为 string 时输出。Token-limit coercion：
+`mode` 仅在值为 string 时进入 OpenAI model object 和内部 routing metadata。
+`supported_endpoints` 只进入内部 routing metadata，不在任何公开 model object 中输出；只有值为
+array 时参与 capability 判断，其中非 string 成员不匹配任何 endpoint。其他值按缺失处理。
+Token-limit coercion：
 
 - bool、null、object、array → 省略；
 - integer → 原值；
@@ -371,7 +377,7 @@ GET /v1/models
 查询参数不改变结果。模型目录 endpoint 不接受客户端传入的 GitHub 或 Copilot
 credential。
 
-### 9.2 成功响应
+### 9.2 默认 OpenAI 成功响应
 
 ```http
 Content-Type: application/json; charset=utf-8
@@ -424,6 +430,73 @@ Cache-Control: no-store
 - capabilities；
 - price；
 - 本地配置或账号字段。
+
+### 9.4 Anthropic 成功响应
+
+请求 headers 中只要存在大小写不敏感的 `anthropic-version`，就使用 Anthropic serializer。
+不校验 header value；empty string 或任意版本值同样触发。
+
+该 header 只选择成功 serializer：
+
+- authentication、权限、CAPI fetch、parse 和内部错误仍使用第 11.2 节 `/v1/models` 错误；
+- 不生成 Anthropic error envelope；
+- 不因未知或空版本值返回版本错误。
+
+非空目录：
+
+```json
+{
+  "data": [
+    {
+      "type": "model",
+      "id": "claude-sonnet-4.5",
+      "display_name": "claude-sonnet-4.5",
+      "created_at": "2023-02-28T18:56:42Z",
+      "max_input_tokens": 200000,
+      "max_tokens": 64000
+    }
+  ],
+  "has_more": false,
+  "first_id": "claude-sonnet-4.5",
+  "last_id": "claude-sonnet-4.5"
+}
+```
+
+空目录：
+
+```json
+{
+  "data": [],
+  "has_more": false,
+  "first_id": null,
+  "last_id": null
+}
+```
+
+字段：
+
+| Anthropic 字段 | 来源 |
+| --- | --- |
+| `data[].type` | 固定 `"model"` |
+| `data[].id` | `CopilotCatalogModel.id` |
+| `data[].display_name` | 与 `id` 相同 |
+| `data[].created_at` | `DEFAULT_MODEL_CREATED_AT_TIME` 转 UTC ISO-8601，并以 `Z` 结尾 |
+| `data[].max_input_tokens` | 第 4.3 节 coercion 结果；缺失时 `null` |
+| `data[].max_tokens` | 第 4.3 节 `max_output_tokens` coercion 结果；缺失时 `null` |
+| `has_more` | 固定 `false` |
+| `first_id` | 第一项 ID；空目录为 `null` |
+| `last_id` | 最后一项 ID；空目录为 `null` |
+
+所有字段按当前 catalog 顺序生成。不得：
+
+- 只保留 Anthropic/Claude model；
+- 根据 `vendor` 或 model ID 过滤；
+- 读取 provider display name；
+- 省略 nullable token-limit fields；
+- 实现 cursor、分页或 `has_more:true`。
+
+`GET /models` alias 仍不注册。这是为了保持本项目 versioned route 一致性而做的有意差异；
+Anthropic content negotiation 在 `/v1/models` 完整提供。
 
 ## 10. `GET /api/tags`
 
@@ -526,6 +599,8 @@ Cache-Control: no-store
 - `param` 固定为 `null`。
 - `code` 是最终 HTTP status 的十进制 string。
 
+存在 `anthropic-version` header 不改变该 error status、headers 或 body。
+
 ### 11.3 `/api/tags` 错误
 
 ```json
@@ -575,6 +650,7 @@ HTTP status 与第 11.1 节相同。
 
 ```text
 serializeOpenAIModels(catalog, metadataByModelId, defaultModelCreatedAt)
+serializeAnthropicModels(catalog, metadataByModelId, defaultModelCreatedAt)
 serializeOllamaTags(catalog)
 serializeOpenAIModelsError(status)
 serializeOllamaTagsError()
@@ -598,7 +674,8 @@ Service 在调用 serializer 前完成第 4.3 节 lookup，并传入只读
 - 对两个 route应用 inference authentication middleware；
 - 取得 caller cancellation signal；
 - 调用同一个 Copilot model catalog service；
-- 选择 OpenAI 或 Ollama serializer；
+- `/v1/models` 根据 `anthropic-version` header presence 选择 OpenAI 或 Anthropic serializer；
+- `/api/tags` 选择 Ollama serializer；
 - 设置成功响应 `Content-Type` 与 `Cache-Control`；
 - 设置 HTTP status 和 `Retry-After`；
 - 客户端断开后抑制响应。
@@ -657,11 +734,17 @@ Service 在调用 serializer 前完成第 4.3 节 lookup，并传入只读
 
 - 使用与 inference routes 相同的 inbound authentication middleware。
 - 成功响应固定 `Content-Type: application/json; charset=utf-8` 和 `Cache-Control: no-store`。
-- 非空和空目录与第 9 节深度等值。
+- 无 `anthropic-version` 时，非空和空目录与第 9.2–9.3 节深度等值。
 - 每项至少有 `id`、`object`、`created`、`owned_by`；第 4.3 节有值时追加对应 metadata fields。
 - `created` 使用可由环境覆盖的 `DEFAULT_MODEL_CREATED_AT_TIME`。
 - `owned_by` 固定为 `"openai"`。
 - 错误 envelope、type、param 和 code 与第 11 节一致。
+- 任意值的 `anthropic-version` header（包括 empty string）触发第 9.4 节 Anthropic shape。
+- Anthropic shape 包含同一权限 catalog 的全部 models，包括非 Anthropic model。
+- Anthropic token limits 始终存在，未知时为 `null`。
+- Anthropic `has_more` 固定 false；first/last ID 和空目录行为与第 9.4 节一致。
+- Header 不改变任何错误 response。
+- `/models` 返回 404。
 
 ### 14.6 `/api/tags`
 
@@ -689,6 +772,7 @@ Golden fixtures 必须固定 clock、`DEFAULT_MODEL_CREATED_AT_TIME` 环境值�
 - redirect host/effective-port 变化和五个敏感 header；
 - invalidate/remove/clear 与在途成功写回竞态；
 - LiteLLM unknown-model四字段 object与 known-model metadata fields；
+- Anthropic header presence、empty header、非 Anthropic model、nullable limits 和 empty list；
 - RFC3339Nano `modified_at` 与 empty `parent_model`；
 - 每个错误 status、合法/非法/重复 `Retry-After` 和取消后零 response bytes。
 
@@ -697,9 +781,10 @@ Golden fixtures 必须固定 clock、`DEFAULT_MODEL_CREATED_AT_TIME` 环境值�
 实现完成必须同时满足：
 
 1. CAPI 账号、token、endpoint、模型过滤、顺序和缓存符合 cc-switch 固定提交。
-2. `/v1/models` envelope 和 model object 符合 LiteLLM 固定提交。
+2. `/v1/models` 的 OpenAI 与 Anthropic envelopes/model objects 符合 LiteLLM 固定提交。
 3. `/api/tags` 符合第 10 节 Ollama 映射。
 4. 非 Ollama 行为不依赖目标仓库旧模型、认证、HTTP 或 CLI 实现。
 5. 目标仓库只提供代码落点和依赖注入，不改变协议行为。
-6. 两个公开 endpoint 使用同一个按账号缓存的 Copilot model catalog。
+6. 两个公开 endpoint、以及 `/v1/models` 的两种 serializers，使用同一个按账号缓存的 Copilot
+   model catalog。
 7. 第 14 节全部测试通过。

--- a/docs/github_copilot_model_listing_apis.md
+++ b/docs/github_copilot_model_listing_apis.md
@@ -1,0 +1,705 @@
+# GitHub Copilot 模型列表接口实现规范
+
+> 状态：唯一生产行为规范；不保留目标仓库旧实现兼容分支
+>
+> 固定来源：cc-switch `3217f72596f2d1c0f879f0a05f83803825d9809f`；
+> LiteLLM `ae7e50f096a8722bad14d63b6a0d4634d59bf475`；
+> Ollama `f96e7aa0513b9973a0ccc71be414c2ecb9d65b1a`
+
+## 1. 行为来源与优先级
+
+本规范采用三个明确的行为来源：
+
+1. GitHub Copilot CAPI 账号、token、动态 endpoint、模型获取和模型缓存采用
+   cc-switch 的 GitHub Copilot provider 行为。
+2. `GET /v1/models` 的成功 envelope 和 model object 采用 LiteLLM 的
+   OpenAI-compatible Models 行为。
+3. `GET /api/tags` 的字段结构采用 Ollama 官方协议；CAPI 没有对应值的字段使用
+   第 10.2 节明文规定的固定占位值。
+
+发生冲突时，账号、credential、CAPI request、endpoint、transport、解析、过滤和缓存以
+cc-switch 为准；OpenAI `/v1/models` response 以 LiteLLM 为准；Ollama `/api/tags`
+response 以 Ollama 官方结构和第 10 节映射为准。不存在运行时 profile 选项。
+
+当前仓库已有的模型、认证、HTTP helper、CLI 或错误处理代码不是行为来源。若已有
+实现与本文冲突，必须修改或替换已有实现，不得降低本文要求以保持旧行为。
+
+源码文件名和模块名只表示目标仓库中的代码落点，不具有行为规范效力。
+
+## 2. 范围
+
+实现：
+
+```text
+GET /v1/models
+GET /api/tags
+```
+
+两个接口都列出默认 GitHub Copilot 账号在 CAPI `/models` 中可见且允许显示的模型：
+
+- `/v1/models` 输出 OpenAI Models 格式。
+- `/api/tags` 输出 Ollama List Models 格式。
+- 两个接口使用同一份 Copilot 模型目录。
+- 不维护第二份静态模型表。
+- 不从模型名称推断账号权限。
+- 不执行模型 ID alias、dash/dot 改写或 family fallback。
+- 不按名称合并不同 model item。
+
+## 3. 非目标
+
+本实现不负责：
+
+- 改变当前推理模型；
+- 修改 Copilot 账号；
+- 实现 device-code 登录 UI；
+- 返回价格或推测的 token limits；
+- 判断请求参数是否被模型支持；
+- 代理任意第三方 provider 的 `/v1/models`；
+- 实现 Ollama 模型下载、删除、复制或详情接口。
+
+## 4. 公共模型类型
+
+### 4.1 `CopilotCatalogModel`
+
+```text
+CopilotCatalogModel {
+  id: string
+  name: string
+  vendor: string
+  modelPickerEnabled: boolean
+}
+```
+
+该类型只包含 CAPI 模型目录中参与两个公开接口转换的字段。
+
+不把 `version`、`preview`、`capabilities` 或 `supported_endpoints` 加入公开目录
+类型；这些字段不参与本规范的模型枚举。
+
+### 4.2 `CopilotModelCatalog`
+
+```text
+CopilotModelCatalog {
+  accountId: string
+  models: CopilotCatalogModel[]
+  fetchedAt: string
+}
+```
+
+`fetchedAt` 是成功获得、严格解析、过滤并映射 CAPI 目录后立即读取一次时钟所得的
+UTC instant，序列化使用 Go `time.Time` 等价的 RFC3339Nano。实现必须在写入 cache 前读取一次时钟，同一 catalog 的全部
+`modified_at` 使用该值。它只用于 `/api/tags` 的 `modified_at` 占位值。
+
+### 4.3 LiteLLM model metadata
+
+```text
+getModelInfo(modelId)
+  -> {
+       mode?: JsonValue
+       max_input_tokens?: JsonValue
+       max_output_tokens?: JsonValue
+     }
+     | null
+     | throws
+```
+
+Lookup null 或异常时不添加 metadata fields。`llm_router` 固定为 null。
+
+`mode` 仅在值为 string 时输出。Token-limit coercion：
+
+- bool、null、object、array → 省略；
+- integer → 原值；
+- float → Python `int(value)`；转换异常时省略；
+- string → Python `int(value)`；转换异常时省略。
+
+## 5. Copilot credential provider
+
+模型目录实现依赖以下抽象接口，不依赖目标仓库当前如何保存 token：
+
+```text
+CopilotCredentialProvider {
+  resolveDefaultAccountId()
+    -> Promise<string | null>
+
+  getValidTokenForAccount(accountId)
+    -> Promise<string>
+
+  getApiEndpointForAccount(accountId)
+    -> Promise<string>
+}
+```
+
+### 5.1 默认账号
+
+- 两个公开 endpoint 都调用 `resolveDefaultAccountId()`。
+- 没有默认账号时返回认证错误。
+- 已保存 default account ID 且该账号仍存在时使用它；否则选择 `authenticated_at` 最大的账号，
+  时间相同时选择字典序最小的稳定 account ID；
+- 一个 HTTP 请求只能绑定一个 account ID。
+- 请求执行期间默认账号变化不得改变该请求已绑定的 account ID。
+
+### 5.2 有效 token
+
+`getValidTokenForAccount(accountId)` 负责：
+
+- github.com 账号使用有效 Copilot session token；
+- GHES 账号直接使用已保存的 GitHub OAuth token，不执行 Copilot token exchange；
+- Copilot token 缺失，或 `expires_at - now < 60` 秒时，以该账号已有 GitHub credential
+  刷新；差值恰好为 60 秒时仍视为有效；
+- GHES 账号按 provider 规则使用相应 GitHub credential；
+- 同一账号的并发 token 刷新使用互斥锁；
+- 获得锁后必须再次检查是否已有其他请求完成刷新；
+- 不存在账号、GitHub credential 无效或 token endpoint 明确返回 401 时抛出认证错误；
+- token 刷新的 network/connect/TLS 错误、timeout、非 401 HTTP 错误和成功响应解析错误
+  必须保留为独立错误类别，不得改写为认证错误。
+
+模型目录模块不得读取固定 token 文件，不得自行启动 device-code flow。
+
+### 5.3 动态 API endpoint
+
+`getApiEndpointForAccount(accountId)` 负责：
+
+1. 按账号查询已缓存 endpoint。
+2. 缓存未命中时，使用该账号的 GitHub credential 请求
+   `/copilot_internal/user`。
+3. 响应存在 `endpoints.api` 时使用该值。
+4. 动态查询失败或响应缺少 `endpoints.api` 时，github.com 账号回退到
+   `https://api.githubcopilot.com`。
+5. 企业账号回退到 `https://copilot-api.{normalizedGitHubDomain}`；保留规范化
+   domain 中的显式 port，且不进行额外 DNS 探测。
+6. 查询成功时按账号缓存动态 endpoint；成功响应缺少 `endpoints.api` 时缓存对应 fallback。
+7. 查询因 network、HTTP 或解析错误而使用 fallback 时不缓存 fallback，下次调用重新查询。
+8. 同一账号的并发 endpoint discovery 使用互斥锁并在锁内二次检查。
+
+模型目录模块不得根据推理模型名称选择 endpoint。
+
+`/copilot_internal/user` 必须先完整反序列化：
+
+```text
+CopilotUsageResponse {
+  copilot_plan: string
+  quota_reset_date: string
+  quota_snapshots: {
+    chat: QuotaDetail
+    completions: QuotaDetail
+    premium_interactions: QuotaDetail
+  }
+  endpoints?: {
+    api: string
+    telemetry?: string
+  } | null
+}
+
+QuotaDetail {
+  entitlement: integer
+  remaining: integer
+  percent_remaining: number
+  unlimited: boolean
+}
+```
+
+只有整个 DTO 合法才算查询成功。`endpoints` missing/null 时缓存 fallback；`endpoints:{}`、
+缺任一其他 required 字段或字段类型错误均是解析失败，使用但不缓存 fallback。
+
+## 6. CAPI Models 请求
+
+### 6.1 URL
+
+```text
+modelsUrl = apiEndpoint + "/models"
+```
+
+要求：
+
+- 直接在 credential provider 返回的 endpoint 后追加字面量 `/models`。
+- 模型目录层不解析、不清理、不补全 endpoint。
+- Endpoint 的规范化、scheme、host、port、path、query、fragment 和尾 `/` 均由
+  credential provider 负责。
+- 构造后的 URL 无法由 HTTP client 接受时按 network/configuration error 处理。
+
+示例：
+
+```text
+https://api.githubcopilot.com
+  -> https://api.githubcopilot.com/models
+
+https://copilot.example.com/capi
+  -> https://copilot.example.com/capi/models
+```
+
+### 6.2 Headers
+
+```http
+GET {modelsUrl}
+Authorization: Bearer <provider token>
+Content-Type: application/json
+copilot-integration-id: vscode-chat
+editor-version: vscode/1.110.1
+editor-plugin-version: copilot-chat/0.38.2
+user-agent: GitHubCopilotChat/0.38.2
+x-github-api-version: 2025-10-01
+```
+
+不得接受入站请求覆盖这些 headers。
+
+### 6.3 Transport
+
+- 不发送请求 body。
+- Connect timeout 为 30 秒。
+- 整个请求 timeout 为 600 秒。
+- 调用方取消时必须取消上游请求。
+- 不实现模型目录层重试。
+- HTTP transport 是否复用连接由共享 client 管理。
+- Transport 不自动解压响应；请求不声明压缩编码。
+- 重定向行为匹配 cc-switch 所用 reqwest 0.12.28 默认策略：最多跟随 10 次；超过上限、
+  `Location` 无效或最终仍为 3xx 时按上游失败处理。Redirect 的 host 或有效 port 改变时删除
+  `Authorization`、`Cookie`、`Cookie2`、`Proxy-Authorization` 和 `WWW-Authenticate`；
+  仅 scheme 改变但 host/effective-port 不变时按 reqwest 固定行为处理。
+
+### 6.4 HTTP 状态
+
+- 任意 2xx 进入 JSON 解析。
+- 非 2xx 视为模型目录获取失败。
+- 429 具有单个合法 `Retry-After` 时必须传递给公开 endpoint。
+- 非 2xx body 不作为公开错误 message。
+- 网络、连接、TLS、timeout 和取消必须与 HTTP 非 2xx 区分。
+
+## 7. CAPI 响应解析
+
+### 7.1 根结构
+
+成功响应必须能严格反序列化为：
+
+```text
+CopilotModelsResponse {
+  data: CopilotModelsResponseItem[]
+}
+
+CopilotModelsResponseItem {
+  id: string
+  name: string
+  vendor: string
+  model_picker_enabled: boolean
+}
+```
+
+规则：
+
+- 根必须是 object。
+- `data` 必须存在且为 array。
+- 每个 item 必须是 object。
+- 四个 item 字段都必须存在且类型正确。
+- 未知根字段和未知 item 字段忽略。
+- 任一 item 缺字段或类型错误时，整个响应解析失败。
+- string 原值保留，不 trim、不截断、不 fallback。
+- 不添加默认 `name` 或 `vendor`。
+
+### 7.2 过滤和顺序
+
+解析成功后：
+
+1. 只保留 `model_picker_enabled === true` 的 item。
+2. 映射为 `CopilotCatalogModel`。
+3. 保持上游原始相对顺序。
+4. 不排序。
+5. 不去重。
+6. 不按 `name` 或 `version` 合并。
+
+合法空 `data` 或过滤后的空列表都是成功结果。
+
+## 8. 模型目录缓存
+
+### 8.1 Cache key
+
+缓存 key 是稳定 account ID：
+
+```text
+Map<accountId, CopilotModelCatalog>
+Map<accountId, uint64> generation
+```
+
+不同账号不得共享目录。
+
+### 8.2 生命周期
+
+- Cache 命中时直接返回该账号目录，不请求 CAPI。
+- Cache 没有 TTL。
+- 合法空目录也必须缓存。
+- 获取失败不得写入 cache。
+- 删除账号或退出全部账号时必须删除相应目录。
+- 进程退出时 cache 自然销毁。
+
+### 8.3 并发 miss
+
+不增加 single-flight：
+
+- 同一账号的多个并发 miss 可以各自请求 CAPI。
+- 每个调用方返回自己成功获取的 catalog。
+- Fetch 开始前捕获当前 account generation。
+- 成功时 generation 未变化才写入 cache；后完成者覆盖先完成者。
+- Generation 已变化时向当前调用方返回该次成功结果，但不写 cache。
+- 一个调用方取消只取消自己的上游请求，不影响其他调用方。
+- 获取失败不得删除另一个并发调用已经写入的有效 cache。
+- `invalidate(accountId)` 删除 entry并递增该账号 generation，不取消在途请求。
+- 删除账号执行对应 `invalidate(accountId)`。
+- `clear()` 删除全部 entries，并递增所有已知账号 generation。
+
+### 8.4 强制失效
+
+模型目录 service 必须提供：
+
+```text
+invalidate(accountId) -> void
+clear() -> void
+```
+
+公开 `/v1/models` 和 `/api/tags` 不提供绕过 cache 的 query 参数。
+
+## 9. `GET /v1/models`
+
+### 9.1 路由
+
+只注册：
+
+```text
+GET /v1/models
+```
+
+该 route 使用与 Chat/Responses inference routes 相同的 inbound authentication middleware。
+
+不要求注册 `/models` alias。
+
+查询参数不改变结果。模型目录 endpoint 不接受客户端传入的 GitHub 或 Copilot
+credential。
+
+### 9.2 成功响应
+
+```http
+Content-Type: application/json; charset=utf-8
+Cache-Control: no-store
+```
+
+```json
+{
+  "data": [
+    {
+      "id": "claude-sonnet-4.5",
+      "object": "model",
+      "created": 1677610602,
+      "owned_by": "openai"
+    }
+  ],
+  "object": "list"
+}
+```
+
+空目录：
+
+```json
+{
+  "data": [],
+  "object": "list"
+}
+```
+
+### 9.3 字段转换
+
+| OpenAI 字段 | 来源 |
+| --- | --- |
+| `data[].id` | `CopilotCatalogModel.id` |
+| `data[].object` | 固定 `"model"` |
+| `data[].created` | `DEFAULT_MODEL_CREATED_AT_TIME` |
+| `data[].owned_by` | 固定 `"openai"` |
+| `data[].mode` | 第 4.3 节返回的 string，存在时 |
+| `data[].max_input_tokens` | 第 4.3 节 coercion 结果，存在时 |
+| `data[].max_output_tokens` | 第 4.3 节 coercion 结果，存在时 |
+| `object` | 固定 `"list"` |
+
+`DEFAULT_MODEL_CREATED_AT_TIME` 在模块初始化时读取同名环境变量并转十进制 integer；缺失时为
+`1677610602`。
+
+不得输出：
+
+- `name`；
+- `model_picker_enabled`；
+- capabilities；
+- price；
+- 本地配置或账号字段。
+
+## 10. `GET /api/tags`
+
+### 10.1 成功响应
+
+该 route 使用与 Chat/Responses inference routes 相同的 inbound authentication middleware。
+
+成功响应设置：
+
+```http
+Content-Type: application/json; charset=utf-8
+Cache-Control: no-store
+```
+
+```json
+{
+  "models": [
+    {
+      "name": "claude-sonnet-4.5",
+      "model": "claude-sonnet-4.5",
+      "modified_at": "2026-08-30T05:00:00Z",
+      "size": 0,
+      "digest": "copilot-claude-sonnet-4.5",
+      "details": {
+        "parent_model": "",
+        "format": "Copilot API",
+        "family": "GitHub Copilot",
+        "families": ["GitHub Copilot"],
+        "parameter_size": "unknown",
+        "quantization_level": "unknown"
+      }
+    }
+  ]
+}
+```
+
+空目录：
+
+```json
+{
+  "models": []
+}
+```
+
+### 10.2 字段转换
+
+| Ollama 字段 | 来源 |
+| --- | --- |
+| `models[].name` | `CopilotCatalogModel.id` |
+| `models[].model` | `CopilotCatalogModel.id` |
+| `models[].modified_at` | `CopilotModelCatalog.fetchedAt` |
+| `models[].size` | 固定 `0` |
+| `models[].digest` | `"copilot-" + id` |
+| `models[].details.parent_model` | 固定 `""` |
+| `models[].details.format` | 固定 `"Copilot API"` |
+| `models[].details.family` | 固定 `"GitHub Copilot"` |
+| `models[].details.families` | 固定 `["GitHub Copilot"]` |
+| `models[].details.parameter_size` | 固定 `"unknown"` |
+| `models[].details.quantization_level` | 固定 `"unknown"` |
+
+## 11. 公开错误协议
+
+### 11.1 状态分类
+
+| 条件 | HTTP status |
+| --- | ---: |
+| 无默认账号、账号不存在、credential 无效或 token endpoint 明确返回 401 | 401 |
+| Token refresh 的任意 reqwest error（含 network/connect/TLS/timeout） | 502 |
+| Token refresh 的其他 HTTP 或解析错误 | 502 |
+| CAPI 401 或 403 | 保留上游 status |
+| CAPI 429 | 429 |
+| CAPI 其他 4xx/5xx | 保留上游 status |
+| CAPI 3xx | 502 |
+| CAPI 任意 reqwest error（含 network、connect、TLS、timeout） | 502 |
+| CAPI 成功 body 无法严格反序列化 | 502 |
+| Credential provider 返回的 endpoint 无法构造合法 request URL | 502 |
+| 未分类内部错误 | 500 |
+
+取消的 HTTP 请求不得写错误响应。
+
+### 11.2 `/v1/models` 错误
+
+```json
+{
+  "error": {
+    "message": "Failed to list GitHub Copilot models",
+    "type": "api_error",
+    "param": null,
+    "code": "502"
+  }
+}
+```
+
+字段：
+
+- `message` 使用固定公开文本，不拼接上游 body。
+- 401/403 的 `type` 为 `authentication_error`。
+- 429 的 `type` 为 `rate_limit_error`。
+- 其他错误的 `type` 为 `api_error`。
+- `param` 固定为 `null`。
+- `code` 是最终 HTTP status 的十进制 string。
+
+### 11.3 `/api/tags` 错误
+
+```json
+{
+  "error": "Failed to list GitHub Copilot models"
+}
+```
+
+HTTP status 与第 11.1 节相同。
+
+### 11.4 Error headers
+
+上游 429 具有单个合法 `Retry-After` 时，两个公开 endpoint 都保留该 header。
+其他响应不生成 `Retry-After`。
+
+错误响应不得包含 token、完整 endpoint、上游 headers 或 body。
+
+## 12. 取消与资源释放
+
+- 每个公开请求具有独立 caller cancellation signal。
+- 等待账号、token 或 endpoint 时发生取消，立即停止该调用方处理。
+- 等待 model fetch 时发生取消，取消该调用方自己的上游 HTTP 请求。
+- 并发 miss 彼此独立，一个调用方取消不影响其他调用方。
+- 连接关闭后不得写响应。
+- 所有 signal listener、timer、response body 和 socket 必须释放。
+
+## 13. 目标代码边界
+
+本节只规定代码放置位置，不是行为来源。
+
+### 13.1 `src/utils/copilot_models_client.js`
+
+负责：
+
+- 调用 `CopilotCredentialProvider`；
+- 构造 CAPI Models URL 和 headers；
+- 发送请求；
+- 严格解析 CAPI 响应；
+- 过滤 `model_picker_enabled`；
+- 按账号缓存目录；
+- 管理 account generation；
+- 目录失效。
+
+### 13.2 `src/utils/model_response_utils.js`
+
+导出纯函数：
+
+```text
+serializeOpenAIModels(catalog, metadataByModelId, defaultModelCreatedAt)
+serializeOllamaTags(catalog)
+serializeOpenAIModelsError(status)
+serializeOllamaTagsError()
+```
+
+Service 在调用 serializer 前完成第 4.3 节 lookup，并传入只读
+`Map<modelId, normalizedMetadata>`。
+
+序列化器不得读取账号、token、网络、cache 或当前时间。
+
+### 13.3 Credential adapter
+
+认证模块必须提供第 5 节接口。其内部存储格式不属于本文协议，不得暴露给模型目录
+模块。
+
+### 13.4 `src/server.js`
+
+负责：
+
+- 注册两个 GET route；
+- 对两个 route应用 inference authentication middleware；
+- 取得 caller cancellation signal；
+- 调用同一个 Copilot model catalog service；
+- 选择 OpenAI 或 Ollama serializer；
+- 设置成功响应 `Content-Type` 与 `Cache-Control`；
+- 设置 HTTP status 和 `Retry-After`；
+- 客户端断开后抑制响应。
+
+现有模型列表实现可以被删除或替换；不要求保留旧返回结构或旧调用链。
+
+## 14. 验收要求
+
+### 14.1 Credential 和 endpoint
+
+- 无默认账号返回 401。
+- Saved default 不存在时，按 `authenticated_at DESC, accountId ASC` 选择账号。
+- GHES 直接返回保存的 GitHub OAuth token。
+- 同一请求绑定的账号不随默认账号变化。
+- Token 刷新按账号加锁并在锁内二次检查。
+- Token 提前刷新阈值精确为 60 秒。
+- Stored default 缺失时按最近认证时间和 account ID 稳定 fallback；GHES 直接使用 OAuth token。
+- Endpoint discovery 按账号加锁并在锁内二次检查。
+- github.com 和企业账号使用第 5.3 节精确定义的动态或 fallback endpoint。
+- Endpoint response 必须完整匹配 `CopilotUsageResponse`；只有 `endpoints` missing/null 缓存 fallback。
+- `endpoints:{}`、quota 字段缺失/错型和 network/HTTP/parse fallback 均不缓存。
+- 模型目录模块不读取认证存储文件。
+
+### 14.2 CAPI request
+
+- URL 由 credential provider 的 endpoint 直接追加 `/models`。
+- Headers 与第 6.2 节完全一致。
+- 请求无 body。
+- Connect timeout 为 30 秒，总 timeout 为 600 秒。
+- 取消会终止该调用方自己的上游请求。
+- 非 2xx 不自动重试。
+- 重定向最多 10 次，host/effective-port 改变时删除第 6.3 节完整敏感 header 集。
+
+### 14.3 CAPI response
+
+- 完整四字段 item 成功解析。
+- 缺少任一字段使整个响应失败。
+- 任一字段类型错误使整个响应失败。
+- 未知字段被忽略。
+- `model_picker_enabled:false` 被过滤。
+- 上游顺序保持。
+- 重复 ID 保持，不去重。
+- 合法空目录被缓存。
+
+### 14.4 Cache
+
+- 不同账号缓存隔离。
+- 同账号并发 miss 可以各自请求 CAPI，后完成的成功结果覆盖 cache。
+- 获取失败不缓存。
+- 删除账号或退出全部账号会使目录失效。
+- Invalidate/delete/clear 后，旧 generation 的在途成功请求不写 cache。
+- Cache 命中不请求 CAPI。
+- 公开 query 参数不能绕过 cache。
+
+### 14.5 `/v1/models`
+
+- 使用与 inference routes 相同的 inbound authentication middleware。
+- 成功响应固定 `Content-Type: application/json; charset=utf-8` 和 `Cache-Control: no-store`。
+- 非空和空目录与第 9 节深度等值。
+- 每项至少有 `id`、`object`、`created`、`owned_by`；第 4.3 节有值时追加对应 metadata fields。
+- `created` 使用可由环境覆盖的 `DEFAULT_MODEL_CREATED_AT_TIME`。
+- `owned_by` 固定为 `"openai"`。
+- 错误 envelope、type、param 和 code 与第 11 节一致。
+
+### 14.6 `/api/tags`
+
+- 成功响应 `Content-Type` 为 `application/json; charset=utf-8`。
+- 使用与 inference routes 相同的 inbound authentication middleware。
+- 成功响应 `Cache-Control` 为 `no-store`。
+- 非空和空目录与第 10 节深度等值。
+- `name` 和 `model` 相同。
+- 同一 catalog 的 `modified_at` 相同。
+- `modified_at` 是 RFC3339Nano；整秒不增加 `.000`。
+- `details.parent_model` 固定为空 string。
+- 不输出禁止字段。
+- 错误只包含 `error` string。
+
+### 14.7 安全和取消
+
+- 日志与响应不包含 credential 或完整上游 body。
+- 一个已取消调用方不影响其他并发 fetch。
+- 连接关闭后不写响应。
+- 所有 timer、listener、body 和 socket 被释放。
+
+Golden fixtures 必须固定 clock、`DEFAULT_MODEL_CREATED_AT_TIME` 环境值和 model metadata，并覆盖：
+
+- 完整 endpoint DTO 与每个 malformed branch；
+- redirect host/effective-port 变化和五个敏感 header；
+- invalidate/remove/clear 与在途成功写回竞态；
+- LiteLLM unknown-model四字段 object与 known-model metadata fields；
+- RFC3339Nano `modified_at` 与 empty `parent_model`；
+- 每个错误 status、合法/非法/重复 `Retry-After` 和取消后零 response bytes。
+
+## 15. 完成标准
+
+实现完成必须同时满足：
+
+1. CAPI 账号、token、endpoint、模型过滤、顺序和缓存符合 cc-switch 固定提交。
+2. `/v1/models` envelope 和 model object 符合 LiteLLM 固定提交。
+3. `/api/tags` 符合第 10 节 Ollama 映射。
+4. 非 Ollama 行为不依赖目标仓库旧模型、认证、HTTP 或 CLI 实现。
+5. 目标仓库只提供代码落点和依赖注入，不改变协议行为。
+6. 两个公开 endpoint 使用同一个按账号缓存的 Copilot model catalog。
+7. 第 14 节全部测试通过。

--- a/docs/litellm/claude_messages_to_chat_completions.md
+++ b/docs/litellm/claude_messages_to_chat_completions.md
@@ -1,0 +1,1264 @@
+# Anthropic Messages API 到 Chat Completions 桥接规格
+
+本文档描述 LiteLLM 如何把 Anthropic Messages API 请求转换为 Chat Completions 请求，以及如何把 Chat Completions 响应重新组装成 Anthropic Messages API 响应
+
+本文档基于提交 `9cebc4738974fd9338e7b960a51025356790a5fa`。它同时记录当前实现、兼容性约束和已知偏差，目标是让另一个 agent 不依赖原实现结构也能重写这条桥接链路
+
+## 1. 结论
+
+仓库中已经有完整实现，核心目录是
+
+```text
+litellm/llms/anthropic/experimental_pass_through/adapters/
+```
+
+| 文件 | 职责 |
+| --- | --- |
+| `handler.py` | 组织请求转换、context management polyfill、调用 `litellm.completion()` 或 `litellm.acompletion()`、选择流式或非流式响应转换 |
+| `transformation.py` | Messages request、Chat Completions request、Chat response、Anthropic response 的字段级转换 |
+| `streaming_iterator.py` | 把 Chat Completions chunks 转成 Anthropic SSE 事件 |
+
+外层路由和预处理位于
+
+| 文件 | 职责 |
+| --- | --- |
+| `../messages/handler.py` | `/v1/messages` 主入口、provider config 选择、MCP、web search、native、Responses 和 Chat 三条路径分派 |
+| `litellm/proxy/anthropic_endpoints/endpoints.py` | Proxy HTTP `POST /v1/messages` 入口和 Anthropic 风格错误输出 |
+| `../context_management/` | `context_management` edits 和 compaction polyfill |
+
+该模块不会自己直接拼接字面上的 `/chat/completions` URL。它调用 LiteLLM 的统一 `completion` 或 `acompletion` 入口，后续 provider adapter 再决定真实上游 URL。对该桥接层而言，上游协议已经是 Chat Completions
+
+## 2. HTTP 入口和三类分派
+
+Proxy HTTP 入口是
+
+```text
+POST /v1/messages
+```
+
+请求进入 `litellm.anthropic_messages`，完成预处理后进入同步分派函数 `anthropic_messages_handler`
+
+分派优先级如下
+
+1. 如果请求包含 LiteLLM MCP gateway tool reference，先展开 MCP 工具
+2. 如果 provider 有原生 `BaseAnthropicMessagesConfig`，使用原生 Messages adapter
+3. 如果 deployment 的 `model_info.supported_endpoints` 包含 `/v1/messages`，使用 OpenAI-like Messages passthrough config
+4. 如果没有原生 config，但满足 Responses API 条件，走 Messages 到 Responses API 桥
+5. 其他没有原生 config 的 provider，走本文档描述的 Messages 到 Chat Completions 桥
+
+```mermaid
+flowchart TD
+    A[POST /v1/messages] --> B[sanitize and hooks]
+    B --> C{MCP gateway reference}
+    C -->|yes| D[expand MCP tools]
+    C -->|no| E[resolve provider and model]
+    D --> E
+    E --> F{native Messages config exists}
+    F -->|yes| G[native Messages adapter]
+    F -->|no| H{deployment declares /v1/messages passthrough}
+    H -->|yes| I[OpenAI-like Messages passthrough]
+    H -->|no| J{should route to Responses API}
+    J -->|yes| K[Messages to Responses bridge]
+    J -->|no| L[Messages to Chat Completions bridge]
+    L --> M[litellm completion or acompletion]
+    M --> N{stream}
+    N -->|no| O[ModelResponse to Anthropic message]
+    N -->|yes| P[Chat chunks to Anthropic SSE]
+```
+
+### 2.1 Responses API 优先条件
+
+OpenAI provider 默认走 Responses API，而不是本文档的 Chat Completions 桥
+
+```text
+custom_llm_provider == "openai"
+and litellm.use_chat_completions_url_for_anthropic_messages is false
+```
+
+设置以下全局开关可以关闭该特殊 Responses 优先级，当前特殊 provider 集合只包含 OpenAI
+
+```python
+litellm.use_chat_completions_url_for_anthropic_messages = True
+```
+
+如果原请求模型在去掉 provider prefix 前被识别为 Responses-only，但去掉 prefix 后被错误识别为 Chat 模型，外层也会保留 Responses API 路由，避免把 Responses-only deployment 错发到 Chat endpoint
+
+### 2.2 OpenAI thinking 的二次 Responses 路由
+
+即使全局开关强制 OpenAI 进入 Chat bridge，只要请求满足以下条件，adapter 仍会把模型名改为 `openai/responses/<model>`，让后续 `litellm.completion` 再转到 Responses API
+
+```text
+provider == openai
+thinking.type == enabled
+model registry 没有明确 supports_reasoning == false
+```
+
+这是为了获得 OpenAI Responses API 的 reasoning 文本，再转换为 Anthropic `thinking` content block
+
+因此“Messages 请求转 Chat Completions”不是所有 provider 和参数组合的统一行为。重写时必须保留 native、Responses 和 Chat 三条清晰边界
+
+## 3. 进入桥接前的请求预处理
+
+主 Messages handler 在 provider 分派前执行以下处理
+
+1. 删除空字符串、全空白 text block 和空 thinking block
+2. 规范化历史中的 `tool_use.id`、`server_tool_use.id` 和 `tool_result.tool_use_id`
+3. 展平无法加密的 web search result history
+4. 根据 Anthropic cache-control hook 注入 cache breakpoints
+5. 执行 custom logger `async_pre_request_hook`
+6. 尝试 web-search-only short circuit
+7. 尝试 Messages interceptors，例如 advisor orchestration
+
+tool ID 规范化要求满足
+
+```text
+^[a-zA-Z0-9_-]+$
+```
+
+Gemini thought signature 后缀先删除，其他非法字符替换为 `_`。结果为空时使用 `tool_use_id`
+
+这些预处理属于端到端接口契约。重写 adapter 时可以把它们留在外层，但不能让不同分派路径绕过
+
+## 4. Handler 调用契约
+
+Chat bridge 的统一入口是
+
+```python
+LiteLLMMessagesToCompletionTransformationHandler.anthropic_messages_handler(
+    max_tokens,
+    messages,
+    model,
+    metadata=None,
+    stop_sequences=None,
+    stream=False,
+    system=None,
+    temperature=None,
+    thinking=None,
+    tool_choice=None,
+    tools=None,
+    top_k=None,
+    top_p=None,
+    output_format=None,
+    _is_async=False,
+    **kwargs,
+)
+```
+
+同步路径调用 `litellm.completion`，异步路径调用 `litellm.acompletion`
+
+处理顺序如下
+
+1. 读取并执行 `context_management`
+2. 得到可能被 edits 修改的 messages 和 system
+3. 调用 `_prepare_completion_kwargs`
+4. 调用 Chat Completions 统一入口
+5. 非流式 `ModelResponse` 转为 `AnthropicMessagesResponse`
+6. 流式 response 包装为 `AnthropicStreamWrapper`
+7. SSE wrapper 输出 bytes
+
+流式 Chat 请求强制加入
+
+```json
+{
+  "stream": true,
+  "stream_options": {
+    "include_usage": true
+  }
+}
+```
+
+这是为了让 Anthropic 最终 `message_delta.usage` 包含完整 token 和 cache usage
+
+## 5. 顶层请求字段转换
+
+### 5.1 字段映射
+
+| Anthropic Messages 输入 | Chat Completions 输出 | 规则 |
+| --- | --- | --- |
+| `model` | `model` | 原值，特殊 OpenAI thinking 情况可能改为 `openai/responses/<model>` |
+| `messages` | `messages` | 使用第 6 节算法 |
+| `system` | `messages` | 转成置顶 system message，使用第 6.7 节算法 |
+| `max_tokens` | `max_tokens` | 原值 |
+| `metadata.user_id` | `user` | 完整字符串 |
+| `metadata.user_id` | `prompt_cache_key` | provider 支持时取前 64 字符 |
+| `stop_sequences` | `stop` | 非空列表原样 |
+| `temperature` | `temperature` | 原值 |
+| `top_k` | `top_k` | 原值，后续 provider 层决定是否支持 |
+| `top_p` | `top_p` | 原值 |
+| `thinking` | `thinking` 或 `reasoning_effort` | 使用第 8 节算法 |
+| `tool_choice` | `tool_choice` | 使用第 7.4 节算法 |
+| `tools` | `tools` 和可选 `web_search_options` | 使用第 7 节算法 |
+| `output_format` | `response_format` | 使用第 9 节算法 |
+| `output_config.format` | `response_format` | `output_format` 不存在时使用 |
+| `output_config.effort` | `reasoning_effort` 或 `output_config` | 取决于目标模型和 provider |
+| `stream` | `stream` 和 `stream_options` | 由 handler 添加 |
+
+转换器明确消费以下 Anthropic-only 字段，不会再以原名复制
+
+```text
+messages
+metadata
+system
+tool_choice
+tools
+thinking
+output_format
+output_config
+stop_sequences
+```
+
+其他 Anthropic request 字段由 `_copy_untranslated_anthropic_params` 原样复制到 completion kwargs。之后 `extra_kwargs` 中不与已转换字段冲突的非空键也会补入
+
+`output_config` 和内部标记 `anthropic_messages` 被禁止在 extra kwargs 合并时重新加入，避免 Chat provider 收到 Anthropic-only 对象
+
+调用方显式提供的 `prompt_cache_key` 最后覆盖从 `metadata.user_id` 派生的值
+
+### 5.2 required 参数
+
+adapter 要求 `model` 和 `messages` 都为 truthy
+
+缺失或空值分别抛出
+
+```text
+ValueError: Bad Request: model is required for Anthropic Messages Request
+ValueError: Bad Request: messages is required for Anthropic Messages Request
+```
+
+`max_tokens` 是 handler 的 required Python 参数，但 adapter 内部没有单独验证其正数范围
+
+### 5.3 metadata
+
+Proxy 外层先用 `AnthropicMetadata` 校验 `metadata`，Anthropic shape 当前只承载 `user_id`
+
+转换规则如下
+
+```json
+{
+  "metadata": {
+    "user_id": "session-123"
+  }
+}
+```
+
+转换为
+
+```json
+{
+  "user": "session-123",
+  "prompt_cache_key": "session-123"
+}
+```
+
+只有目标 provider 的 `get_supported_openai_params` 包含 `prompt_cache_key` 时才派生该字段。`litellm_proxy` 因为后端能力未知，不做派生
+
+`user` 保留完整 user ID，只有 `prompt_cache_key` 截断到 64 字符
+
+Anthropic `metadata` 和 Proxy 内部 `litellm_metadata` 是不同概念。后者包含认证、计费、trace 等字段，并通过 extra kwargs 继续传给 LiteLLM completion
+
+## 6. Anthropic messages 到 Chat messages
+
+### 6.1 顺序规则
+
+输入 messages 按顺序扫描。中途出现的 `role="system"` message 保持原位置
+
+每个 Anthropic user message 最多拆成以下 Chat messages
+
+1. 零个或多个 `role="tool"` messages
+2. 一个字符串 user message
+3. 一个多模态 user message
+
+当前实现会把同一 Anthropic user message 内的所有 tool results 移到文本和图片前面，因此 content block 的精确交错顺序不会保留
+
+每个 Anthropic assistant message转换为一个 Chat assistant message，其中可以同时包含 content、thinking blocks 和 tool calls
+
+### 6.2 user 字符串
+
+```json
+{
+  "role": "user",
+  "content": "hello"
+}
+```
+
+保持相同结构
+
+空字符串不会创建 Chat user message
+
+### 6.3 user text block
+
+```json
+{
+  "type": "text",
+  "text": "hello"
+}
+```
+
+转换为
+
+```json
+{
+  "type": "text",
+  "text": "hello"
+}
+```
+
+同一 user message 的 text、image 和 document blocks 收集为一个 Chat 多模态 user message
+
+如果 block 有 `prompt_cache_breakpoint`，该字段通过共享 helper 保留
+
+`cache_control` 只在目标模型名包含 `anthropic` 或 `claude`，或者模型是 Bedrock ARN 时保留。其他目标删除该字段
+
+### 6.4 image 和 document
+
+Anthropic base64 source
+
+```json
+{
+  "type": "base64",
+  "media_type": "image/png",
+  "data": "<base64>"
+}
+```
+
+转换为 Chat image URL
+
+```json
+{
+  "type": "image_url",
+  "image_url": {
+    "url": "data:image/png;base64,<base64>"
+  }
+}
+```
+
+Anthropic URL source
+
+```json
+{
+  "type": "url",
+  "url": "https://example.com/image.png"
+}
+```
+
+转换为同 URL 的 Chat `image_url`
+
+Anthropic `document` 当前也按 Chat `image_url` content part 处理，包括 PDF data URL
+
+source 类型无效、base64 data 为空或 URL source 缺少有效 URL 时删除该 block
+
+### 6.5 tool_result
+
+Anthropic
+
+```json
+{
+  "type": "tool_result",
+  "tool_use_id": "toolu_1",
+  "content": "sunny"
+}
+```
+
+转换为
+
+```json
+{
+  "role": "tool",
+  "tool_call_id": "toolu_1",
+  "content": "sunny"
+}
+```
+
+tool result content 支持以下形态
+
+| Anthropic content | Chat tool content |
+| --- | --- |
+| 字符串 | 原字符串 |
+| 单个 text block | 降为字符串 |
+| 多个 text blocks | Chat `text` parts 列表，保持顺序 |
+| image block | Chat `image_url` part |
+| document block | Chat `image_url` part |
+| `tool_reference` | `{"type":"tool_reference","tool_name":"..."}` |
+| 无法识别的 block | 删除 |
+| 非字符串且非列表 | 空字符串 |
+| 列表内没有可转换 block | 空字符串 |
+
+并行 tool results 生成多个相邻 Chat tool messages
+
+`is_error` 当前不会映射到 Chat tool message 的显式字段
+
+### 6.6 assistant 文本、thinking 和 tool_use
+
+Anthropic assistant 字符串 content 直接成为 Chat assistant content
+
+assistant content 数组中的 text blocks 有两种输出
+
+1. 任一 text block 保留了 `cache_control` 时，Chat content 使用 text parts 数组
+2. 没有 cache control 时，所有 text 按顺序直接拼接成字符串
+
+assistant `thinking` block 转为
+
+```json
+{
+  "type": "thinking",
+  "thinking": "...",
+  "signature": "...",
+  "cache_control": {}
+}
+```
+
+assistant `redacted_thinking` block 转为
+
+```json
+{
+  "type": "redacted_thinking",
+  "data": "...",
+  "cache_control": {}
+}
+```
+
+这些 blocks 写入 Chat assistant message 的 `thinking_blocks`
+
+所有普通 thinking 文本还会通过 `reasoning_content_from_thinking_blocks` 合并到 Chat message 的 `reasoning_content`
+
+Anthropic `tool_use` 转为 Chat `tool_calls`
+
+```json
+{
+  "id": "<Anthropic tool_use.id>",
+  "type": "function",
+  "function": {
+    "name": "<possibly truncated name>",
+    "arguments": "<JSON serialization of tool_use.input>"
+  }
+}
+```
+
+如果 Anthropic `tool_use.provider_specific_fields.signature` 存在，会写到 Chat function 的 `provider_specific_fields.thought_signature`
+
+assistant message 可以同时携带 text、thinking 和多个 tool calls
+
+### 6.7 system
+
+顶层 `system` 字符串转换为置于所有 messages 之前的 Chat system message
+
+顶层 `system` content block 数组只保留 `type="text"` 的 blocks，并转换为 Chat text parts。cache control 和 prompt cache breakpoint 按前述规则处理
+
+messages 数组内中途出现的 `role="system"` 不会上移，字符串或 text blocks 保持原序
+
+空 system 字符串、空 block 数组、非 text blocks 不生成 message
+
+顶层 system 始终排在中途 system 以及其他 messages 之前
+
+## 7. 工具定义转换
+
+### 7.1 普通 Anthropic function tool
+
+Anthropic
+
+```json
+{
+  "name": "get_weather",
+  "description": "Get weather",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "city": {
+        "type": "string"
+      }
+    }
+  },
+  "strict": true
+}
+```
+
+转换为
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "get_weather",
+    "description": "Get weather",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "city": {
+          "type": "string"
+        }
+      }
+    },
+    "strict": true
+  }
+}
+```
+
+`strict` 放在 function 对象上，不放入 JSON schema
+
+工具缺少 name 或 name 为空时生成
+
+```text
+litellm_unnamed_tool_<zero-based-index>
+```
+
+除以下已映射字段外，其他工具字段合并进 `function.parameters`
+
+```text
+name
+type
+input_schema
+description
+cache_control
+strict
+```
+
+### 7.2 长工具名
+
+OpenAI function name 上限为 64 字符
+
+长度不超过 64 时原样保留。更长时转换为
+
+```text
+<前 55 字符>_<原名 SHA-256 的前 8 个十六进制字符>
+```
+
+请求转换同时生成 `truncated_name -> original_name` mapping
+
+非流式和流式响应中的 tool name 都必须通过该 mapping 恢复
+
+### 7.3 原样保留的工具
+
+以下工具不重写
+
+1. 已经是 OpenAI `{"type":"function","function":{...}}` 形态的工具
+2. 只含一个未知 provider-native key，且 value 是对象的工具
+3. `type` 以 Anthropic hosted tool 前缀开头的工具
+
+已知 hosted tool 前缀包括
+
+```text
+web_search
+bash
+text_editor
+code_execution
+web_fetch
+memory
+tool_search_tool
+```
+
+但 web search 在总转换前会被单独识别，见下一节
+
+### 7.4 web search
+
+如果工具 `type` 以 `web_search` 开头，或 `name=="web_search"`，它不会进入 Chat `tools`
+
+只要存在至少一个 web search tool，Chat request 加入
+
+```json
+{
+  "web_search_options": {}
+}
+```
+
+原 Anthropic web search 的 `max_uses`、`user_location` 等字段不会复制到 `web_search_options`
+
+混合工具列表中，web search 被移除，其他工具继续转换
+
+### 7.5 tool_choice
+
+| Anthropic `tool_choice` | Chat `tool_choice` |
+| --- | --- |
+| `{"type":"any"}` | `"required"` |
+| `{"type":"auto"}` | `"auto"` |
+| `{"type":"none"}` | `"none"` |
+| `{"type":"tool","name":"x"}` | `{"type":"function","function":{"name":"x"}}` |
+| 未知 type | 抛出 `ValueError` |
+
+指定工具名时使用与 tools 定义相同的 64 字符截断算法
+
+Anthropic `disable_parallel_tool_use` 当前不会转换
+
+## 8. thinking 和 reasoning 转换
+
+### 8.1 非 Claude 目标
+
+`thinking.type` 转换如下
+
+| Anthropic thinking | Chat `reasoning_effort` |
+| --- | --- |
+| `{"type":"disabled"}` | `"none"` |
+| `{"type":"enabled","budget_tokens":n}` | 按 budget bucket |
+| `{"type":"adaptive"}` | 默认 `"medium"`，如果 `output_config.effort` 存在则用该值 |
+| 未知或无效 | 不发送 |
+
+默认 budget thresholds 可通过环境变量覆盖
+
+| budget_tokens | effort |
+| --- | --- |
+| `>= 4096` | `high` |
+| `>= 2048` 且 `< 4096` | `medium` |
+| `>= 1024` 且 `< 2048` | `low` |
+| `< 1024` | `minimal` |
+
+如果 thinking 有 `summary`，结果包装为
+
+```json
+{
+  "effort": "<tier>",
+  "summary": "<requested summary>"
+}
+```
+
+如果启用了 `litellm.reasoning_auto_summary` 或环境变量 `LITELLM_REASONING_AUTO_SUMMARY=true`，且调用方未提供 summary，则自动使用 `"detailed"`
+
+`thinking.type=="disabled"` 始终保留 plain string `"none"`，不会包装 summary
+
+### 8.2 Claude 目标
+
+模型名包含 `anthropic` 或 `claude`，或者是 Bedrock ARN 时，原始 `thinking` 对象作为 Chat extension param 保留
+
+Bedrock target 如果 `output_config` 除 `format` 外还有字段，会把剩余部分作为 `output_config` 保留
+
+非 Bedrock Claude target 只有在 provider 明确声明支持 `reasoning_effort` 时才额外发送 adaptive effort tier
+
+budgeted Claude thinking 保留原 `budget_tokens`，不会额外生成 effort tier
+
+### 8.3 effort 能力降级
+
+handler 在可能加 `responses/` 前缀前根据 model registry 规范化 tier
+
+```text
+max -> max -> xhigh -> high
+xhigh -> xhigh -> high
+minimal -> minimal -> low
+```
+
+选择目标声明支持的第一个 tier。能力信息缺失时使用链尾
+
+其他 effort 值不做降级
+
+## 9. Structured Outputs
+
+支持两种 Anthropic 输入位置
+
+```text
+output_format
+output_config.format
+```
+
+两者同时存在时 `output_format` 优先
+
+只接受
+
+```json
+{
+  "type": "json_schema",
+  "schema": {}
+}
+```
+
+转换为
+
+```json
+{
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "structured_output",
+      "schema": {},
+      "strict": true
+    }
+  }
+}
+```
+
+转换前 deep copy schema，不修改调用方对象
+
+为满足 OpenAI strict schema，递归执行以下规范化
+
+1. 每个带 properties 的 object 加入 `additionalProperties:false`
+2. 每个 object 的 `required` 重写为全部 property keys
+3. 递归处理 object properties
+4. 递归处理 array `items`
+5. 递归处理 `anyOf`、`oneOf`、`allOf`
+6. 递归处理 `$defs` 和 `definitions`
+
+非 `json_schema`、缺少 schema 或非对象输入不生成 `response_format`
+
+## 10. context management
+
+Chat bridge 在调用 completion 前支持 Anthropic `context_management` polyfill
+
+高层流程如下
+
+1. 检查历史中客户端已经发送的 `compaction` block
+2. 如果没有计划运行 `compact_20260112` polyfill，先应用客户端 compaction history slicing
+3. 根据 edits 运行 dispatcher
+4. 使用结果中的 messages 和 system 替换原请求
+5. 把 `compaction_block`、`applied_edits` 和 `iterations_usage` 带到响应转换
+
+`additional_drop_params` 包含 `context_management` 时显式禁用 polyfill
+
+普通 `drop_params` 不禁用 polyfill，因为这里把 context management 视为 LiteLLM 支持的功能，而不是未知 provider 参数
+
+同步 handler 通过 `run_async_function` 执行 async polyfill。为避免跨 event loop 使用 proxy router 的 httpx clients，同步路径不会自动取得全局 proxy router
+
+如果没有 context management 且历史中没有 compaction block，同步路径跳过 async bridge
+
+compact-only polyfill 发生非 AnthropicContextManagementError 异常时可降级为 history slicing。包含其他 edit type 时异常提升为 `AnthropicContextManagementError`
+
+## 11. 非流式 Chat response 到 Anthropic response
+
+### 11.1 顶层对象
+
+`translate_openai_response_to_anthropic` 输出
+
+```json
+{
+  "id": "<chat response id>",
+  "type": "message",
+  "role": "assistant",
+  "model": "<chat response model or unknown-model>",
+  "content": [],
+  "stop_reason": "end_turn|max_tokens|tool_use",
+  "stop_sequence": null,
+  "usage": {}
+}
+```
+
+如果 context polyfill 产生可见 edits，额外加入
+
+```json
+{
+  "context_management": {
+    "applied_edits": []
+  }
+}
+```
+
+如果 polyfill 产生 compaction block，该 block 插入 content 数组最前面
+
+### 11.2 finish reason
+
+| Chat `finish_reason` | Anthropic `stop_reason` |
+| --- | --- |
+| `stop` | `end_turn` |
+| `length` | `max_tokens` |
+| `tool_calls` | `tool_use` |
+| 其他 | `end_turn` |
+
+`stop_sequence` 始终为 `null`，当前实现不恢复真实匹配的 stop sequence
+
+总 stop reason 只读取 `choices[0].finish_reason`
+
+### 11.3 content block 顺序
+
+对每个 choice 按以下顺序追加
+
+1. thinking 或 redacted thinking blocks
+2. reasoning_content fallback
+3. text block
+4. 所有 tool use blocks
+
+多个 choices 的 blocks 继续追加到同一个 Anthropic message content 数组
+
+### 11.4 thinking
+
+如果 Chat message 有 `thinking_blocks`
+
+| Chat block | Anthropic block |
+| --- | --- |
+| `thinking` | `{"type":"thinking","thinking":"...","signature":"..."}` |
+| `redacted_thinking` | `{"type":"redacted_thinking","data":"..."}` |
+
+空 thinking block 删除
+
+只有在没有 `thinking_blocks` 时，才把 `message.reasoning_content` 转成
+
+```json
+{
+  "type": "thinking",
+  "thinking": "<reasoning content>",
+  "signature": null
+}
+```
+
+### 11.5 text
+
+`message.content is not None` 时生成一个 Anthropic text block
+
+```json
+{
+  "type": "text",
+  "text": "<message.content>"
+}
+```
+
+adapter 期望最终 Chat ModelResponse 的 content 已经是字符串。它不会在这里把 Chat multimodal assistant parts 展平
+
+空字符串不是 `None`，因此会产生空 text block
+
+### 11.6 tool calls
+
+每个 Chat tool call 转换为
+
+```json
+{
+  "type": "tool_use",
+  "id": "<normalized tool call id>",
+  "name": "<restored original name>",
+  "input": "<parsed JSON arguments>"
+}
+```
+
+工具名先通过长名称 mapping 恢复
+
+arguments 通过共享 `parse_tool_call_arguments` 解析。解析行为由该 helper 负责，adapter 不手写宽松 JSON parser
+
+tool call ID 先删除 Gemini thought-signature suffix，再把非法字符替换为 `_`
+
+如果 tool call 或 function 的 `provider_specific_fields.thought_signature` 存在，Anthropic tool use block 加入
+
+```json
+{
+  "provider_specific_fields": {
+    "signature": "<signature>"
+  }
+}
+```
+
+### 11.7 usage
+
+基础映射如下
+
+| Chat usage | Anthropic usage |
+| --- | --- |
+| `prompt_tokens - cache_read - cache_creation` | `input_tokens`，最小为 0 |
+| `completion_tokens` | `output_tokens` |
+| cache read 值 | `cache_read_input_tokens`，只在大于 0 时输出 |
+| cache creation 值 | `cache_creation_input_tokens`，只在大于 0 时输出 |
+| web search request count | `server_tool_use.web_search_requests`，只在大于 0 时输出 |
+
+cache read 优先级
+
+1. `usage.cache_read_input_tokens`
+2. `usage._cache_read_input_tokens`
+3. `usage.prompt_tokens_details.cached_tokens`
+
+cache creation 优先级
+
+1. `usage.cache_creation_input_tokens`
+2. `usage._cache_creation_input_tokens`
+3. `usage.prompt_tokens_details.cache_creation_tokens`
+4. `usage.prompt_tokens_details.cache_write_tokens`
+
+只接受正整数，或数值为正整数的 float。布尔值、负数、零和小数当作 0
+
+web search usage 优先使用共享 `get_web_search_requests_from_usage`，其次读取 `prompt_tokens_details.web_search_requests`
+
+如果 polyfill 有 `iterations_usage`，最终 usage 加入原 polyfill iterations，再追加本次 message iteration
+
+## 12. 流式转换总览
+
+`AnthropicStreamWrapper` 同时实现同步和异步 iterator。外层分别使用
+
+```python
+anthropic_sse_wrapper()
+async_anthropic_sse_wrapper()
+```
+
+每个 dict event 编码成
+
+```text
+event: <event.type>
+data: <JSON event>
+
+```
+
+标准文本流事件顺序是
+
+```text
+message_start
+content_block_start
+content_block_delta  repeated
+content_block_stop
+message_delta
+message_stop
+```
+
+不同 block type 之间必须先 stop 前一个 block，再 start 新 block
+
+### 12.1 message_start
+
+流的第一个事件固定为
+
+```json
+{
+  "type": "message_start",
+  "message": {
+    "id": "msg_<uuid4>",
+    "type": "message",
+    "role": "assistant",
+    "content": [],
+    "model": "<provider-local model name>",
+    "stop_reason": null,
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0
+    }
+  }
+}
+```
+
+流式 message ID 不复用 Chat stream ID
+
+provider prefix 会从 message_start 的 model 中删除
+
+### 12.2 combined chunk splitter
+
+部分 provider 会在同一个 Chat chunk 中同时返回 content 和 finish reason。Anthropic state machine 假设两者分开，因此 wrapper 先拆成
+
+1. content-only chunk，删除 finish reason 和 usage
+2. finish-only chunk，清空 content、tool calls、reasoning 和 thinking blocks，保留 finish reason 和 usage
+
+单 choice chunk 如果同时带多种 payload，再按 Anthropic block 顺序拆成
+
+```text
+reasoning or thinking
+text
+tool calls
+```
+
+以下情况不按 payload kind 拆分
+
+1. choices 数量不是 1
+2. tool call 只有 argument continuation，没有 function name
+3. 只有一种 payload kind
+
+没有 signature 的 thinking blocks 会规范化为 `reasoning_content`，避免 block start body 和 delta 重复累计 thinking 文本
+
+### 12.3 block start
+
+首个非空 Chat delta 决定 content block type
+
+| Chat delta | Anthropic block start |
+| --- | --- |
+| `content` | `{"type":"text","text":""}` |
+| 新 tool call name 或 ID | `{"type":"tool_use","id":"...","name":"...","input":{}}` |
+| `thinking_blocks` | thinking block |
+| `reasoning_content` | `{"type":"thinking","thinking":"","signature":""}` |
+
+leading role-only、空 content、空 reasoning 和空 thinking chunks 不会打开 content block
+
+同一 tool call 的 argument continuation 不会新建 block。新的 function name 代表新的并行 tool call，会关闭前一个 tool block 并打开下一个
+
+### 12.4 block deltas
+
+| Chat delta | Anthropic delta |
+| --- | --- |
+| `delta.content` | `{"type":"text_delta","text":"..."}` |
+| tool `function.arguments` | `{"type":"input_json_delta","partial_json":"..."}` |
+| thinking text | `{"type":"thinking_delta","thinking":"..."}` |
+| thinking signature | `{"type":"signature_delta","signature":"..."}` |
+
+一个 chunk 内多个 choices 的相同字段会拼接
+
+tool arguments 按该 chunk 内所有 tool calls 顺序拼接到一个 `partial_json`
+
+如果同一 thinking chunk 同时有 signature 和 thinking text，当前转换优先输出 `signature_delta`
+
+空 delta 不发送。这样可以避免在 thinking block 内误发空 `text_delta`
+
+### 12.5 block 切换
+
+发现 payload type 与当前 block type 不同时排队
+
+```text
+content_block_stop for previous index
+content_block_start for new index
+triggering content_block_delta if non-empty
+```
+
+新 block index 自增
+
+触发切换的 chunk 必须在 start 后重新发送 delta，否则新 block 的第一个 token 或首段 tool arguments 会丢失
+
+### 12.6 finish reason 和 usage 合并
+
+finish chunk 转为
+
+```json
+{
+  "type": "message_delta",
+  "delta": {
+    "stop_reason": "end_turn|max_tokens|tool_use"
+  },
+  "usage": {}
+}
+```
+
+Chat Completions 的 `include_usage` 通常产生一个后续 choices 为空的 usage-only chunk
+
+wrapper 会暂存带 stop reason 的 `message_delta`。如果后续收到 usage-only chunk，把 usage 合并后再发送，保证
+
+```text
+content_block_stop
+message_delta with final usage
+message_stop
+```
+
+如果 stream 结束仍未收到独立 usage chunk，暂存的 message delta 使用已有 usage 或零值后发送
+
+一旦 final usage message delta 已发送，后续 provider chunks 删除，避免 Anthropic SSE 在终止事件后继续出现 content
+
+### 12.7 compaction streaming
+
+polyfill 产生 compaction block 时，在普通 content 前发送独立 block 生命周期
+
+```text
+content_block_start
+  content_block = {"type":"compaction","content":""}
+content_block_delta
+  delta = {"type":"compaction_delta","content":"<summary>"}
+content_block_stop
+```
+
+compaction 使用当前 index，结束后 index 自增
+
+`context_management.applied_edits` 附在最终 `message_delta`
+
+如果有 polyfill `iterations_usage`，最终 usage 加入 iterations。本次 message 只有在 input 或 output tokens 大于 0 时才追加 message iteration
+
+### 12.8 流结束
+
+正常流最终只发送一次 `message_stop`
+
+如果 provider 发送 choices 为空但没有 usage，chunk 跳过
+
+同步 iterator 的任意非 StopIteration 异常会记录日志并转换成 StopIteration。异步 iterator 没有同等的通用吞错分支
+
+## 13. 错误转换
+
+Proxy `/v1/messages` 对 `AnthropicContextManagementError` 使用 Anthropic error body，并保留对应 HTTP status
+
+其他 adapter 或 provider 异常最终进入 LiteLLM exception mapping，再由 Proxy 包装为 `ProxyException`
+
+重写应保留以下显式错误边界
+
+| 条件 | 当前行为 |
+| --- | --- |
+| model 缺失或空 | `ValueError` |
+| messages 缺失或空 | `ValueError` |
+| 未知 tool_choice type | `ValueError` |
+| request translator 返回 `None` | `ValueError` |
+| streaming translator 返回 `None` | `ValueError` |
+| non-stream translator 返回 `None` | `ValueError` |
+| context management schema 或 edit 错误 | `AnthropicContextManagementError` |
+| provider completion 异常 | 传播到 LiteLLM exception mapping |
+
+## 14. 重写必须保持的兼容性不变量
+
+以下是规范性要求，不要求保留当前类名或文件结构
+
+1. provider 有原生 Messages config 时不得绕到 Chat bridge
+2. deployment 显式声明 `/v1/messages` passthrough 时不得转换请求 shape
+3. OpenAI 默认 Responses 路由和强制 Chat 开关必须有清晰、可测试的优先级
+4. system、mid-turn system、user、assistant 和 tool result 的相对 turn 顺序必须可预测
+5. tool use ID 和 tool result ID 必须使用完全相同的规范化算法
+6. assistant message 必须能同时携带 text、thinking 和 parallel tool calls
+7. tool result 的 text、image、document 和 tool reference 内容不得丢失
+8. 长工具名必须确定性截断，并在非流式和流式响应中恢复
+9. cache control 只能发送给确定支持 Anthropic cache semantics 的目标
+10. `metadata.user_id` 映射到 `user`，派生 cache key 时必须遵守目标能力和长度上限
+11. thinking 必须根据目标模型和 provider capability选择 `thinking`、`output_config` 或 `reasoning_effort`
+12. structured output schema 必须 deep copy 并递归满足 OpenAI strict schema
+13. Chat finish reason 必须稳定映射到 Anthropic stop reason
+14. cache read 和 cache creation tokens 必须从 input token count 中扣除，且不能产生负数
+15. 流式每个 content block 必须严格遵守 start、delta、stop 生命周期
+16. payload type 切换时不能丢失触发切换的第一个 delta
+17. final usage 必须位于最后 content block stop 之后、message stop 之前
+18. choices 为空的 usage chunk 必须合并，而不是结束或破坏 stream
+19. context management 的 edits、compaction block 和 iteration usage 必须同时支持 sync 和 async
+20. SSE 必须同时提供正确的 `event:` 和 `data:` 行
+
+## 15. 当前实现中不应盲目复制的偏差
+
+### 15.1 user message 内 block 重排
+
+一个 Anthropic user message 同时含 tool result 和 text 或 image 时，adapter 会先输出全部 Chat tool messages，再输出 user content
+
+这可能改变原 content block 的精确顺序。重写应显式定义允许的 Anthropic block ordering，并尽量保持原始语义顺序
+
+### 15.2 document 降级为 image_url
+
+普通 user document 和 tool result document 都使用 Chat `image_url` shape
+
+目标 Chat provider 如果有原生 file 或 document part，新的实现应由 capability mapper 选择更准确的 shape，而不是统一伪装成 image
+
+### 15.3 web search 配置丢失
+
+Anthropic web search 只触发空对象 `web_search_options={}`，原 `max_uses`、`user_location`、`allowed_callers` 等字段不保留
+
+重写应定义可映射字段和无法映射字段的错误或 warning 行为
+
+### 15.4 tool result `is_error`
+
+`is_error` 在 Anthropic 到 Chat 转换中丢失
+
+如果 provider 支持 tool error status，应保留。如果不支持，至少应通过结构化 metadata 或清晰降级规则表达
+
+### 15.5 stop sequence
+
+响应 `stop_sequence` 固定为 `null`，即使 Chat provider 因具体 stop string 结束
+
+重写应在上游能够提供匹配 stop sequence 时恢复它
+
+### 15.6 多 choices 合并
+
+所有 Chat choices 被合并进一个 Anthropic content 数组，但顶层 stop reason只看第一个 choice
+
+Anthropic Messages 没有 `n` choices 对等结构。重写应在请求侧禁止 `n>1`，或定义确定性选择策略，不应静默拼接独立候选答案
+
+### 15.7 空 text block
+
+非流式 Chat `message.content==""` 会生成空 Anthropic text block。外层预处理下一轮历史时又会删除该 block
+
+重写应在响应生成阶段直接避免无意义的空 text block
+
+### 15.8 stream ID 不一致
+
+非流式 response 使用 Chat response ID，流式 `message_start.message.id` 使用新的随机 `msg_<uuid>`
+
+重写应为同一调用定义统一、稳定且 Anthropic-compatible 的 ID 策略
+
+### 15.9 thinking signature 和 delta 优先级
+
+一个 streaming chunk 同时包含 thinking text 和 signature 时，delta translator 优先 signature，可能依赖 block start 中已经带有完整 thinking snapshot
+
+重写应把 snapshot 与 incremental delta 区分清楚，确保每段 thinking 文本恰好发送一次，signature 也恰好发送一次
+
+### 15.10 同步 stream 吞错
+
+同步 `AnthropicStreamWrapper.__next__` 捕获所有异常、记录日志并结束迭代，客户端可能把失败误认为正常 EOF
+
+重写应把 provider 和转换错误映射成 Anthropic SSE `error` event 或向外抛出，不应 success-shaped stop
+
+### 15.11 container 参数传播
+
+外层 `anthropic_messages_handler` 接收 named `container`，但进入无原生 config 的 `_shared_kwargs` 时没有显式加入，因此 Chat bridge 不一定收到该字段
+
+重写应从一个完整、typed 的规范化 request 对象分派，避免 named 参数和 `kwargs` 分裂造成字段丢失
+
+### 15.12 raw extra 参数
+
+除 translatable list 外的 Anthropic 字段会原样复制到 Chat completion kwargs。新增 Anthropic-only 字段如果忘记加入排除集合，可能泄漏到严格 Chat provider 并造成 400
+
+重写应使用 allowlist schema，而不是默认复制所有未知字段
+
+## 16. 推荐的重写边界
+
+建议把 I/O 和纯转换拆开
+
+```text
+normalize_messages_request(raw_request) -> NormalizedMessagesRequest | MessagesError
+select_messages_transport(request, deployment_capabilities) -> Native | Responses | Chat
+anthropic_messages_to_chat_messages(messages, target_capabilities) -> tuple[ChatMessage, ...] | ConversionError
+anthropic_tools_to_chat_tools(tools, target_capabilities) -> ToolConversion | ConversionError
+anthropic_options_to_chat_options(request, target_capabilities) -> ChatOptions | ConversionError
+chat_response_to_anthropic(response, conversion_context) -> AnthropicMessage | ConversionError
+chat_chunk_to_anthropic_events(state, chunk) -> StreamTransition | ConversionError
+apply_context_edits(request, context_services) -> EditedRequest | ContextError
+```
+
+`ToolConversion` 至少保存
+
+```text
+translated tools
+web search options
+truncated name to original name mapping
+tool ID normalization policy
+warnings for lossy fields
+```
+
+`ConversionContext` 至少保存原模型、provider-local 模型、工具名 mapping、请求 stop sequences、context management result 和 ID strategy
+
+`StreamTransition` 应返回新 state 和零个或多个事件。这样 combined chunk、block transition 和 usage-only chunk 都能在纯函数中确定性测试
+
+## 17. 最小验收测试矩阵
+
+| 类别 | 用例 |
+| --- | --- |
+| 路由 | native Messages config 优先 |
+| 路由 | deployment `/v1/messages` passthrough 优先 |
+| 路由 | 无 native config 的普通 provider 走 Chat |
+| 路由 | OpenAI 默认走 Responses |
+| 路由 | 全局开关强制 OpenAI Chat |
+| 路由 | OpenAI enabled thinking 二次转 Responses |
+| 预处理 | 空 text 和 thinking blocks 删除 |
+| 预处理 | tool use 和 result ID 同步规范化 |
+| messages | user 字符串、text blocks、image、document |
+| messages | assistant text、thinking、redacted thinking、parallel tools |
+| messages | mid-turn system 保持位置 |
+| tool result | string、多个 text、image、document、tool reference |
+| tool result | malformed content 产生空结果而不丢 tool turn |
+| tools | 普通 schema、strict、cache control、额外字段 |
+| tools | 空 name 生成确定性后备名 |
+| tools | 64 字符边界、长名称 hash、collision avoidance、响应恢复 |
+| tools | OpenAI function 和 provider-native tool 原样 |
+| tools | hosted tools 和 web search 分离 |
+| tool choice | any、auto、none、named tool、未知 type |
+| metadata | user、64 字符 cache key、显式 cache key 覆盖 |
+| thinking | disabled、budget buckets、adaptive effort、summary |
+| thinking | Claude、Bedrock ARN、非 Claude provider capability 分支 |
+| structured output | nested object、array、union、defs、原对象不修改 |
+| 非流式 | text、thinking、redacted thinking、text plus tools |
+| 非流式 | finish reason 和 stop reason 全矩阵 |
+| 非流式 | tool ID 规范化和 thought signature |
+| usage | 无 cache、cache read、cache create、private aliases |
+| usage | integral float 接受，bool、fractional、negative 拒绝 |
+| usage | web search server tool count |
+| streaming | 文本完整事件顺序 |
+| streaming | thinking、signature、text、tool 多 block 切换 |
+| streaming | combined content plus finish chunk |
+| streaming | payload-kind combined chunk |
+| streaming | bundled tool arguments 首 delta 不丢失 |
+| streaming | parallel tools 每个独立 block |
+| streaming | choices 为空的 final usage chunk |
+| streaming | leading empty chunks 不打开虚假 block |
+| streaming | message delta 在 message stop 前且包含 usage |
+| context | compaction block、applied edits、iterations usage |
+| 同步性 | sync 和 async 请求、响应、SSE 顺序等价 |
+| 错误 | provider stream 异常不能伪装正常结束 |
+
+现有主要回归测试位于
+
+```text
+tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/
+tests/test_litellm/llms/anthropic/experimental_pass_through/messages/
+tests/test_litellm/llms/anthropic/experimental_pass_through/context_management/
+tests/e2e/llm_translation/test_messages_e2e.py
+```
+
+## 18. 关键源码索引
+
+| 行为 | 源码 |
+| --- | --- |
+| 主分派 | `../messages/handler.py::anthropic_messages_handler` |
+| Responses 与 Chat 路由选择 | `../messages/handler.py::_should_route_to_responses_api` |
+| Chat bridge handler | `handler.py::LiteLLMMessagesToCompletionTransformationHandler` |
+| completion kwargs 组装 | `handler.py::_prepare_completion_kwargs` |
+| 总请求转换 | `transformation.py::translate_anthropic_to_openai` |
+| messages 转换 | `transformation.py::translate_anthropic_messages_to_openai` |
+| tools 转换 | `transformation.py::translate_anthropic_tools_to_openai` |
+| thinking 转换 | `transformation.py::_translate_thinking_to_openai` |
+| structured output | `transformation.py::translate_anthropic_output_format_to_openai` |
+| 非流式总响应转换 | `transformation.py::translate_openai_response_to_anthropic` |
+| response content blocks | `transformation.py::_translate_openai_content_to_anthropic` |
+| usage 转换 | `transformation.py::_translate_openai_usage_to_anthropic_usage_delta` |
+| 单 chunk delta 转换 | `transformation.py::translate_streaming_openai_response_to_anthropic` |
+| streaming state machine | `streaming_iterator.py::AnthropicStreamWrapper` |
+| combined chunk 拆分 | `streaming_iterator.py::_CombinedChunkSplitter` |
+| context management | `../context_management/` |
+| Proxy HTTP 入口 | `litellm/proxy/anthropic_endpoints/endpoints.py::anthropic_response` |

--- a/docs/litellm/codex_response_to_chat_completions.md
+++ b/docs/litellm/codex_response_to_chat_completions.md
@@ -1,0 +1,1108 @@
+# Responses API 到 Chat Completions 桥接规格
+
+本文档描述 LiteLLM 如何把 OpenAI Responses API 请求转换为 Chat Completions 请求，以及如何把 Chat Completions 响应重新组装成 Responses API 响应
+
+本文档基于提交 `ae7e50f096a8722bad14d63b6a0d4634d59bf475`。它同时记录当前实现、兼容性约束和已知偏差，目标是让另一个 agent 不依赖原实现结构也能重写此模块
+
+## 1. 结论
+
+仓库中已经有完整实现，核心目录是 `litellm/responses/litellm_completion_transformation/`
+
+| 文件 | 职责 |
+| --- | --- |
+| `handler.py` | 组织 Responses 请求转换、调用 `litellm.completion()` 或 `litellm.acompletion()`、选择非流式或流式响应转换 |
+| `transformation.py` | 请求字段、输入消息、工具、非流式响应、usage 的双向转换 |
+| `streaming_iterator.py` | 把 Chat Completions chunk 转换为 Responses API 事件流 |
+| `session_handler.py` | 使用 `previous_response_id` 从 spend logs 和冷存储恢复 Chat Completions 消息历史 |
+| `custom_tools.py` | 在 Responses `custom` 工具和 Chat Completions `function` 工具之间转换 |
+
+这个模块不会自己直接发送 HTTP 请求到字面上的 `/chat/completions` URL。它调用 LiteLLM 的统一 `completion` 或 `acompletion` 入口，后续 provider adapter 再决定真实上游 URL。对调用方而言，上游协议已经是 Chat Completions
+
+## 2. HTTP 入口和启用条件
+
+Proxy 接受以下等价入口，它们最终进入 `litellm.aresponses`
+
+```text
+POST /v1/responses
+POST /responses
+POST /openai/v1/responses
+```
+
+路由入口位于 `litellm/proxy/response_api_endpoints/endpoints.py`，核心分派位于 `litellm/responses/main.py`
+
+桥接在以下任一条件成立时启用
+
+1. `ProviderConfigManager.get_provider_responses_api_config()` 返回 `None`，说明 provider 没有原生 Responses API adapter
+2. 调用参数 `use_chat_completions_api` 为 truthy
+3. 模型名使用 `openai/chat_completions/<model>`，该前缀会被规范化为 `openai/<model>`，同时强制启用桥接
+
+如果 provider 有原生 Responses API config，且调用方没有强制桥接，则直接使用 provider 的 Responses API handler
+
+MCP gateway 和 emulated file search 的分派发生在普通桥接判断之前，因此这两个功能可能先接管请求。file search 内部再次调用 Responses API 时会继续传递 `use_chat_completions_api=True`
+
+```mermaid
+flowchart TD
+    A[POST /v1/responses] --> B[Proxy pre-call processing]
+    B --> C[litellm.aresponses]
+    C --> D{MCP gateway}
+    D -->|yes| E[MCP pipeline]
+    D -->|no| F{emulated file_search}
+    F -->|yes| G[file_search pipeline]
+    F -->|no| H[resolve provider Responses config]
+    H --> I{config is None or bridge forced}
+    I -->|no| J[native Responses API adapter]
+    I -->|yes| K[Responses request to Chat request]
+    K --> L[litellm.acompletion]
+    L --> M{ModelResponse or stream}
+    M -->|ModelResponse| N[Chat response to Responses response]
+    M -->|CustomStreamWrapper| O[Chat chunks to Responses events]
+```
+
+## 3. Handler 调用契约
+
+入口方法是
+
+```python
+LiteLLMCompletionTransformationHandler.response_api_handler(
+    model,
+    input,
+    responses_api_request,
+    custom_llm_provider=None,
+    _is_async=False,
+    stream=None,
+    extra_headers=None,
+    **kwargs,
+)
+```
+
+处理顺序如下
+
+1. 调用 `transform_responses_api_request_to_chat_completion_request`
+2. 以 `kwargs` 为基础，再覆盖转换后的 Chat Completions 字段
+3. 强制加入 `_skip_responses_api_bridge=True`
+4. 同步路径调用 `litellm.completion`，异步路径调用 `litellm.acompletion`
+5. `ModelResponse` 进入非流式转换
+6. `CustomStreamWrapper` 包装为 `LiteLLMCompletionStreamingIterator`
+7. 其他返回类型抛出 `ValueError`
+
+`_skip_responses_api_bridge=True` 是递归保护。某些模型在 Chat Completions 入口会因为 model cost map 的 `mode="responses"` 再被转到 Responses API，如果没有该标记会形成 Responses 到 Chat 再回 Responses 的无限递归
+
+异步路径在调用 `acompletion` 前处理 `previous_response_id`，同步路径当前没有对应的会话恢复步骤
+
+## 4. 顶层请求字段转换
+
+### 4.1 字段映射
+
+`transform_responses_api_request_to_chat_completion_request` 生成以下 Chat Completions 参数
+
+| Responses API 输入 | Chat Completions 输出 | 规则 |
+| --- | --- | --- |
+| `model` | `model` | 原值 |
+| `input` | `messages` | 使用第 5 节算法 |
+| `instructions` | `messages[0]` | 非空时插入 `{"role":"system","content":instructions}` |
+| `max_output_tokens` | `max_tokens` | 原值 |
+| `parallel_tool_calls` | `parallel_tool_calls` | 原值 |
+| `temperature` | `temperature` | 原值 |
+| `top_p` | `top_p` | 原值 |
+| `user` | `user` | 原值 |
+| `stream` | `stream` | handler 的显式 `stream` 参数 |
+| `tools` | `tools` | 使用第 6 节算法 |
+| `tools` 中的 web search | `web_search_options` | 从工具定义派生，不保留在 `tools` 中 |
+| `tool_choice` | `tool_choice` | 使用第 6.5 节算法 |
+| `text.format` | `response_format` | 使用第 4.2 节算法 |
+| `reasoning` | `reasoning_effort` | 使用第 4.3 节算法 |
+| `context_management` | `context_management` | 原值 |
+| `custom_llm_provider` | `custom_llm_provider` | handler 参数 |
+| `extra_headers` | `extra_headers` | handler 参数 |
+| `metadata` | `metadata` | 当前代码读取 `kwargs["metadata"]`，不是 `responses_api_request["metadata"]` |
+| `service_tier` | `service_tier` | 当前代码读取 `kwargs["service_tier"]` |
+
+所有值为 `None` 的键在返回前删除
+
+如果转换后 `tools` 为空，则同时删除 `tools` 和 `tool_choice`，避免 Chat Completions provider 拒绝没有工具定义的 `tool_choice`
+
+流式请求额外加入
+
+```json
+{
+  "stream_options": {
+    "include_usage": true
+  }
+}
+```
+
+这是为了保证最终 `response.completed` 能携带 usage。相同值还会写入传入的 LiteLLM logging object
+
+`extra_body`、`timeout`、`allowed_openai_params` 以及其他 LiteLLM 参数不是由转换函数创建，而是 handler 合并 `kwargs` 时继续传入 `completion` 或 `acompletion`
+
+### 4.2 `text.format` 到 `response_format`
+
+| Responses `text.format.type` | Chat `response_format` |
+| --- | --- |
+| `json_schema` | `{"type":"json_schema","json_schema":{"name":name 或 "response_schema","schema":schema 或 {},"strict":strict 或 false}}` |
+| `json_object` | `{"type":"json_object"}` |
+| `text` | 不发送 `response_format` |
+| 缺失或未知 | 不发送 `response_format` |
+
+### 4.3 `reasoning` 到 `reasoning_effort`
+
+| `reasoning` 值 | `reasoning_effort` |
+| --- | --- |
+| 字符串 | 原字符串 |
+| 包含 `summary` 的对象 | 保留完整对象，包括 `effort` 和 `summary` |
+| 仅包含 `effort` 的对象 | 只传 `effort` 字符串 |
+| 其他非空对象 | 原对象 |
+| 空值 | 不发送 |
+
+### 4.4 当前不会由核心转换器映射的 Responses 字段
+
+以下字段可能在更外层被消费，但核心 Responses 到 Chat 转换器不会把它们转换为 Chat Completions 参数
+
+| 字段 | 当前结果 |
+| --- | --- |
+| `include` | 不进入 Chat 请求 |
+| `store` | 不进入 Chat 请求 |
+| `background` | 普通桥接转换不处理 |
+| `truncation` | 不进入 Chat 请求 |
+| `prompt` | 在进入桥接前由 prompt management 处理 |
+| `previous_response_id` | 仅用于异步历史恢复，不直接发给 Chat provider |
+| `safety_identifier` | 核心转换器不处理 |
+
+## 5. `input` 到 `messages` 的转换
+
+### 5.1 字符串输入
+
+```json
+"hello"
+```
+
+转换为
+
+```json
+[
+  {
+    "role": "user",
+    "content": "hello"
+  }
+]
+```
+
+如果有 `instructions`，system message 位于该 user message 前面
+
+### 5.2 通用输入项
+
+对于不是工具调用、工具结果或 reasoning 的对象
+
+```json
+{
+  "type": "message",
+  "role": "user",
+  "content": "hello"
+}
+```
+
+转换为
+
+```json
+{
+  "role": "user",
+  "content": "hello"
+}
+```
+
+`role` 缺失时默认为 `user`。`content` 为 `null` 时整项删除
+
+### 5.3 content part 转换
+
+| Responses content part | Chat content part |
+| --- | --- |
+| 字符串 | 原字符串 |
+| `{"type":"input_text","text":"x"}` | `{"type":"text","text":"x"}` |
+| `{"type":"output_text","text":"x"}` | `{"type":"text","text":"x"}` |
+| `{"type":"tool_result","text":"x"}` | `{"type":"text","text":"x"}` |
+| `{"type":"input_audio",...}` | type 保持 `input_audio`，只保留转换器生成的 `type` 和 `text` |
+| 未知 type 且有 `text` | type 降级为 `text` |
+| 任意文本 part 且 `text` 为 `null` | 删除该 part |
+| `cache_control` | 在文本、文件和图片 part 上保留 |
+
+`input_file` 转换为
+
+```json
+{
+  "type": "file",
+  "file": {
+    "file_id": "effective-id-or-url",
+    "file_data": "optional-base64"
+  }
+}
+```
+
+`file_id` 优先于 `file_url`，没有 `file_id` 时把 `file_url` 放入 Chat 的 `file.file_id`。`file_data` 独立保留
+
+`input_image` 转换为
+
+```json
+{
+  "type": "image_url",
+  "image_url": {
+    "url": "original-image_url-or-empty-string",
+    "detail": "original-detail-or-auto"
+  }
+}
+```
+
+content part 的 `type="encrypted_content"` 会变成 Chat 文本 part，其中 `text` 等于原 `encrypted_content` 字符串
+
+如果 content 本身既不是字符串也不是列表，转换器抛出 `ValueError`
+
+### 5.4 `function_call` 和 `custom_tool_call`
+
+Responses 输入
+
+```json
+{
+  "type": "function_call",
+  "call_id": "call_1",
+  "id": "fc_1",
+  "name": "get_weather",
+  "arguments": "{\"city\":\"Paris\"}",
+  "status": "completed"
+}
+```
+
+转换为
+
+```json
+{
+  "role": "assistant",
+  "content": null,
+  "tool_calls": [
+    {
+      "id": "call_1",
+      "type": "function",
+      "index": 0,
+      "function": {
+        "name": "get_weather",
+        "arguments": "{\"city\":\"Paris\"}"
+      }
+    }
+  ]
+}
+```
+
+ID 优先级为 `call_id`、`id`、空字符串
+
+如果 `arguments` 等于 LiteLLM 的 redaction sentinel，会替换为有效 JSON 占位符 `"{}"`
+
+`custom_tool_call` 的原始负载位于 `input`。转换时包装为
+
+```json
+{
+  "content": "<raw input>"
+}
+```
+
+并序列化到 Chat function arguments
+
+带 `namespace` 的普通 function call 使用 `<namespace>__<name>` 作为 Chat function name。custom tool 不加 namespace 前缀
+
+连续的多个 function call 会合并到同一个 assistant message 的 `tool_calls` 数组。这样可以满足要求多个 tool use block 和后续 tool result 相邻的 provider
+
+如果一个普通 assistant content message 紧跟在只有 `tool_calls` 且 `content` 为空的 assistant message 后面，content 会折叠进前一个 assistant message
+
+### 5.5 工具执行结果
+
+以下 Responses item type 都按工具结果处理
+
+```text
+function_call_output
+custom_tool_call_output
+web_search_call
+computer_call_output
+tool_result
+```
+
+基础输出是
+
+```json
+{
+  "role": "tool",
+  "tool_call_id": "call_1",
+  "content": "tool output"
+}
+```
+
+`call_id` 缺失或为空时删除整项，因为无法构造有效 Chat tool message
+
+`output` 规范化规则如下
+
+| `output` 类型 | Chat `content` |
+| --- | --- |
+| `null` | 空字符串 |
+| 字符串 | 原字符串 |
+| 只包含文本 part 的列表 | 按顺序拼接全部文本 |
+| 包含图片 part 的列表 | 保留为 `text` 和 `image_url` content part 列表 |
+| 其他列表、对象或数值 | JSON 序列化，失败时使用 `str(value)` |
+
+图片 part 接受 `input_image` 或 `image_url`，URL 可以是字符串，也可以是 `{"url":"..."}` 对象
+
+模块使用进程内 `TOOL_CALLS_CACHE` 保存先前生成的 tool call 定义。如果处理 tool output 时命中缓存，会在 tool message 前补一个 assistant `tool_calls` message
+
+已有 function call input 和缓存恢复出的 assistant wrapper 使用 call ID 去重，避免同一工具调用出现两次
+
+### 5.6 reasoning 输入项
+
+provider-bound 转换调用时使用 `replay_reasoning=True`
+
+reasoning 文本提取优先级如下
+
+1. 非空字符串 `content`
+2. `content` 列表中非 `encrypted_content`、非 `redacted_thinking` block 的 `text`，多个值以换行连接
+3. `summary` 列表中各 block 的 `text`，多个值以换行连接
+
+提取到的文本不会成为可见 assistant content，而是生成
+
+```json
+{
+  "role": "assistant",
+  "content": null,
+  "reasoning_content": "..."
+}
+```
+
+如果 `encrypted_content` 是本模块先前写出的 JSON thinking block 数组，则恢复带有效 `signature` 的 `thinking` block 和带有效 `data` 的 `redacted_thinking` block，并写入 assistant message 的 `thinking_blocks`
+
+reasoning-only assistant message 如果紧跟普通 assistant answer 或 tool call assistant message，会合并到后者。多个 reasoning 文本以换行连接，恢复的 thinking blocks 放在目标 message 已有 blocks 前面
+
+如果 reasoning 后面是 user message或位于输入末尾，则保留独立 reasoning-only assistant message
+
+没有文本且没有可验证 thinking block 的 reasoning item 会删除
+
+供 guardrail、token counting 等只读调用方使用的 `replay_reasoning=False` 模式会把 reasoning 文本留在普通 `content` 中，保证可扫描性
+
+## 6. 工具定义转换
+
+### 6.1 function 工具
+
+Responses 工具
+
+```json
+{
+  "type": "function",
+  "name": "get_weather",
+  "description": "Get weather",
+  "parameters": {
+    "type": "object",
+    "properties": {}
+  },
+  "strict": true
+}
+```
+
+转换为
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "get_weather",
+    "description": "Get weather",
+    "parameters": {
+      "type": "object",
+      "properties": {}
+    },
+    "strict": true
+  }
+}
+```
+
+`parameters` 缺失、为空或缺少 `type` 时补 `"type":"object"`
+
+以下扩展字段在外层保留
+
+```text
+cache_control
+defer_loading
+allowed_callers
+input_examples
+```
+
+### 6.2 web search 工具
+
+`web_search` 和 `web_search_preview` 不进入 Chat `tools`，而是转换为
+
+```json
+{
+  "web_search_options": {
+    "search_context_size": "low|medium|high",
+    "user_location": {}
+  }
+}
+```
+
+如果目标 provider 的 `get_supported_openai_params` 明确不包含 `web_search_options`，则删除派生参数。provider 未映射、返回 `None` 时保留
+
+### 6.3 custom 工具
+
+Responses `type="custom"` 工具降级为单参数 Chat function
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "<custom name>",
+    "description": "<description plus optional grammar>",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "The <name> content following the specified format"
+        }
+      },
+      "required": ["content"]
+    }
+  }
+}
+```
+
+如果 custom tool 有 `format.definition`，description 末尾追加 fenced grammar，语言标识使用 `format.syntax`
+
+`allowed_callers` 必须是严格的字符串列表或 `null`，否则抛出 `ValueError`
+
+响应转换时，原始 request 中同名 custom tool 的 function call 会恢复为 `custom_tool_call`，并从 `{"content":"..."}` arguments 中取出原始字符串
+
+为防止异常大 JSON 解析，arguments 超过 1,000,000 字符时不解包，原样返回
+
+### 6.4 namespace 工具
+
+嵌套 namespace
+
+```json
+{
+  "type": "namespace",
+  "name": "weather",
+  "description": "Weather tools",
+  "tools": [
+    {
+      "type": "function",
+      "name": "lookup",
+      "parameters": {}
+    }
+  ]
+}
+```
+
+展平为名为 `weather__lookup` 的 Chat function。namespace description 和子工具 description 以两个换行连接
+
+只有嵌套 `type="function"` 子工具会转换，其他子工具删除
+
+没有 `tools` 数组的扁平 namespace 按单个 function 处理，名称不加 `namespace__` 前缀
+
+如果顶层 function 名与某个展平后的 namespace function 名冲突，转换器抛出 `ValueError`
+
+响应恢复时支持两种名称
+
+1. 完整的 `namespace__tool`
+2. 在所有 namespace 中唯一，且不与顶层 function 同名的短名称 `tool`
+
+恢复后的 Responses function call 使用短 `name`，并额外写入 `namespace`
+
+### 6.5 其他工具
+
+| Responses tool type | 当前行为 |
+| --- | --- |
+| `mcp` | 原样放入 Chat `tools` |
+| `computer_use` | 记录 warning 后删除 |
+| `image_generation` | 记录 warning 后删除 |
+| `shell` | 记录 warning 后删除 |
+| 其他未知类型 | 原样放入 Chat `tools` |
+
+### 6.6 `tool_choice`
+
+| Responses 值 | Chat 值 |
+| --- | --- |
+| `"auto"`、`"none"`、`"required"` | 原字符串 |
+| `{"type":"auto"}` | `"auto"` |
+| `{"type":"none"}` | `"none"` |
+| `{"type":"required"}`、`{"type":"tool"}`、`{"type":"any"}` | `"required"` |
+| `{"type":"function","name":"x"}` | `{"type":"function","function":{"name":"x"}}` |
+| `{"type":"function"}` | `"required"` |
+| `{"type":"custom","name":"x"}` | `{"type":"function","function":{"name":"x"}}` |
+| `{"type":"custom","custom":{"name":"x"}}` | 同上 |
+| 无法识别 | 原样返回 |
+
+标准 Chat 形式 `{"type":"function","function":{"name":"x"}}` 原样返回
+
+## 7. `previous_response_id` 和会话恢复
+
+Responses request 预处理会先尝试解码 LiteLLM 管理的 response ID，取出原始上游 `response_id`
+
+异步桥接检测到 `previous_response_id` 后执行以下算法
+
+1. 用 `previous_response_id` 对应的原始 response ID 查询 `LiteLLM_SpendLogs.request_id`
+2. 取得匹配记录的 `session_id`
+3. 查询同一 session 的所有 spend logs，并按 `endTime ASC` 排序
+4. 从每条记录的 `proxy_server_request.input` 或 `messages` 重建 Chat 输入消息
+5. 从每条记录的 `response.choices[*].message` 追加 assistant 历史
+6. 把历史和本次新 messages 拼接
+7. 修复缺少对应 assistant tool call 的 tool result
+8. 把 spend log session ID 写入 `litellm_trace_id`
+
+如果 request payload 因长度被截断，并且配置了 cold storage logger，则通过 spend log metadata 中的 `cold_storage_object_key` 读取完整请求
+
+刚完成的请求可能尚未写入 spend log，因此查询最多按配置重试 `RESPONSES_SESSION_LOOKUP_MAX_ATTEMPTS` 次，每次间隔 `RESPONSES_SESSION_LOOKUP_RETRY_INTERVAL`
+
+如果禁用了 spend logs，只查询一次
+
+tool result 修复优先级如下
+
+1. 从前一个 assistant message 恢复空的 `tool_call_id`
+2. 检查该 assistant 是否已有同 ID tool call
+3. 从 `TOOL_CALLS_CACHE` 恢复完整定义
+4. 缓存未命中时，从当前 tools 列表构造 name 加空 arguments 的最小 tool call
+5. 仍无法修复且还有其他非 tool message 时删除无效 tool message
+
+如果最终 messages 为空，优先恢复本次原始 messages，再恢复 session messages。两者都为空时抛出 LiteLLM `BadRequestError`
+
+## 8. 非流式 Chat 响应到 Responses 响应
+
+### 8.1 顶层对象
+
+`transform_chat_completion_response_to_responses_api_response` 接受 `ModelResponse` 或可构造成 `ModelResponse` 的字典
+
+| Chat 字段 | Responses 字段 | 缺省值或规则 |
+| --- | --- | --- |
+| `id` | `id` | 原值 |
+| `created` | `created_at` | 原值 |
+| `model` | `model` | 原值 |
+| 固定值 | `object` | `"response"` |
+| `error` | `error` | `null` |
+| `incomplete_details` | `incomplete_details` | `null` |
+| `instructions` | `instructions` | `null` |
+| `metadata` | `metadata` | `{}` |
+| `parallel_tool_calls` | `parallel_tool_calls` | `false` |
+| `temperature` | `temperature` | `0` |
+| `tool_choice` | `tool_choice` | `"auto"` |
+| `tools` | `tools` | `[]` |
+| `top_p` | `top_p` | `null` |
+| `max_output_tokens` | `max_output_tokens` | `null` |
+| `previous_response_id` | `previous_response_id` | `null` |
+| 固定值 | `reasoning` | `null` |
+| 固定值 | `text` | `{}` |
+| `truncation` | `truncation` | `null` |
+| `user` | `user` | `null` |
+| `usage` | `usage` | 使用第 8.7 节算法 |
+
+顶层 `status` 只看第一个 choice 的 `finish_reason`
+
+| Chat `finish_reason` | Responses `status` |
+| --- | --- |
+| `stop`、`tool_calls`、`function_call`、`null` | `completed` |
+| `length`、`content_filter`、`refusal` | `incomplete` |
+| 未知值 | `completed` |
+
+### 8.2 output 顺序
+
+output 按以下顺序构建
+
+1. 最多一个 reasoning item
+2. 每个 choice 的 message item 或 image generation items
+3. 所有 choice 的 function 或 custom tool call items
+4. provider 预构建的 server-side tool result 替换对应 function call
+
+因此一个带 reasoning、文本和 tool call 的 choice 可以同时产生三个 output item
+
+### 8.3 文本 message
+
+每个没有 `message.images` 的 choice 生成
+
+```json
+{
+  "type": "message",
+  "id": "msg_<uuid4>",
+  "status": "<mapped from finish_reason>",
+  "role": "<chat message role>",
+  "content": [
+    {
+      "type": "output_text",
+      "text": "<message.content>",
+      "annotations": []
+    }
+  ]
+}
+```
+
+每次转换生成新的随机 message ID，不复用 Chat completion ID
+
+### 8.4 annotations
+
+只转换 Chat annotation `type="url_citation"`
+
+```json
+{
+  "type": "url_citation",
+  "start_index": 0,
+  "end_index": 10,
+  "url": "https://example.com",
+  "title": "Example"
+}
+```
+
+其他 annotation type 当前删除
+
+### 8.5 reasoning 输出
+
+转换器只检查第一个包含 reasoning 的 choice，生成最多一个 reasoning item
+
+```json
+{
+  "type": "reasoning",
+  "id": "rs_<uuid4>",
+  "status": "<mapped from finish_reason>",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "output_text",
+      "text": "<message.reasoning_content>",
+      "annotations": []
+    }
+  ],
+  "encrypted_content": "<optional-json>"
+}
+```
+
+如果 message 有带 `signature` 或 `data` 的 `thinking_blocks`，这些 blocks 会被紧凑 JSON 序列化到 `encrypted_content`
+
+即使没有明文 `reasoning_content`，只要存在可保留的 thinking block 也会生成 reasoning item，此时 `content` 为空数组
+
+### 8.6 工具调用输出
+
+所有 choice 的 `message.tool_calls` 都会收集。普通 function call 生成
+
+```json
+{
+  "type": "function_call",
+  "id": "<chat tool call id>",
+  "call_id": "<chat tool call id>",
+  "name": "<function name>",
+  "arguments": "<raw arguments string>",
+  "status": "<function status or completed>"
+}
+```
+
+tool call 同时写入 `TOOL_CALLS_CACHE`，供后续 `function_call_output` 恢复 assistant tool call
+
+如果原始 Responses request 定义了同名 custom tool，则输出改为
+
+```json
+{
+  "type": "custom_tool_call",
+  "id": "<chat tool call id>",
+  "call_id": "<chat tool call id>",
+  "name": "<function name>",
+  "input": "<unwrapped content>",
+  "status": "<function status or completed>"
+}
+```
+
+namespace function name 按第 6.4 节恢复
+
+tool call 或 function 上的 `provider_specific_fields` 会原样附加到 Responses function call
+
+provider adapter 可以把 server-side code execution result 放在 `message.provider_specific_fields["code_interpreter_results"]`。这些对象被转换为 `code_interpreter_call`，并按 ID 替换同 call ID 的普通 `function_call`
+
+### 8.7 图片输出
+
+如果 choice message 有 `images`，该 choice 不生成文本 message，而是为每个有效图片生成
+
+```json
+{
+  "type": "image_generation_call",
+  "id": "ig_<uuid4>",
+  "status": "completed|incomplete|failed",
+  "result": "<base64-without-data-url-prefix>"
+}
+```
+
+`data:image/...;base64,` 前缀会删除。没有前缀的字符串按纯 base64 原样使用
+
+| finish reason | image status |
+| --- | --- |
+| `stop` | `completed` |
+| `length` | `incomplete` |
+| `content_filter`、`error` | `failed` |
+| 其他 | `completed` |
+
+### 8.8 usage
+
+基础映射如下
+
+| Chat usage | Responses usage |
+| --- | --- |
+| `prompt_tokens` | `input_tokens` |
+| `completion_tokens` | `output_tokens` |
+| `total_tokens` | `total_tokens` |
+| `usage.cost` | 动态 `cost` 字段 |
+
+没有 usage 时三个 token count 都为 `0`
+
+`prompt_tokens_details` 映射为 `input_tokens_details`
+
+| Chat detail | Responses detail |
+| --- | --- |
+| `cached_tokens` | `cached_tokens`，缺失时在 detail 对象内补 `0` |
+| `text_tokens` | `text_tokens` |
+| `audio_tokens` | `audio_tokens` |
+| `cache_write_tokens` | `cache_write_tokens` |
+| `cache_creation_tokens` | 当 `cache_write_tokens` 缺失时作为其后备 |
+
+`completion_tokens_details` 映射为 `output_tokens_details`
+
+| Chat detail | Responses detail |
+| --- | --- |
+| `reasoning_tokens` | `reasoning_tokens`，缺失时补 `0` |
+| `audio_tokens` | `audio_tokens` |
+| `text_tokens` | `text_tokens` |
+| `image_tokens` | `image_tokens` |
+
+只有原 Chat detail 对象存在时才创建对应 Responses detail 对象
+
+### 8.9 hidden 和 provider 字段
+
+Chat response 的 `_hidden_params` 整体复制到 Responses response
+
+如果 `_hidden_params["provider_specific_fields"]` 存在，还会把它暴露为顶层动态 `provider_specific_fields`
+
+## 9. 流式转换
+
+### 9.1 输入和状态
+
+`LiteLLMCompletionStreamingIterator` 同时支持同步和异步迭代。它维护以下关键状态
+
+| 状态 | 用途 |
+| --- | --- |
+| `_cached_response_id` | 保证所有 response-level 事件使用同一 ID |
+| `_cached_item_id` | 文本 message item ID |
+| `_cached_reasoning_item_id` | reasoning item ID |
+| `collected_chat_completion_chunks` | 在流结束时用 `stream_chunk_builder` 重建完整 ModelResponse |
+| `_pending_response_events` | reasoning、message、annotation 等待发送事件 |
+| `_pending_tool_events` | function call 等待发送事件 |
+| `_tool_args_by_call_id` | 累积每个工具调用的 arguments |
+| `_tool_call_id_by_index` | 恢复后续没有 ID 的 tool delta |
+| `_tool_output_index_by_call_id` | 固定每个工具 output index |
+| `_sequence_number` | 部分事件的序号 |
+| `completed_response` | 保存最终 `response.completed`，供外层 fallback 和 ownership hook 使用 |
+
+迭代器会在发出 `response.created` 前先读取第一个非空上游 chunk，并缓存它。这样优先使用 Chat stream 的真实 ID，而不是先生成随机 ID
+
+如果流在首个 chunk 前结束，则生成 `resp_<uuid4>` 作为后备 ID
+
+### 9.2 普通文本事件序列
+
+预期普通文本序列如下
+
+```text
+response.created
+response.in_progress
+response.output_item.added
+response.content_part.added
+response.output_text.delta  repeated
+response.output_text.done
+response.content_part.done
+response.output_item.done
+response.completed
+```
+
+message output index 和 content index 都是 `0`
+
+初始 message item 为
+
+```json
+{
+  "id": "msg_<uuid4>",
+  "type": "message",
+  "role": "assistant",
+  "status": "in_progress",
+  "content": []
+}
+```
+
+初始 content part 为
+
+```json
+{
+  "type": "output_text",
+  "text": "",
+  "annotations": []
+}
+```
+
+每个 Chat chunk 只读取第一个 choice 的 `delta.content`
+
+流结束时完整 chunks 交给 `stream_chunk_builder`，随后调用同一个非流式响应转换器构造 `response.completed.response`
+
+最终 snapshot 中 message 和 reasoning item ID 会替换为流中已经发出的 ID，保证中间事件与完成快照一致
+
+### 9.3 reasoning 事件
+
+首个有效 delta 是 `reasoning_content` 时，先发送
+
+```text
+response.output_item.added
+```
+
+item 使用 `type="reasoning"`、`status="in_progress"`、`output_index=0`
+
+每个 reasoning delta 转换为
+
+```text
+response.reasoning_summary_text.delta
+```
+
+当 chunk 首次出现普通 content、function call、tool call 或非空 finish reason 时，reasoning 阶段结束，并排队
+
+```text
+response.reasoning_summary_text.done
+response.reasoning_summary_part.done
+response.output_item.done
+```
+
+reasoning 文本由所有已见 `reasoning_content` 直接拼接
+
+### 9.4 function tool call 事件
+
+发现一个新的 call ID 时发送
+
+```text
+response.output_item.added
+```
+
+item 是 `function_call` 或 `custom_tool_call`，初始 status 为 `in_progress`
+
+工具 output index 从 `1` 开始，因为当前实现保留 `0` 给 message 或 reasoning item
+
+Chat provider 可能一次给出很长的 arguments delta。桥接器固定按最多 10 个字符切片，每片发送
+
+```text
+response.function_call_arguments.delta
+```
+
+流结束后，每个工具调用按顺序发送
+
+```text
+response.function_call_arguments.done
+response.output_item.done
+```
+
+如果完整 tool call 只出现在 `stream_chunk_builder` 的最终 ModelResponse 中，而流式 delta 中没有出现，迭代器会补发 added、全部 argument deltas、arguments done 和 item done
+
+后续 tool delta 没有 call ID 时，用 Chat tool call `index` 找回 ID。若同一个 index 曾对应多个不同 call ID，该 index 标为歧义，后续无 ID delta 会跳过，避免把 arguments 拼到错误调用
+
+parallel tool calls 按 call ID 分别累积，并获得不同 output index
+
+### 9.5 annotation 事件
+
+首次看到 `delta.annotations` 时，把所有可转换的 URL citations 排队为
+
+```text
+response.output_text.annotation.added
+```
+
+当前实现只处理第一次出现 annotations 的 chunk
+
+### 9.6 provider-specific 数据
+
+每个 chunk 顶层和 `choice[0].delta` 的 `provider_specific_fields` 都会累积
+
+同名字段采用最后值覆盖。列表也不追加，因为 provider 通常发送到当前时刻为止的完整累计列表
+
+流结束后这些字段写入完整 ModelResponse 的 `_hidden_params["provider_specific_fields"]`
+
+### 9.7 response ID 编码
+
+流式 `response.created`、`response.in_progress` 和 `response.completed` 会经过 `ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id`
+
+编码格式为
+
+```text
+resp_<base64("litellm:custom_llm_provider:<provider>;model_id:<model-id>;response_id:<original-id>")>
+```
+
+这个 ID 用于下一次请求的 deployment affinity 和 session lookup。已经是 LiteLLM 编码格式的 ID 不会重复编码
+
+非流式核心转换器本身只复制 Chat response ID。调用链如果需要统一管理 ID，必须在外层明确执行相同编码步骤
+
+## 10. 错误和降级规则
+
+重写时应保留以下显式错误
+
+| 条件 | 当前行为 |
+| --- | --- |
+| handler 收到既不是 `ModelResponse` 也不是 `CustomStreamWrapper` 的返回值 | `ValueError` |
+| input content 既不是字符串也不是列表 | `ValueError` |
+| namespace 展平名称与顶层 function 冲突 | `ValueError` |
+| `allowed_callers` 不是字符串列表或 `null` | `ValueError` |
+| `previous_response_id` 恢复后仍无法构造任何 message | LiteLLM `BadRequestError` |
+| 上游 completion 异常 | 原样传播 |
+| streaming iterator 内部异常 | 标记 finished 后原样传播 |
+
+以下情况静默删除或降级
+
+| 条件 | 当前行为 |
+| --- | --- |
+| input item `content=null` | 删除 item |
+| content part `text=null` | 删除 part |
+| tool output 缺少 call ID | 删除 item |
+| opaque 或无法解析的 reasoning encrypted content | 不重放 |
+| `computer_use`、`image_generation`、`shell` 工具 | warning 后删除 |
+| 未知 content part type | 降级为 text |
+| 未知 finish reason | 顶层状态按 completed |
+| 无 usage | token counts 全部为 0 |
+
+## 11. 重写必须保持的兼容性不变量
+
+下面这些应视为目标实现的规范性要求，而不是对当前类结构的要求
+
+1. 桥接必须在没有原生 Responses adapter 时自动启用，并允许调用方显式强制启用
+2. 必须设置递归保护，Chat 调用不能再次桥回 Responses
+3. request input item 顺序必须保持，尤其是 assistant tool call 和紧随其后的 tool result
+4. 并行 function calls 必须合并到同一个 assistant message
+5. Chat tool result 必须有对应 assistant tool call，不得发送孤立 tool result
+6. custom tool、namespace tool 的名称和 payload 必须能往返恢复
+7. reasoning 明文和签名 thinking blocks 必须与可见 content 分离并支持多轮重放
+8. 每个 Responses output item 必须有符合类型前缀且在该响应内稳定的 ID
+9. 流式同一 response 的所有 response-level 事件必须共享一个 response ID
+10. `response.completed` 的 item ID 必须复用中间事件已公布的 item ID
+11. 工具 arguments deltas 必须按 call ID 隔离，不能在并行调用之间串线
+12. 流式结束前必须提供 usage，因此 Chat stream 必须请求 `include_usage`
+13. finish reason 到 Responses status 的映射必须同时用于顶层 response 和各 output item
+14. URL citation、cache token、reasoning token、image token 和 provider-specific 字段不能在桥接中丢失
+15. `previous_response_id` 必须恢复完整有序历史，并保持 deployment 和 trace affinity
+16. 同步和异步接口应产生等价的请求、响应和 session 行为
+
+## 12. 当前实现中不应盲目复制的偏差
+
+这些是从代码路径直接观察到的行为。重写前应先决定是否修复，并用兼容测试锁定决定
+
+### 12.1 named 参数传播不一致
+
+请求转换器从 `kwargs` 读取 `metadata` 和 `service_tier`，但它们在 `responses()` 中是 named 参数，并且已经存在于 `responses_api_request` 或局部变量。桥接分派没有显式把这两个 named 参数再次放入 `kwargs`
+
+新的实现应从规范化后的 Responses request 读取它们，不应依赖它们是否恰好还存在于 `kwargs`
+
+### 12.2 同步 `previous_response_id`
+
+只有异步 handler 调用 session handler。同步桥接会忽略历史恢复
+
+新的实现应让同步路径执行等价恢复，或明确拒绝同步 session continuation
+
+### 12.3 非流式 ID 管理
+
+非流式转换器直接把 `chatcmpl-*` ID 放到 Responses 顶层 `id`，而流式路径显式编码为 LiteLLM `resp_*` ID
+
+新的实现应统一两条路径，并保证 ID 可用于 `previous_response_id`
+
+### 12.4 流式首 chunk 和 item 生命周期
+
+异步迭代器会在排队初始 item 事件后继续转换同一个 chunk。同步迭代器在排队初始 item 事件后立即返回，当前 chunk 的 delta 只进入最终 chunk builder，可能没有对应的中间 delta 事件
+
+reasoning-first 流在 reasoning 结束并进入普通文本时不会重新发送 message `output_item.added` 和 `content_part.added`，但后续仍可能发送 message text delta 和 done 事件
+
+tool-only 流结束后仍经过默认 message text done、content part done 和 item done 状态，可能产生空 message 生命周期
+
+新的实现应为 reasoning、message 和每个 tool call 分别维护独立 item state，不应使用单个 `sent_output_item_added_event` 控制所有 item
+
+### 12.5 sequence number 不一致
+
+只有部分事件带 `sequence_number`。部分 done event 没有动态序号，message `output_item.done` 甚至固定使用 `1`
+
+如果目标客户端依赖 OpenAI 事件顺序，重写应为每个发出的事件分配严格单调递增的 sequence number
+
+### 12.6 advertised 参数与实际参数不一致
+
+`get_supported_openai_params` 声明支持 `metadata` 和 `previous_response_id`，但同步路径或 named 参数传播不能完整兑现。反过来，转换器实际处理 `context_management`，但该字段不在 advertised list 中
+
+重写应从单一 schema 生成支持列表和转换逻辑，避免两份能力定义漂移
+
+## 13. 推荐的重写边界
+
+为了减少当前实现中的共享可变状态，建议把重写拆成以下纯转换边界
+
+```text
+normalize_responses_request(request, provider_capabilities) -> NormalizedBridgeRequest | BridgeError
+responses_input_to_chat_messages(input_items, replay_context) -> tuple[ChatMessage, ...] | BridgeError
+responses_tools_to_chat_tools(tools, provider_capabilities) -> ToolConversion
+chat_response_to_responses(chat_response, original_request, id_context) -> ResponsesResponse
+chat_chunk_to_events(stream_state, chat_chunk) -> StreamTransition
+restore_session(previous_response_id, history_store) -> SessionHistory | SessionError
+```
+
+`ToolConversion` 至少需要同时返回 Chat tools、web search options、custom tool name set 和 namespace name map
+
+`StreamTransition` 应返回新 state 和零个或多个事件。这样同一 chunk 可以先创建 item，再发 delta，不会因为 iterator 一次只能 return 一个对象而丢失当前 chunk
+
+I/O、数据库查询、provider capability lookup、ID encoding 和纯字段转换应使用依赖注入分离，便于对每个边界做确定性测试
+
+## 14. 最小验收测试矩阵
+
+另一个实现至少应覆盖以下测试
+
+| 类别 | 用例 |
+| --- | --- |
+| 路由 | provider 无 Responses config 自动桥接 |
+| 路由 | `use_chat_completions_api=True` 强制桥接 |
+| 路由 | `openai/chat_completions/<model>` 规范化并桥接 |
+| 路由 | provider 有原生 config 且未强制时不桥接 |
+| 递归 | forwarded completion 带 `_skip_responses_api_bridge=True` |
+| 输入 | 字符串、message、文本数组、图片、文件、空 content |
+| 输入 | file ID、file URL、file data 和优先级 |
+| 工具 | function schema 缺少 type 时补 object |
+| 工具 | custom grammar 工具往返 |
+| 工具 | namespace 展平、短名称恢复、冲突拒绝 |
+| 工具 | web search 派生与 provider capability 删除 |
+| 工具 | unsupported Responses-only tools 删除 |
+| 工具 | 多个并行 function call 合并 |
+| 工具 | function call output 与 assistant call 相邻 |
+| reasoning | 明文、summary-only、签名 thinking block、多轮合并 |
+| 非流式 | 文本、reasoning、tool call、custom tool call、image output |
+| 非流式 | 所有 finish reason 状态映射 |
+| usage | 无 details、cached、cache write、reasoning、audio、text、image tokens |
+| annotations | URL citation 索引和字段保持 |
+| 流式 | 普通文本完整事件序列 |
+| 流式 | reasoning 后继续输出文本 |
+| 流式 | tool-only 流不生成虚假 message item |
+| 流式 | 并行 tool calls 和无 ID 后续 delta |
+| 流式 | final-only tool call 补发 |
+| 流式 | response 和 item ID 全程稳定 |
+| 流式 | sequence number 严格递增 |
+| 会话 | previous response 恢复输入、输出和 tool calls |
+| 会话 | spend log 延迟重试和 cold storage 回源 |
+| 同步性 | sync 和 async 结果等价 |
+
+现有主要回归测试位于
+
+```text
+tests/test_litellm/responses/litellm_completion_transformation/
+tests/test_litellm/responses/test_responses_api_bridge_flag.py
+tests/test_litellm/test_responses_api_bridge_non_stream.py
+tests/e2e/llm_translation/test_responses_bridge_streaming_e2e.py
+```
+
+## 15. 关键源码索引
+
+| 行为 | 源码 |
+| --- | --- |
+| 桥接启用判断 | `litellm/responses/main.py::_bridges_to_chat_completions` |
+| 强制桥接模型前缀 | `litellm/responses/main.py::_normalize_openai_chat_completions_responses_model` |
+| 请求总转换 | `transformation.py::transform_responses_api_request_to_chat_completion_request` |
+| input 到 messages | `transformation.py::transform_responses_api_input_to_messages` |
+| 单个 input item | `transformation.py::_transform_responses_api_input_item_to_chat_completion_message` |
+| Responses tools 到 Chat tools | `transformation.py::transform_responses_api_tools_to_chat_completion_tools` |
+| 非流式响应总转换 | `transformation.py::transform_chat_completion_response_to_responses_api_response` |
+| Chat tools 到 Responses output | `transformation.py::transform_chat_completion_tools_to_responses_tools` |
+| usage 转换 | `transformation.py::_transform_chat_completion_usage_to_responses_usage` |
+| 流式 chunk 转换 | `streaming_iterator.py::_transform_chat_completion_chunk_to_response_api_chunk` |
+| 流式完成快照 | `streaming_iterator.py::_emit_response_completed_event` |
+| session 恢复 | `session_handler.py::get_chat_completion_message_history_for_previous_response_id` |
+| response ID 编码 | `litellm/responses/utils.py::_update_responses_api_response_id_with_model_id` |

--- a/docs/ollama_chat_to_chat_completions.md
+++ b/docs/ollama_chat_to_chat_completions.md
@@ -1,0 +1,747 @@
+# Ollama Chat → Chat Completions 桥接规范
+
+> 状态：唯一生产行为规范；不保留目标仓库旧实现兼容分支
+>
+> 固定来源：Ollama `f96e7aa0513b9973a0ccc71be414c2ecb9d65b1a`；
+> LiteLLM `ae7e50f096a8722bad14d63b6a0d4634d59bf475`
+
+## 1. 范围与优先级
+
+本文定义：
+
+1. Ollama `POST /api/chat` request → OpenAI-compatible Chat Completions request；
+2. Chat Completions JSON response → Ollama Chat JSON；
+3. Chat Completions SSE bytes → Ollama Chat NDJSON。
+
+固定优先级：
+
+| 方向 | 规范来源 |
+|---|---|
+| 入站 Ollama request、Ollama response shape、NDJSON bytes | 固定 Ollama 源码 |
+| Chat response 兼容、finish/reasoning/tool/usage fallback | 固定 LiteLLM 源码 |
+
+实现只使用上述固定来源，不提供运行时 profile 或 capability/pointer 配置。目标仓库已有 adapter、
+默认值、header、error 和 stream 行为不参与规范选择；冲突的旧实现必须替换。
+
+目标 Chat dialect 固定采用 Ollama 同一提交中 OpenAI compatibility DTO 可表达的字段。GitHub hosted
+Copilot 是否接受全部字段是外部部署约束，不得通过模型名、hostname 或目标仓库旧代码猜测。
+
+## 2. Transport
+
+### 2.1 Downstream Ollama
+
+- Route：`POST /api/chat`；
+- `stream` 缺失时默认为 `true`；
+- nonstream success：`Content-Type: application/json; charset=utf-8`；
+- stream success：`Content-Type: application/x-ndjson`；
+- 每个 stream object 后精确一个 LF；
+- NDJSON 中不出现 `data:`、`event:` 或 `[DONE]`。
+
+### 2.2 Upstream Chat
+
+- Request：JSON Chat Completions object；
+- Nonstream response：JSON Chat Completion；
+- Stream response：OpenAI-compatible SSE；
+- `stream:true` 时 request 固定加入
+  `stream_options:{"include_usage":true}`。
+
+本文不规定 token/endpoint 获取、认证 header、重试或 timeout。
+
+## 3. 固定 DTO
+
+### 3.1 Ollama request
+
+```text
+OllamaChatRequest {
+  model: string
+  messages: OllamaMessage[]
+  stream?: boolean = true
+  format?: JsonValue
+  keep_alive?: string | number
+  tools?: OllamaTool[]
+  options?: Map<string, JsonValue> | null
+  think?: boolean | "low" | "medium" | "high" | "max"
+  truncate?: boolean
+  shift?: boolean
+  _debug_render_only?: boolean
+  logprobs?: boolean
+  top_logprobs?: integer
+}
+
+OllamaMessage {
+  role: string
+  content: string
+  thinking?: string
+  images?: base64[]
+  tool_calls?: OllamaToolCall[]
+  tool_name?: string
+  tool_call_id?: string
+}
+
+OllamaToolCall {
+  id?: string
+  function: {
+    index: integer
+    name: string
+    arguments: ordered JSON object
+  }
+}
+```
+
+Message JSON decode 后把 role 转为 lowercase。
+
+```text
+OllamaTool {
+  type: string
+  items?: JsonValue
+  function: {
+    name: string
+    description?: string
+    parameters: OllamaToolFunctionParameters
+  }
+}
+
+OllamaToolFunctionParameters {
+  type: string
+  $defs?: JsonValue
+  items?: JsonValue
+  required?: string[]
+  properties: ordered Map<string, OllamaToolProperty>
+}
+
+OllamaToolProperty {
+  anyOf?: OllamaToolProperty[]
+  type?: string | string[]
+  items?: JsonValue
+  description?: string
+  enum?: JsonValue[]
+  properties?: ordered Map<string, OllamaToolProperty>
+  required?: string[]
+}
+```
+
+Tool 没有 `strict` 字段。Property 和 tool-call arguments 的 member insertion order 必须保留。
+
+### 3.2 Ollama response
+
+```text
+OllamaChatResponse {
+  model: string
+  remote_model?: string
+  remote_host?: string
+  created_at: RFC3339Nano
+  message: OllamaMessage
+  done: boolean
+  done_reason?: string
+  _debug_info?: {
+    rendered_template: string
+    image_count?: integer
+  }
+  logprobs?: OllamaLogprob[]
+  total_duration?: integer
+  load_duration?: integer
+  prompt_eval_count?: integer
+  prompt_eval_duration?: integer
+  eval_count?: integer
+  eval_duration?: integer
+}
+```
+
+Duration 单位为 nanoseconds。所有 metrics 使用 Go `omitempty` 语义；0 不输出。普通 remote Chat bridge
+不生成 duration、debug 或 remote 字段。
+
+## 4. Request 转换
+
+### 4.1 顶层字段
+
+| Ollama | Chat | 规则 |
+|---|---|---|
+| `model` | `model` | 必须是非空 string，不提供默认值 |
+| `messages` | `messages` | 非空 array；第 4.2 节 |
+| `tools` | `tools` | 第 4.3 节 |
+| `format` | `response_format` | 第 4.5 节 |
+| `options` | Chat sampling/token fields | 第 4.4 节 |
+| `stream` | `stream` | 缺失为 true |
+| `think` | `reasoning_effort` | string/false 按第 4.5 节；true 返回 `unsupported_semantics` |
+| `_debug_render_only` | 同名 | 原 boolean |
+| `logprobs` | 同名 | 原 boolean |
+| `top_logprobs` | 同名 | integer 0..20 |
+| `keep_alive` | 无 | source-valid but unrepresentable |
+| `truncate` | 无 | source-valid but unrepresentable |
+| `shift` | 无 | source-valid but unrepresentable |
+
+Unknown top-level members 按 Go struct JSON decode 行为忽略。Missing/null `options` 等价于 empty map。
+
+`top_logprobs` 即使 `logprobs:false` 也可被解析并发送；此时按 Ollama 语义没有效果，不额外拒绝。
+
+Empty messages、`keep_alive`、`truncate`、`shift` 和第 4.4 节不可表达 options 均归类为
+`unsupported_semantics`，必须在零 upstream call 时返回，并按第 9 节输出错误。
+
+### 4.2 Messages
+
+Role 只执行 lowercase 后原样复制。固定 `Message.UnmarshalJSON` 不做四值 allowlist 校验。
+
+Message mapping：
+
+| Ollama | Chat |
+|---|---|
+| `role` | `role` |
+| `content` | string content，含 images 时变为 text part |
+| `thinking` | `reasoning` |
+| `tool_name` | `name` |
+| `tool_call_id` | `tool_call_id` |
+
+Images 是裸 base64。逐项：
+
+1. 严格 base64 decode；
+2. 通过 decoded magic 只接受 JPEG/JPG、PNG 或 WebP；
+3. 生成 `data:<mime>;base64,<original-data>` image URL part；
+4. undecodable 或未知 magic 失败，不猜 JPEG；
+5. message content 作为首个 text part，空 string 仍保留。
+
+Assistant tool calls：
+
+- function arguments 必须是 JSON object；
+- compact serialize 为 Chat string，保留 object member insertion order；
+- function name 原样；
+- function index 写到 Chat tool call 顶层 `index`；
+- nonempty ID 原样写入；缺失时省略，不生成 synthetic ID；
+- type 固定 `"function"`。
+
+Tool-result message 的 `tool_call_id` 和 `name` 分别直接来自 Ollama `tool_call_id` 与 `tool_name`。
+不建立本地 call/result consumption state。
+
+### 4.3 Tool declarations
+
+Ollama `tools[]` 按第 3.1 节固定类型解析后直接映射为 Chat tools：
+
+- `type` 原值；
+- `items` 原值；
+- function name/description/parameters 原值；
+- parameters 和 properties 保留 insertion order；
+- 不注入空 schema；
+- 不增加 `strict`；
+- 不增加 64-character regex 或 capability gate。
+
+非法类型按 Ollama fixed DTO decode 失败。
+
+### 4.4 Options
+
+只映射 Chat 可表达的字段：
+
+| `options` | Chat |
+|---|---|
+| `num_predict` | `max_tokens` |
+| `temperature` | `temperature` |
+| `top_p` | `top_p` |
+| `seed` | `seed` |
+| `stop` | `stop` |
+| `frequency_penalty` | `frequency_penalty` |
+| `presence_penalty` | `presence_penalty` |
+
+规则：
+
+- `num_predict` 必须是正 integer；`-1`、`-2` 和其他非正值是 Ollama 可识别但 Chat 无法等价表达；
+- `stop` 必须是 string array，不接受 scalar，不增加四项上限；
+- numeric fields 不做 string/bool coercion；
+- 缺失 fields 不发送 target defaults。
+
+下列 Ollama options 不透传到 Chat：
+
+```text
+num_keep
+top_k
+min_p
+typical_p
+repeat_last_n
+repeat_penalty
+num_ctx
+num_batch
+num_gpu
+main_gpu
+use_mmap
+num_thread
+draft_num_predict
+```
+
+显式提供这些 source-valid fields 时不得悄悄忽略或按同名字段发送；它们属于不可表达语义。
+
+### 4.5 Format 与 thinking
+
+`format:"json"`：
+
+```json
+{"response_format":{"type":"json_object"}}
+```
+
+`format:<schema object>`：
+
+```json
+{
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "schema": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}
+```
+
+不增加 `name` 或 `strict`。
+
+其他合法 JSON `format` 值能被 Ollama `json.RawMessage` 接收，但不能映射到固定 Chat response-format
+shape，归类为 `unsupported_semantics`。
+
+`think`：
+
+| Ollama | Chat `reasoning_effort` |
+|---|---|
+| `false` | `"none"` |
+| string | 原 string |
+
+`true` 返回 `unsupported_semantics`，不调用上游。不使用 RFC 6901 pointer，不按模型名推测。
+
+### 4.6 Request 示例
+
+Ollama：
+
+```json
+{
+  "model": "gpt-5",
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "",
+      "thinking": "checking",
+      "tool_calls": [{
+        "id": "call_1",
+        "function": {
+          "index": 0,
+          "name": "weather",
+          "arguments": {"city":"Tokyo"}
+        }
+      }]
+    },
+    {
+      "role": "tool",
+      "content": "sunny",
+      "tool_name": "weather",
+      "tool_call_id": "call_1"
+    }
+  ],
+  "stream": true,
+  "think": "medium",
+  "options": {
+    "num_predict": 256,
+    "stop": ["END"]
+  }
+}
+```
+
+Chat：
+
+```json
+{
+  "model": "gpt-5",
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "",
+      "reasoning": "checking",
+      "tool_calls": [{
+        "id": "call_1",
+        "index": 0,
+        "type": "function",
+        "function": {
+          "name": "weather",
+          "arguments": "{\"city\":\"Tokyo\"}"
+        }
+      }]
+    },
+    {
+      "role": "tool",
+      "content": "sunny",
+      "name": "weather",
+      "tool_call_id": "call_1"
+    }
+  ],
+  "stream": true,
+  "stream_options": {"include_usage":true},
+  "reasoning_effort": "medium",
+  "max_tokens": 256,
+  "stop": ["END"]
+}
+```
+
+## 5. Nonstream Chat response
+
+### 5.1 Choice
+
+`choices` 必须是 array，并且恰好一个 choice 的 `index==0`：
+
+- 无 index 0：invalid upstream response；
+- 多个 index 0：invalid upstream response；
+- 其他 index 被忽略；
+- 选中 choice 的 `message` 必须是 object。
+
+不得按 array position 把非 0 choice 当主 choice。
+
+### 5.2 Output
+
+```text
+model       = original Ollama request.model
+message.role = "assistant"
+message.content = selected message.content ?? ""
+done        = true
+```
+
+Thinking 提取优先级：
+
+1. 只要 key `message.reasoning_content` 存在，就使用其值并停止 fallback；
+2. 否则只要 key `message.reasoning` 存在，就使用其值并停止 fallback；
+3. 否则从 content 开头的完整
+   `<think>...</think>`、`<thinking>...</thinking>` 或
+   `<budget:thinking>...</budget:thinking>` 提取。
+
+Tag 必须从 content 第一个字符开始并同时存在 closing tag。Opening 与 closing 各自可为 `think`、
+`thinking` 或 `budget:thinking`，固定 regex 不要求二者名称相同。未闭合或位于文本中间时不提取。
+匹配后 opening/closing 之间为 thinking，closing 后全部文本为 visible content。
+
+显式 reasoning key 的值必须是 string 或 null；null 表示无 thinking，其他类型是 invalid upstream
+response。Content 必须是 string 或 null；null 规范化为 empty string。
+
+Tool calls：
+
+- Chat function arguments 必须是可 parse 的 JSON object；
+- 输出 ordered object，不接受 array/scalar；
+- ID 原样保留，缺失时省略；
+- function index 优先使用 Chat 顶层非负 `index`，缺失时使用 call array position；
+- function name 原样。
+
+Finish reason：
+
+| Chat | Ollama `done_reason` |
+|---|---|
+| `length` | `"length"` |
+| `tool_calls` / `function_call` 且存在 nonempty converted tool calls | `"stop"` |
+| `stop` | `"stop"` |
+| null / missing | `"stop"` |
+| `content_filter` | `"stop"` |
+| 未知值 | `upstream_invalid_response` |
+| `tool_calls` / `function_call` 且没有 converted tool calls | `upstream_invalid_response` |
+
+### 5.3 Usage 与 logprobs
+
+存在 nonnegative integer usage 时：
+
+```text
+prompt_eval_count = usage.prompt_tokens
+eval_count        = usage.completion_tokens
+```
+
+Nonstream 缺 `prompt_tokens` 时调用
+`litellm.token_counter(model="", messages=<converted Chat messages>)`；
+缺 `completion_tokens` 时调用
+`litellm.token_counter(model="", text=<converted message content>)`。不得从 `total_tokens` 倒推，也
+不得用 string length 替代该 helper。
+
+Streaming 缺 count 时不调用 tokenizer，terminal 对应 count 固定为 0。
+
+Logprob item：
+
+```text
+OllamaTokenLogprob {
+  token: string
+  logprob: finite number
+  bytes?: integer[] where each 0..255
+}
+
+OllamaLogprob {
+  token: string
+  logprob: finite number
+  bytes?: integer[] where each 0..255
+  top_logprobs?: OllamaTokenLogprob[]
+}
+```
+
+Nested `top_logprobs[]` item 不能再含 `top_logprobs`。任一 item malformed 时整个 logprobs 转换失败，
+不返回部分 array。
+
+### 5.4 Timestamp 与省略字段
+
+Chat `created` 为 finite Unix integer seconds 时转 UTC `time.Time`，再以 Go RFC3339Nano 输出；整秒示例
+是 `2023-11-14T22:13:20Z`，不是 `.000Z`。
+
+Chat `created` 为 null 或缺失时，在开始 nonstream response 转换时读取一次 injected clock。其他
+非法类型返回 invalid upstream response。
+
+不输出：
+
+```text
+id
+remote_model
+remote_host
+_debug_info
+total_duration
+load_duration
+prompt_eval_duration
+eval_duration
+```
+
+## 6. SSE parser
+
+### 6.1 Frame union
+
+```text
+SseFrame =
+  | ChatChunk(JsonObject)
+  | ErrorFrame(JsonObject | string)
+  | Done
+```
+
+Parser 只解析 framing，不生成 Ollama response。Reducer 是 `Done` 的唯一消费者和 terminal 唯一 owner；
+不存在第二个 `finish("done_marker")`。
+
+### 6.2 Wire grammar
+
+1. 非 2xx upstream response 不进入 parser；
+2. 使用单个 incremental UTF-8 decoder；
+3. 只忽略 stream 开头一个 BOM；
+4. 接受 LF、CRLF 和 CR；
+5. 空行结束 event；
+6. comment line 忽略；
+7. field 在第一个 `:` 分割，只移除 value 开头一个 space；
+8. 多个 data lines 用 `\n` 连接；
+9. 无 data 的 event 忽略；
+10. data 精确等于 `[DONE]` 时发 `Done`；
+11. `event:error` 或 JSON object 根含 `error` 时发 `ErrorFrame`；
+12. 其他 data 必须 parse 为单个 JSON object，发 `ChatChunk`。
+
+Parser 进入 done/error 后忽略全部后续 bytes；首个 `[DONE]` 是 absorbing terminal，包括后续普通 data、
+重复 `[DONE]` 和 comments。
+
+EOF 有残余 UTF-8/code point、line、event 或 JSON 时返回 `upstream_stream_truncated`。无残余但未见
+`[DONE]` 时同样返回 `upstream_stream_truncated`，即使此前已收到 finish reason。
+
+## 7. Stream reducer
+
+### 7.1 State
+
+```text
+StreamState {
+  phase: "open" | "finished" | "errored"
+  requestModel: string
+  createdAt: time.Time
+  finishReason?: string
+  usage: {
+    promptTokens?: integer
+    completionTokens?: integer
+  }
+  contentFragments: string[]
+  reasoningFragments: string[]
+  toolCalls: Map<integer, {
+    id?: string
+    name?: string
+    argumentFragments: string[]
+  }>
+}
+```
+
+只消费唯一 `choice.index==0`。Usage-only `choices:[]` 合法；非空 choices 没有 index 0、多个 index 0，
+或 choice/message/delta 类型错误时终止为 upstream error。
+
+Output `model` 始终是 original request model，不采用 upstream Chat model。
+
+构造 stream reducer 时读取一次 injected clock并写入 `createdAt`。所有 chunk 的 `created` 字段忽略。
+
+### 7.2 Content、reasoning 与 logprobs
+
+每个 chunk：
+
+- string `delta.content` 追加 content；
+- key `delta.reasoning_content` 存在时只读取该字段，否则读取 `delta.reasoning`；
+- 两个 reasoning key 都不存在时才启用 LiteLLM stream tag state。对每个 nonempty content
+  fragment 按顺序执行：
+  1. 若此前 `started=true && finished=false`，先置 `finished=true`；
+  2. fragment 含 `<think>` 时删除全部该 substring，并置 `started=true`；
+  3. fragment 含 `</think>` 且 `started=true` 时删除全部该 substring，并置 `finished=true`；
+  4. 最终 `started=true && finished=false` 时作为 thinking，否则作为 content。
+  不识别 `<thinking>`/`<budget:thinking>`，不拼接跨 fragment tag；
+- logprobs 逐 chunk按第 5.3 节转换，不跨 chunk累积。
+
+非 terminal chunk 有 content/reasoning/logprobs 时输出一个 `done:false` object。同一 chunk 的 content
+和 thinking 保留在同一 Ollama message。成功写出后推进各自 cursor；terminal 只包含尚未输出的
+content/thinking，不重复已输出 fragment。
+
+### 7.3 Tool calls
+
+`delta.tool_calls[]` 必须具有非负 integer `index`。按 index：
+
+- 首个 nonempty ID/name 锁定；
+- 后续相同值接受，不同值失败；
+- arguments 只接受 string fragment；
+- 各 index 独立累积。
+
+Tools 不提前输出为 `done:false`。收到 `Done` 时：
+
+1. 按 index 升序；
+2. 拼接 arguments；
+3. parse 为 ordered JSON object；
+4. 构造全部 Ollama tool calls；
+5. 与尚未输出的 terminal content/thinking 一起放在唯一 `done:true` object。
+
+### 7.4 Finish、usage 与 terminal
+
+首个 non-null finish reason 锁定。后续不同值不覆盖并视为 upstream inconsistency。
+
+任意 chunk 的 usage 只接受 nonnegative integers，显式 0 必须保留。每个字段 last-valid-wins；
+后续 chunk 缺字段不清空已有值。
+
+收到 `Done` 时输出恰好一个 terminal object：
+
+```json
+{
+  "model": "<original request model>",
+  "created_at": "<RFC3339Nano>",
+  "message": {
+    "role": "assistant",
+    "content": "<remaining terminal content>",
+    "thinking": "<remaining terminal thinking>"
+  },
+  "done": true,
+  "done_reason": "stop",
+  "prompt_eval_count": 12,
+  "eval_count": 6
+}
+```
+
+- finish `length` → `done_reason:"length"`；
+- nonempty tool calls → `done_reason:"stop"`；
+- missing finish → `"stop"`；
+- `content_filter` → `"stop"`；
+- unknown 或 tool finish 但没有 tool calls → `upstream_invalid_response`；
+- nonempty tool calls 时才输出 `message.tool_calls`；
+- missing usage count 固定为 0；
+- terminal 后清空 buffers，phase=`finished`；
+- 不再输出第二个 terminal 或 error。
+
+`created_at` 在全 stream 使用锁定的同一 time value。
+
+## 8. NDJSON bytes
+
+使用与固定 Ollama DTO 等价的 Go `encoding/json`：
+
+1. root field order：
+   `model,remote_model,remote_host,created_at,message,done,done_reason,_debug_info,logprobs,`
+   `total_duration,load_duration,prompt_eval_count,prompt_eval_duration,eval_count,eval_duration`；
+2. message field order：
+   `role,content,thinking,images,tool_calls,tool_name,tool_call_id`；
+3. tool call：`id,function`；
+4. function：`index,name,arguments`；
+5. `omitempty` fields 完全省略；
+6. compact UTF-8 JSON，每 object 后一个 LF；
+7. Go default HTML escaping：`<`、`>`、`&` 以及 U+2028/U+2029 转义；
+8. string/control escaping、number formatting 和 invalid value failure 匹配 Go `encoding/json`；
+9. ordered tool arguments 保持输入 member order；
+10. 最后一行也必须有 LF，无 BOM/CR/空行。
+
+Error object 只有：
+
+```json
+{"error":"<safe text>"}
+```
+
+## 9. Error boundary
+
+Ollama wire error shape固定为 `{"error":"<safe text>"}`：
+
+| Error | HTTP status | Safe text |
+|---|---:|---|
+| `invalid_request` | 400 | `invalid request` |
+| `unsupported_semantics` | 422 | `unsupported semantics` |
+| `upstream_http_error` | upstream 400..599 status | `upstream request failed` |
+| `upstream_timeout` | 504 | `upstream timeout` |
+| `upstream_stream_error` | 502 | `upstream stream error` |
+| `upstream_invalid_response` | 502 | `invalid upstream response` |
+| `upstream_stream_truncated` | 502 | `upstream stream truncated` |
+| `invalid_tool_arguments` | 502 | `invalid tool arguments` |
+| `invalid_logprobs` | 502 | `invalid logprobs` |
+| `internal_error` | 500 | `internal error` |
+
+- Request 尚未转发时的错误返回单个 JSON error body；
+- streaming response 尚未开始时返回普通 HTTP error；
+- 已输出 NDJSON 后只追加一个 NDJSON error object并关闭；
+- error 后不输出 `done:true`；
+- client abort 释放 state且不写 error/done；
+- 不向 wire 暴露 credential、header、完整 upstream body 或 tool arguments；
+- 不生成旁路 diagnostics。
+
+## 10. 测试要求与完成门槛
+
+### 10.1 Request
+
+- model 必填且无默认；
+- stream 缺失为 true；
+- role lowercase；
+- content/thinking/images；
+- JPEG/PNG/WebP 与 invalid base64/unknown magic；
+- tool ID/index/object arguments、tool_name/tool_call_id；
+- Tool `items` 与固定 schema subset；不存在 `strict`；
+- options mapping、array-only stop、unrepresentable options；
+- format json/schema；
+- think boolean/string；
+- logprobs/top_logprobs；
+- empty messages load/unload boundary。
+- `think:true` 零 upstream call与 422 error。
+
+### 10.2 Nonstream
+
+- unique choice index 0；
+- original request model；
+- content/reasoning/`<think>`；
+- valid/invalid ordered tool arguments；
+- stop/length/tool/missing finish；
+- usage supplied、partial、missing与 token fallback；
+- logprobs；
+- nonstream created present/missing/invalid；
+- omitted metrics/remote/debug/id。
+
+### 10.3 Stream
+
+- every byte split point through multibyte UTF-8、CRLF、multi-data event；
+- usage-only chunk；
+- unique choice index 0；
+- content + thinking in same chunk；
+- parallel sparse tool indexes；
+- tools only on `done:true`；
+- final content/thinking on terminal；
+- first `[DONE]` absorbing；
+- duplicate `[DONE]` and post-DONE data ignored；
+- EOF residual and no-DONE EOF；
+- `content_filter`、unknown finish和无 calls 的 tool finish；
+- one terminal/error/client-abort invariant。
+- stream 初始化 clock 与忽略 chunk created。
+
+### 10.4 Bytes
+
+Golden 必须由固定 Go DTO reference encoder生成并逐 byte比较：
+
+- field order与 omitempty；
+- integer/float；
+- `<>&`、U+2028/U+2029、control chars、emoji和中文；
+- ordered arguments，包括 integer-like keys；
+- each line independently parseable；
+- final LF；
+- error 与 terminal 互斥。
+
+实现完成必须同时满足：
+
+1. request shape与固定 Ollama input语义一致；
+2. response defaults与 LiteLLM兼容规则一致；
+3. NDJSON 与固定 Ollama Go encoder逐 byte等值；
+4. 首个 `[DONE]` 只 finalize一次并吸收后续输入；
+5. 不存在运行时 profile、capability 或 pointer 分支；
+6. 目标仓库 tests 更新为本规范预期，不保留旧 behavior snapshot。

--- a/docs/openai_responses_routing.md
+++ b/docs/openai_responses_routing.md
@@ -1,0 +1,291 @@
+# OpenAI Responses 上游路由规范
+
+> 状态：生产行为规范
+>
+> 固定来源：native capability、GitHub Copilot URL、initiator 和 vision behavior 采用 LiteLLM
+> `ae7e50f096a8722bad14d63b6a0d4634d59bf475`；Copilot client identity 采用本项目固定配置；
+> Chat bridge 采用
+> [Responses → Chat Completions 桥接规范](./codex_response_to_chat_completions.md)
+
+## 1. 范围
+
+本文定义 `POST /v1/responses` 在以下两种执行方式之间的确定性选择：
+
+```text
+NativeResponsesPlan
+ChatBridgePlan
+```
+
+本文负责：
+
+1. 根据已解析的 model routing metadata 选择 plan；
+2. 定义 GitHub Copilot native `/responses` 的 URL 与 request ownership；
+3. 定义 native non-stream、stream、error 和取消边界；
+4. 明确 native 与 Chat bridge 的 history 归属。
+
+本文不重新定义 Responses → Chat 的字段转换，也不定义 `/responses/compact`。
+
+只注册：
+
+```text
+POST /v1/responses
+```
+
+不注册 `/responses`、`/openai/v1/responses` 或 `/v1/responses/compact` aliases。
+
+## 2. Planning interface
+
+```text
+planResponsesExecution(
+  request: ResponsesRequest,
+  model: ResolvedModel,
+  target: BoundCopilotTarget
+) -> NativeResponsesPlan | ChatBridgePlan
+```
+
+```text
+ResolvedModel {
+  requestedModel: string
+  upstreamModel: string
+  routing: ResponsesRoutingMetadata
+}
+
+ResponsesRoutingMetadata {
+  mode?: JsonValue
+  supportedEndpoints?: JsonValue
+}
+
+NativeResponsesPlan {
+  kind: "native_responses"
+  request: ResponsesRequest
+  upstreamModel: string
+  upstreamUrl: string
+  stream: boolean
+}
+
+ChatBridgePlan {
+  kind: "chat_bridge"
+  request: ResponsesRequest
+  upstreamModel: string
+}
+```
+
+Planning 发生在 request converter 之前。Planner 可以读取已绑定账号的 model routing metadata，
+但 Responses → Chat converter 仍不得读取 catalog、默认模型或全局配置。
+
+调用 planner 前必须用与实际 upstream request 相同的 model resolver 得到一个
+`ResolvedModel`。Capability gate 只读取该 resolved model 的 metadata；alias、默认模型或
+deployment mapping 不得在 planning 后再次改变 model。
+
+## 3. Native capability
+
+按以下 first-match-wins 规则判断：
+
+1. `routing.mode === "responses"`：native；
+2. `routing.mode === "chat"`：Chat bridge；
+3. mode 不是上述两个 string，且 `routing.supportedEndpoints` 是 array，其中至少一个成员是精确
+   string `"/v1/responses"`：native；
+4. 其他情况：Chat bridge。
+
+Model metadata lookup error、unknown model 或 malformed routing metadata 都安全回退到 Chat bridge。
+
+不得使用以下条件推断 native：
+
+- `model` 以 `gpt-`、`o` 或 `codex` 开头；
+- model `vendor` 为 OpenAI；
+- CAPI endpoint hostname；
+- 请求中存在 Responses-only 字段；
+- native 请求曾经成功或失败。
+
+原因是部分 `gpt-*` model 明确使用 `mode:"chat"`，而部分 Codex model 才使用
+`mode:"responses"`。
+
+一次请求只 planning 一次；执行过程中 metadata 或默认 model 变化不能改变已选择的 plan。
+
+## 4. Model routing metadata
+
+Model catalog 的公开 DTO 仍只服务 `/v1/models`、Anthropic model list 和 `/api/tags`。
+Routing metadata 是独立的内部 snapshot，不在公开 model response 中输出。
+
+来源优先级：
+
+1. pinned model metadata 的 string `mode`；
+2. 同一 resolved model raw metadata 的 `supported_endpoints`；
+3. unknown。
+
+`mode:"chat"` 是显式 opt-out，优先于 `supported_endpoints`。
+
+不得根据 model ID 维护第二份手写 allowlist。
+
+## 5. Native request
+
+Native plan 不执行：
+
+- history enrichment；
+- Responses → Chat request conversion；
+- Chat `stream_options.include_usage` 注入；
+- Chat ToolContext name flattening；
+- Chat reasoning dialect conversion。
+
+执行顺序：
+
+1. 保存已解析的原始 Responses request；
+2. 使用 planning 前已得到的同一个 `ResolvedModel`；
+3. 将 request 的 `model` 设置为 `ResolvedModel.upstreamModel`；
+4. 保留 Responses-native fields，包括 `previous_response_id`、`store`、`include`、`text`、
+   `truncation`、reasoning items 和 `encrypted_content`；
+5. 使用 Responses request serializer 重新生成 JSON body；
+6. 根据 input 判断 vision 与 initiator headers；
+7. 发起一次 native request。
+
+这不是原始 bytes 透传：HTTP body 已解析、model 已解析并重新序列化。但除明确的 model 替换和
+gateway-private metadata 外，不应用 Chat bridge 的字段丢弃与降级规则。
+
+## 6. Native upstream
+
+GitHub Copilot base URL 由绑定账号的 credential provider 返回。去除末尾 `/` 后追加：
+
+```text
+/responses
+```
+
+例如：
+
+```text
+https://api.githubcopilot.com
+  -> https://api.githubcopilot.com/responses
+```
+
+该 path 采用固定 LiteLLM GitHub Copilot Responses adapter。cc-switch 的另一条
+Anthropic → Copilot flow 使用 `/v1/responses`，不作为本文行为来源。
+
+Native request 使用与 Chat/CAPI 相同的固定 Copilot client identity，并额外支持：
+
+- `openai-intent: conversation-panel`；
+- 每请求唯一的 `x-request-id`；
+- `x-vscode-user-agent-library-version: electron-fetch`；
+- 根据 input 得到的 `x-initiator`；
+- 存在 image input 时的 `copilot-vision-request: true`。
+
+Client identity 的 editor/plugin/API versions 使用本项目固定的
+`vscode/1.110.1`、`copilot-chat/0.38.2` 和 `2025-10-01`，不采用 LiteLLM 固定提交中的旧版本值。
+入站请求不能覆盖 credential 或上述固定 headers。
+
+## 7. Native response
+
+### 7.1 Non-stream
+
+任意 2xx response 必须是一个 Responses JSON object。
+
+Native path：
+
+- 不调用 Chat → Responses converter；
+- 不重新生成 response、item 或 call ID；
+- 不重新计算 usage；
+- 保留上游 Responses body 的字段和顺序语义；
+- 删除 hop-by-hop headers；
+- 若 transport 解压 body，删除失效的 `content-encoding` 和 `content-length`。
+
+Malformed 2xx JSON 或非 object root 是 invalid upstream response。
+
+### 7.2 Stream
+
+上游 `Content-Type` 为 SSE 时使用 native Responses stream pipeline：
+
+```text
+upstream Responses SSE bytes
+  -> Responses SSE framing
+  -> native event validation
+  -> Copilot output-item ID normalization
+  -> Responses SSE serialization
+  -> downstream bytes
+```
+
+Native stream 不经过 Chat SSE decoder，也不经过 Chat → Responses item lifecycle converter。
+但不能完全 raw passthrough：GitHub Copilot 可能为同一 `output_index` 的连续 events 返回不同 item
+IDs，严格客户端会因此无法关联 reasoning/text parts。
+
+每个 native stream 维护独立的：
+
+```text
+Map<output_index, stable_item_id>
+```
+
+规则：
+
+1. `response.output_item.added` 具有 integer `output_index`，且 `item.id` 为 string 时，记录该 ID；
+2. 同一 `output_index` 的后续 event 若顶层 `item_id` 为 string，改写为已记录的 stable ID；
+3. `response.output_item.done` 的 `item` 为 object 时，把 `item.id` 改写为 stable ID；
+4. 未见 added、无合法 output index 或无对应字段时不改写；
+5. 除上述 ID 归一化外，event fields、usage 和 ordering 不变。
+
+State 只存在于当前 native stream。SSE parser 同时读取 usage、ID 和 error 供日志与监控使用。
+
+Backpressure 和 client abort 必须传播到同一个 upstream request。Client abort 不追加 synthetic
+event。
+
+### 7.3 Error
+
+- Non-2xx 保留上游 HTTP status，并使用 Responses-compatible safe error body。
+- 上游 secret headers 和完整 body 不进入日志或公开 message。
+- Native request 失败后不得对同一个 provider 自动改发 `/chat/completions`。
+- 未来的跨账号或跨 deployment retry 必须重新 planning，不能在同一 attempt 中改变 wire mode。
+- 已开始 native stream 后不合成 Chat bridge event 或 `response.failed`。
+
+## 8. History ownership
+
+Native plan 使用 GitHub Copilot Responses 自身的 `previous_response_id`、reasoning
+`encrypted_content` 和 store semantics；不读写本地 Chat-bridge `ResponsesHistory`。
+
+ChatBridgePlan 继续完整执行：
+
+```text
+history enrichment
+-> Responses request to Chat
+-> Chat response/events to Responses
+-> local history record
+```
+
+两种 plan 的 response ID namespace 不混用。本地 history lookup 不能猜测或恢复 native upstream
+response ID。
+
+## 9. Compact
+
+当前不注册 `/v1/responses/compact`：
+
+- LiteLLM 只按 provider 是否有 Responses config 推断 compact，没有 Copilot-specific compact
+  capability；
+- cc-switch 在 Chat/Anthropic mode 下把 compact 改发普通生成 endpoint，不证明真实 compaction；
+- 当前固定源码不能证明 GitHub Copilot CAPI 支持 `/responses/compact`。
+
+只有独立 production spec 固定 capability、URL、request、response 和 fallback 后才能增加该 route。
+
+## 10. Tests
+
+必须覆盖：
+
+- `mode:"responses"` native；
+- `mode:"chat"` 即使 endpoints 包含 Responses 仍 bridge；
+- mode missing + `/v1/responses` native；
+- unknown/malformed/lookup error bridge；
+- `gpt-*`、vendor、hostname 不参与推断；
+- planning 后 metadata 变化不改变当前 request；
+- native URL 精确为 normalized base + `/responses`；
+- native request 保留 Responses-only fields 和 encrypted content；
+- native non-stream 不重写 IDs/usage；
+- native stream 不经过 Chat decoder/converter，但按 `output_index` 统一 added/sub-event/done item IDs；
+- 每个 native stream 的 item-ID map 相互隔离；
+- native failure 不进行 same-provider protocol fallback；
+- native 不读写 local history；
+- bridge path 与原转换规范 fixtures 完全一致；
+- `/responses` aliases 和 compact route 为 404。
+
+## 11. 完成标准
+
+1. Routing 与 LiteLLM GitHub Copilot capability gate 等值。
+2. Chat bridge 行为仍完全由原桥接规范决定。
+3. Native 和 bridge 使用 discriminated plan，不在 stream 中途切换。
+4. 不按 model name 或 vendor 猜测 capability。
+5. Native Responses-only fields 不经过 Chat round-trip；stream 只执行 Copilot 必需的 item-ID
+   归一化。
+6. 本地 history 只服务 ChatBridgePlan。

--- a/docs/research/native_responses_and_anthropic_models.md
+++ b/docs/research/native_responses_and_anthropic_models.md
@@ -1,0 +1,305 @@
+# Native Responses 与 Anthropic Models 调研
+
+## 1. 范围与来源
+
+本文回答两个问题：
+
+1. OpenAI Responses 请求何时可以直接调用上游 `/responses`，而不是转换为
+   `/chat/completions`；
+2. LiteLLM Proxy 如何在模型列表接口返回 Anthropic-compatible shape，以及当前 ghcp-gateway
+   文档是否覆盖。
+
+固定源码：
+
+| Repository | Commit |
+| --- | --- |
+| `BerriAI/litellm` | `ae7e50f096a8722bad14d63b6a0d4634d59bf475` |
+| `farion1231/cc-switch` | `3217f72596f2d1c0f879f0a05f83803825d9809f` |
+| `ljie-PI/ghcp-ollama` | `4fb4608cc4f83f4e9a801123b57a62721699cb9d` |
+
+结论只来自上述源码、tests 及仓库内来源说明，没有发起带凭据的真实 GitHub Copilot 请求。
+
+## 2. Native OpenAI Responses
+
+### 2.1 LiteLLM 总路由条件
+
+LiteLLM 的最终判定不是模型名前缀，而是 provider 是否提供 Responses config：
+
+```text
+native = providerResponsesConfig exists
+         and use_chat_completions_api is not true
+```
+
+否则进入 Responses → Chat Completions bridge。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/responses/main.py:394-420`
+  (`_bridges_to_chat_completions`, `_will_bridge_to_chat_completions`)
+- `BerriAI/litellm@ae7e50f:litellm/responses/main.py:1116-1255`
+- `BerriAI/litellm@ae7e50f:tests/test_litellm/responses/test_responses_api_bridge_flag.py:26-83,113-127`
+
+`use_chat_completions_api=true` 强制 bridge；
+`openai/chat_completions/<model>` 也会规范化为 OpenAI model 并强制 bridge。
+
+OpenAI 官方 provider 总是提供 Responses config，不检查 `gpt-*` 前缀。
+OpenAI-compatible provider 是否 native 取决于 provider 注册方式：
+
+- 声明为 OpenAI provider 且提供自定义 `api_base`：仍直接追加 `/responses`；
+- JSON named provider：`supported_endpoints` 必须明确包含 `/v1/responses`；
+- 无 Responses config：bridge。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/utils.py:8590-8697`
+- `BerriAI/litellm@ae7e50f:litellm/llms/openai_like/json_loader.py:12-24,69-79`
+- `BerriAI/litellm@ae7e50f:litellm/llms/openai_like/providers.json:126-190`
+
+### 2.2 GitHub Copilot 的 native gate
+
+LiteLLM 对 GitHub Copilot 使用以下 first-match-wins 规则：
+
+1. `mode == "responses"`：native；
+2. `mode == "chat"`：bridge，即使同时声明 Responses endpoint；
+3. mode 缺失且 raw model metadata 的 `supported_endpoints` 包含 `/v1/responses`：native；
+4. model unknown、metadata lookup error 或无明确支持：bridge。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/llms/github_copilot/responses/transformation.py:42-75`
+- `BerriAI/litellm@ae7e50f:tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py:390-583`
+
+因此不能使用 `model.startsWith("gpt-")` 或 `vendor == "OpenAI"` 作为充分条件。例如固定 model
+metadata 中部分 `gpt-5*` 模型为 `mode=chat`，而 Codex 型号才是 `mode=responses`。
+
+### 2.3 GitHub Copilot native URL 与请求
+
+LiteLLM 的 GitHub Copilot Responses adapter 按以下优先级取得 base：
+
+1. 显式 `api_base`；
+2. authenticator 的动态 base；
+3. `GITHUB_COPILOT_API_BASE`；
+4. `https://api.githubcopilot.com`。
+
+去除末尾 `/` 后追加 `/responses`，默认得到：
+
+```text
+https://api.githubcopilot.com/responses
+```
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/llms/github_copilot/responses/transformation.py:243-263`
+- `BerriAI/litellm@ae7e50f:litellm/llms/github_copilot/common_utils.py:12-17`
+
+Native 不等于 request bytes 原样透传。LiteLLM 会：
+
+- 只提取 typed Responses 参数；
+- 处理 unsupported/drop params；
+- 解码 managed `previous_response_id` 和 encrypted item ID；
+- 重建 request object；
+- 保留 GitHub Copilot reasoning item 的 `encrypted_content`；
+- 添加 Copilot identity、`X-Initiator` 和 vision headers。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/responses/utils.py:160-286,520-548,620-637`
+- `BerriAI/litellm@ae7e50f:litellm/llms/openai/responses/transformation.py:41-276`
+- `BerriAI/litellm@ae7e50f:litellm/llms/github_copilot/responses/transformation.py:178-234,265-302`
+
+### 2.4 Native response、stream 与错误
+
+LiteLLM non-stream 会构造 `ResponsesAPIResponse`，并包装 response ID；下一轮请求再解码 managed
+ID。Stream 使用 OpenAI Responses SSE decoder，保留 typed events，并统一同一 output index 的
+item ID。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/responses/main.py:1244-1253`
+- `BerriAI/litellm@ae7e50f:litellm/responses/utils.py:309-361,538-548`
+- `BerriAI/litellm@ae7e50f:litellm/responses/streaming_iterator.py:246-390,763-838`
+- `BerriAI/litellm@ae7e50f:litellm/llms/github_copilot/responses/transformation.py:127-180,278-307`
+
+Native HTTP error 由 provider config 映射。Stream 中的 429、5xx 或未知失败可以进入跨 deployment
+fallback，但没有“同一个 provider 的 `/responses` 失败后自动改发 `/chat/completions`”。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/llms/custom_httpx/llm_http_handler.py:5926-5986`
+- `BerriAI/litellm@ae7e50f:litellm/responses/streaming_iterator.py:150-176,497-525`
+- `BerriAI/litellm@ae7e50f:litellm/router.py:4935-4981,6424-6428,7041-7102`
+
+### 2.5 cc-switch 的适用范围
+
+cc-switch 对 Codex/Responses 入站默认选择 native；只有显式配置为 Chat/Anthropic，或 base URL 以
+`/chat/completions` 结尾时才 bridge。它不使用 `gpt-*` 或 `supported_endpoints` gate。
+
+来源：
+
+- `farion1231/cc-switch@3217f72:src-tauri/src/proxy/providers/codex.rs:25-85,162-207`
+
+cc-switch 的 native Responses 路径会 parse JSON、执行 model mapping/normalization、删除私有字段并
+重新序列化。成功 non-stream body 和 stream chunks 基本透传；response ID 与 usage 不做 LiteLLM
+式包装。
+
+来源：
+
+- `farion1231/cc-switch@3217f72:src-tauri/src/proxy/forwarder.rs:1245-1390,1517-1683`
+- `farion1231/cc-switch@3217f72:src-tauri/src/proxy/body_filter.rs:21-125`
+- `farion1231/cc-switch@3217f72:src-tauri/src/proxy/response_processor.rs:70-209,212-337,682-803`
+
+但固定提交中已证实的托管 GitHub Copilot native Responses 是：
+
+```text
+Anthropic Messages input
+  -> live CAPI model vendor routing
+  -> Responses request
+  -> GitHub Copilot /v1/responses
+```
+
+没有找到 OpenAI Responses 入站经 Codex adapter 使用托管 Copilot token 的完整 preset/闭环，因此
+不能用 cc-switch 证明本项目的 OpenAI Responses → GitHub Copilot native transport。
+
+来源：
+
+- `farion1231/cc-switch@3217f72:src-tauri/src/proxy/providers/copilot_auth.rs:190-216,796-903`
+- `farion1231/cc-switch@3217f72:src-tauri/src/proxy/forwarder.rs:2655-2757,3206-3268,4684-4695`
+- `farion1231/cc-switch@3217f72:src-tauri/src/proxy/providers/claude.rs:401-453,755-765,921-967`
+- `farion1231/cc-switch@3217f72:src-tauri/src/proxy/providers/mod.rs:259-283`
+
+### 2.6 `/responses/compact`
+
+LiteLLM 注册 `/v1/responses/compact`、`/responses/compact` 和
+`/openai/v1/responses/compact`。它没有 Chat bridge；provider 无 Responses config 时直接失败，
+并在普通 Responses URL 后追加 `/compact`。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/proxy/response_api_endpoints/endpoints.py:938-1017`
+- `BerriAI/litellm@ae7e50f:litellm/responses/main.py:1959-2079`
+- `BerriAI/litellm@ae7e50f:litellm/llms/openai/responses/transformation.py:623-686`
+
+没有源码证据证明 GitHub Copilot CAPI 支持 compact。cc-switch 在 Chat/Anthropic 模式下把 compact
+请求改发普通生成 endpoint，这不等同于真实 compaction primitive。
+
+### 2.7 对 ghcp-gateway 的结论
+
+- 应支持 `NativeResponsesPlan | ChatBridgePlan`。
+- Native gate 应使用明确 model metadata，不按 `gpt-*` 或 vendor 猜测。
+- 推荐采用 LiteLLM 的 Copilot gate：`mode=responses`、`mode=chat`、再检查
+  `supported_endpoints`，unknown 时安全回退 bridge。
+- Native stream 仍需解析 Responses events，并按 `output_index` 统一到
+  `response.output_item.added.item.id`；不能完全 raw passthrough。
+- Native 与 bridge 在发请求前确定；同一 provider 的 native HTTP 失败不能自动协议降级。
+- `/responses/compact` 暂不注册，直到有 GitHub Copilot capability 和 wire behavior 的独立证据。
+- LiteLLM 使用 `/responses`，cc-switch 的另一条 Copilot flow 使用 `/v1/responses`；实现前必须用
+  可重复测试或官方行为确认最终 CAPI path。
+
+## 3. Anthropic-compatible model list
+
+### 3.1 Route 与 header 判定
+
+LiteLLM 的 `GET /v1/models` 和 `GET /models` 共用 `model_list`，并先执行 API-key auth。
+
+只要 `anthropic-version` header 存在就返回 Anthropic shape：
+
+```python
+request.headers.get("anthropic-version") is not None
+```
+
+它不校验 header 值；空值或任意版本字符串同样触发。Header 缺失时返回默认 OpenAI shape。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/proxy/proxy_server.py:9871-9939`
+- `BerriAI/litellm@ae7e50f:tests/test_litellm/proxy/proxy_server/test_routes_models.py:104-196`
+
+### 3.2 模型来源
+
+Anthropic formatter 接收与默认 OpenAI model list 相同的、已经按当前 credential 权限过滤的完整模型
+列表。它不是向 Anthropic 上游查询官方模型目录，也不按 provider/model name 过滤，所以 GPT 等
+非 Anthropic 模型也会出现。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/proxy/proxy_server.py:9929-10064`
+- `BerriAI/litellm@ae7e50f:litellm/proxy/utils.py:7337-7508`
+- `BerriAI/litellm@ae7e50f:litellm/proxy/auth/model_checks.py:97-244`
+- `BerriAI/litellm@ae7e50f:tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py:2076-2105`
+
+在 ghcp-gateway 中，这对应同一份已经按默认 GitHub Copilot 账号取得并过滤的 CAPI catalog。
+
+### 3.3 Response shape
+
+每个 model：
+
+| Anthropic field | Source |
+| --- | --- |
+| `type` | 固定 `"model"` |
+| `id` | OpenAI-shaped row 的 `id` |
+| `display_name` | 同 `id` |
+| `created_at` | `DEFAULT_MODEL_CREATED_AT_TIME` 转 UTC ISO-8601 `Z` |
+| `max_input_tokens` | row 的 `max_input_tokens` |
+| `max_tokens` | row 的 `max_output_tokens` |
+
+`max_input_tokens` 和 `max_tokens` 是 nullable、非 optional；未知时输出 `null`。
+
+Envelope：
+
+```json
+{
+  "data": [],
+  "has_more": false,
+  "first_id": null,
+  "last_id": null
+}
+```
+
+非空时 `first_id`、`last_id` 分别取第一项和最后一项 ID。实现不分页，不接受 Anthropic cursor；
+始终返回完整权限列表。
+
+来源：
+
+- `BerriAI/litellm@ae7e50f:litellm/llms/anthropic/common_utils.py:1322-1353`
+- `BerriAI/litellm@ae7e50f:litellm/constants.py:1639-1641`
+- `BerriAI/litellm@ae7e50f:tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py:2076-2160`
+
+Header 只改变成功 serializer。认证、invalid scope 或内部错误不自动转换成 Anthropic error envelope。
+
+### 3.4 `/models` alias
+
+LiteLLM 同时注册 `/v1/models` 与 `/models`。ghcp-gateway 当前文档明确只注册 `/v1/models`。
+
+Anthropic-compatible response 不依赖 `/models` alias；在 `/v1/models` 上进行 header content
+negotiation 即可满足 Claude 客户端 discovery。是否增加 alias 是独立兼容性决策。
+
+## 4. 当前文档覆盖度
+
+| Document | Native Responses | Anthropic Models |
+| --- | --- | --- |
+| `docs/codex_response_to_chat_completions.md` | 只完整定义 Chat bridge；缺少 native planner、transport 和 response | 不适用 |
+| `docs/github_copilot_model_listing_apis.md` | 具有 catalog/metadata 基础，但未保留 routing capability | 只有 OpenAI/Ollama serializers；未覆盖 header negotiation |
+| `docs/architecture.md` | 明确所有 Responses 都走 Chat，与 native requirement 冲突 | 只描述 OpenAI `/v1/models` |
+| Ollama/Anthropic conversion specs | 不适用 | 不覆盖 model list |
+
+因此两个问题当前都没有被生产规范完整覆盖。
+
+## 5. 建议修订
+
+1. 在 Responses 生产规范中增加 transport planner，保留现有 Chat bridge 章节不变。
+2. 在内部 model routing metadata 中保留 `mode` 和 `supported_endpoints`；公开 model list 不必暴露。
+3. Architecture 将 Responses upstream 改为 native/bridge discriminated plan，并提供两条 stream
+   pipeline。
+4. Native URL、request normalization、ID strategy 和 error behavior必须在实现前固定；不能只写
+   “passthrough”。
+5. Model catalog 生产规范增加 `anthropic-version` content negotiation 与完整 Anthropic serializer。
+6. 为保持 route 简洁，可继续只注册 `/v1/models`，明确这是相对 LiteLLM 的有意差异。
+7. 暂不注册 `/responses/compact`。
+
+## 6. 尚未解决
+
+- LiteLLM Copilot 使用 `{apiBase}/responses`，cc-switch 的另一条 Copilot flow 使用
+  `{apiBase}/v1/responses`；本地源码不能证明 CAPI 当前接受哪一个或两者都接受。
+- cc-switch 没有证实 OpenAI Responses 入站使用托管 Copilot credential 的完整 native flow。
+- LiteLLM 的 compact gate 不证明 GitHub Copilot CAPI 真实支持 compact。
+- 未执行带真实 credential 的 CAPI probe。


### PR DESCRIPTION
## Summary
- add the normative Ollama, Anthropic, Responses, and model catalog protocol documents
- define the ghcp-gateway TypeScript/Hono architecture, streaming ownership, persistence, and admin UI
- add model-metadata-based GitHub Copilot native Responses routing with a Chat bridge fallback
- add `anthropic-version` model-list content negotiation on `/v1/models`
- record the single `ghcp-gateway` CLI identity, GitHub.com/GHES client settings, and `refactor` delivery strategy

## Research
- compare the fixed LiteLLM and cc-switch implementations for native Responses, stream item-ID normalization, compact behavior, and Anthropic model listing
- capture source citations in `docs/research/native_responses_and_anthropic_models.md`

## Scope
Documentation only; no runtime code or README changes.