### PR TITLE
docs: configure agent skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,208 +1,36 @@
-# AGENTS.md - Developer Guide for AI Coding Agents
+# Agent guide
 
-This guide provides coding standards and workflows for AI agents working in this repository.
+## Sources of truth
 
-## Project Overview
+- **Architecture or refactor work:** read `docs/architecture.md` before changing modules, interfaces, routes, runtime configuration, persistence, CLI behavior, or delivery workflow.
+- **OpenAI Responses routing:** read `docs/openai_responses_routing.md` before changing native Responses selection, Chat bridging, upstream URLs, streaming, IDs, or history ownership.
+- **Responses conversion:** read `docs/codex_response_to_chat_completions.md` before changing Responses <-> Chat request, response, stream, tool, reasoning, or history behavior.
+- **Anthropic conversion:** read `docs/claude_messages_to_chat_completions.md` before changing Messages <-> Chat behavior.
+- **Ollama conversion:** read `docs/ollama_chat_to_chat_completions.md` before changing `/api/chat` behavior or bytes.
+- **Model listing:** read `docs/github_copilot_model_listing_apis.md` before changing credentials, CAPI model fetching, caching, `/v1/models`, or `/api/tags`.
 
-**ghcp-ollama** is a GitHub Copilot proxy providing Ollama, OpenAI, and Anthropic compatible APIs.
-- **Language**: JavaScript (ES Modules)
-- **Runtime**: Node.js >=18.0.0
-- **Package Manager**: npm
-- **Module System**: ESM (`"type": "module"` in package.json)
+The production specifications above override the legacy JavaScript implementation. Do not preserve conflicting legacy behavior.
 
-## Build, Lint & Test Commands
+## Delivery workflow
 
-### Development
-```bash
-npm install              # Install dependencies
-npm start               # Start server (production)
-npm run dev             # Start server with auto-reload (development)
-npm run build           # Build the project
-```
+- Start each refactor change from the latest `refactor` branch and merge it through a pull request targeting `refactor`.
+- Keep `main` unchanged until the final `refactor` -> `main` pull request.
+- Implement one coherent module or route at a time and remove its superseded implementation once its contract tests pass.
+- Update `README.md` only after the runtime, CLI, and migration behavior are complete.
 
-### Linting
-```bash
-npm run lint            # Check code style
-npm run lint:fix        # Auto-fix code style issues
-```
+## Engineering guardrails
 
-### Testing
-```bash
-# Run all tests (unit + integration)
-npm test
+- Keep comments and code documentation in English.
+- Keep credentials and request/response content out of commits, logs, metrics, and public errors.
+- Treat exact protocol fields, ordering, terminal events, and wire bytes as observable behavior.
+- Test through module interfaces; use deterministic clock/UUID inputs and protocol golden fixtures where required.
 
-# Run unit tests only (fast, no server required)
-npm run test:unit
+## Agent skills
 
-# Run integration tests (requires running server)
-npm run test:integration
+### Issue tracker
 
-# Run a single test file
-npx vitest run tests/unit/image_utils.test.js
+Issues and specs are tracked in this repository's GitHub Issues. See `docs/agents/issue-tracker.md`.
 
-# Run tests matching a pattern
-npx vitest run tests/unit/adapters/
+### Domain docs
 
-# Watch mode for test-driven development
-npm run test:watch
-
-# Interactive UI for tests
-npm run test:ui
-
-# Coverage report
-npm run test:coverage
-
-# Generate golden outputs for integration tests
-npm run test:golden
-```
-
-### Server Management
-```bash
-npm run server:start    # Start server as daemon
-npm run server:stop     # Stop server daemon
-npm run server:restart  # Restart server daemon
-npm run server:status   # Check server status
-```
-
-## Code Style Guidelines
-
-### ESLint Configuration
-- **Indentation**: 2 spaces
-- **Quotes**: Double quotes (`"`)
-- **Semicolons**: Required (`;`)
-- **Line endings**: Unix (LF)
-- **Trailing commas**: Only in multiline
-- **Console**: `console.log()` allowed (not an error)
-- **Unused vars**: Error (except params prefixed with `_`)
-
-### Import Style
-```javascript
-// External modules first
-import fs from "fs";
-import path from "path";
-import express from "express";
-
-// Internal modules second
-import { CopilotAuth } from "./utils/auth_client.js";
-import { detectImageType } from "./utils/image_utils.js";
-
-// Always use .js extension in imports (ESM requirement)
-```
-
-### File Organization
-```
-src/
-├── utils/
-│   ├── adapters/           # API format converters
-│   │   ├── base_adapter.js
-│   │   ├── ollama_adapter.js
-│   │   ├── openai_adapter.js
-│   │   └── anthropic_adapter.js
-│   ├── auth_client.js      # GitHub authentication
-│   ├── chat_client.js      # Chat API client
-│   └── image_utils.js      # Image processing
-└── server.js               # Main server
-```
-
-### Naming Conventions
-- **Files**: `snake_case.js` (e.g., `chat_client.js`, `base_adapter.js`)
-- **Classes**: `PascalCase` (e.g., `BaseAdapter`, `OllamaAdapter`)
-- **Functions**: `camelCase` (e.g., `convertRequest`, `parseResponse`)
-- **Constants**: `UPPER_SNAKE_CASE` (e.g., `BASE_URL`, `TIMEOUT`)
-- **Private params**: Prefix with `_` (e.g., `_payload`, `_response`)
-
-### Documentation (JSDoc)
-```javascript
-/**
- * Brief description of function/class.
- * Additional details if needed.
- *
- * @param {string} base64String - Parameter description
- * @param {Object} options - Options object
- * @param {boolean} [options.stream=false] - Optional parameter
- * @returns {string} Return value description
- * @throws {Error} When something goes wrong
- */
-export function detectImageType(base64String) {
-  // Implementation
-}
-```
-
-### Error Handling
-```javascript
-// Always validate inputs
-if (!payload || typeof payload !== "object") {
-  throw new Error("Invalid payload");
-}
-
-// Provide descriptive error messages
-throw new Error("BaseAdapter is an abstract class and cannot be instantiated directly");
-
-// Use try-catch for async operations
-try {
-  const result = await apiCall();
-  return { success: true, data: result };
-} catch (error) {
-  return { success: false, error: error.message };
-}
-```
-
-### Testing Guidelines
-
-**Unit Tests** (`tests/unit/`)
-- No external dependencies (server, network)
-- Use mocks for external services
-- Test file naming: `<module>.test.js`
-- Structure: `describe` > `it` pattern
-- Use fixtures from `tests/unit/fixtures/`
-
-**Integration Tests** (`tests/integration/`)
-- Require running server
-- Test real API endpoints
-- Use golden outputs for comparison
-- Timeout: 30 seconds per test
-
-**Test Structure**
-```javascript
-import { describe, it, expect } from "vitest";
-
-describe("ModuleName", () => {
-  describe("functionName", () => {
-    it("should do something specific", () => {
-      const result = functionName(input);
-      expect(result).toBe(expected);
-    });
-  });
-});
-```
-
-## Critical Rules
-
-1. **All comments MUST be in English** (not Chinese)
-2. **Never commit secrets** (use .env, don't commit .env files)
-3. **Always use ESM imports** (not `require()`)
-4. **Test before committing** (`npm run lint && npm run test:unit`)
-5. **Deep clone fixtures** in tests to avoid mutation between tests
-6. **Coverage target**: 80%+ for adapters, 90%+ for utilities
-
-## Common Tasks
-
-### Adding a new adapter
-1. Extend `BaseAdapter` class
-2. Implement `convertRequest()`, `parseResponse()`, `parseStreamChunk()`
-3. Add unit tests in `tests/unit/adapters/`
-4. Add integration tests in `tests/integration/`
-5. Update `chat_client.js` to use new adapter
-
-### Fixing a bug
-1. Write a failing test that reproduces the bug
-2. Fix the bug in source code
-3. Verify test passes: `npx vitest run path/to/test.js`
-4. Run full suite: `npm run test:unit`
-
-### Adding a new feature
-1. Write unit tests first (TDD approach)
-2. Implement feature
-3. Add integration tests if needed
-4. Update README.md if user-facing
-5. Ensure coverage remains above threshold
+This is a single-context repository using root `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,29 @@
+# Domain Docs
+
+How engineering skills consume this repository's domain documentation.
+
+## Before exploring, read these
+
+- `CONTEXT.md` at the repository root.
+- Relevant ADRs under `docs/adr/`.
+
+If these files do not exist, proceed silently. The `/domain-modeling` skill creates them lazily when terms or decisions are resolved.
+
+## File structure
+
+This is a single-context repository:
+
+```text
+/
+|-- CONTEXT.md
+|-- docs/adr/
+`-- src/
+```
+
+## Use the glossary's vocabulary
+
+When output names a domain concept, use the term defined in `CONTEXT.md`. Avoid synonyms the glossary rejects. A missing concept may indicate either unsuitable terminology or a real gap for `/domain-modeling`.
+
+## Flag ADR conflicts
+
+If work contradicts an ADR, surface the conflict explicitly rather than silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,26 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`.
+- **Read an issue**: `gh issue view <number> --comments`, also fetching labels.
+- **List issues**: use `gh issue list` with the appropriate state/label filters and JSON output.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`.
+- **Apply/remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`.
+- **Close**: `gh issue close <number> --comment "..."`.
+
+Infer the repository from `git remote -v`; `gh` does this automatically inside the clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+GitHub shares one number space across issues and PRs. Resolve a bare `#42` with `gh pr view 42`, then fall back to `gh issue view 42`.
+
+## Skill operations
+
+- "Publish to the issue tracker" means create a GitHub issue.
+- "Fetch the relevant ticket" means run `gh issue view <number> --comments`.
+- `/wayfinder` uses a `wayfinder:map` issue and linked child issues; native GitHub sub-issues and dependencies are preferred, with task-list and `Blocked by:` fallbacks.


### PR DESCRIPTION
## Summary
- replace stale legacy JavaScript guidance with concise refactor source-of-truth pointers
- configure GitHub Issues as the engineering skills issue tracker
- configure a single-context domain documentation layout
- omit triage labels because the triage skill is not installed

## Scope
Documentation and agent configuration only.