### PR TITLE
docs: define ghc-gateway refactor master spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,9 @@
 ## Sources of truth
 
 - **Architecture or refactor work:** read `docs/architecture.md` before changing modules, interfaces, routes, runtime configuration, persistence, CLI behavior, or delivery workflow.
+- **Implementation handoff:** read `docs/specs/refactor_master_spec.md` before claiming or implementing any refactor slice.
+- **Gateway HTTP behavior:** read `docs/gateway_http_contracts.md` before changing listener, request parsing, admission, limits, timeouts, request IDs, or public errors.
+- **OpenAI Chat:** read `docs/openai_chat_completions.md` before changing `/v1/chat/completions` request planning, native Chat responses, SSE, or model resolution.
 - **OpenAI Responses routing:** read `docs/openai_responses_routing.md` before changing native Responses selection, Chat bridging, upstream URLs, streaming, IDs, or history ownership.
 - **Responses conversion:** read `docs/codex_response_to_chat_completions.md` before changing Responses <-> Chat request, response, stream, tool, reasoning, or history behavior.
 - **Anthropic conversion:** read `docs/claude_messages_to_chat_completions.md` before changing Messages <-> Chat behavior.
@@ -15,7 +18,7 @@ The production specifications above override the legacy JavaScript implementatio
 
 - Start each refactor change from the latest `refactor` branch and merge it through a pull request targeting `refactor`.
 - Keep `main` unchanged until the final `refactor` -> `main` pull request.
-- Implement one coherent module or route at a time and remove its superseded implementation once its contract tests pass.
+- Implement one coherent module or route at a time in the non-default TypeScript app. Keep the legacy default runtime intact until the master spec's atomic cutover slice removes it.
 - Update `README.md` only after the runtime, CLI, and migration behavior are complete.
 
 ## Engineering guardrails

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,45 @@
+# GHC Gateway
+
+GHC Gateway exposes several client protocols through one local GitHub Copilot gateway while preserving each protocol's observable behavior.
+
+## Language
+
+**Gateway Foundation**:
+The shared runtime capabilities on which all protocol endpoints and management functions run.
+_Avoid_: Framework, platform layer
+
+**Protocol Endpoint Module**:
+A client-facing protocol slice that owns one route's request planning, response semantics, streaming lifecycle, and wire behavior.
+_Avoid_: Protocol adapter, controller
+
+**Responses Execution Plan**:
+The immutable choice for one Responses request to use the native upstream protocol or the Chat bridge.
+_Avoid_: Runtime profile, fallback mode
+
+**Bound Account**:
+The stable GitHub.com or GHES identity selected for one request and held unchanged for that request's lifetime.
+_Avoid_: Current account, active login
+
+**Responses History**:
+The minimal durable history used by the Chat bridge to reconstruct calls referenced by a later Responses request.
+_Avoid_: Session, conversation log
+
+**Stream Execution**:
+One live inference stream between a client and an upstream model.
+_Avoid_: Session, resumable stream
+
+**Admin Session**:
+The authenticated browser state used to access local management functions.
+_Avoid_: Session
+
+**Semantic Checkpoint**:
+A completed Responses output item whose minimal history is safe to commit durably.
+_Avoid_: Chunk, packet
+
+**Usage Bucket**:
+A content-free aggregate of request, token, error, and latency measurements for one time period and dimension set.
+_Avoid_: Raw telemetry, event log
+
+**Operational Event**:
+A sanitized diagnostic record of a gateway lifecycle transition or administrative action.
+_Avoid_: Request log, audit body

--- a/docs/adr/0001-protocol-endpoint-modules.md
+++ b/docs/adr/0001-protocol-endpoint-modules.md
@@ -1,0 +1,3 @@
+# Use protocol endpoint modules
+
+Each client protocol is implemented as a deep Protocol Endpoint Module rather than through a shared `BaseAdapter` or reversible canonical message model. OpenAI Chat, Responses, Anthropic, and Ollama share transport capabilities, but their field defaults, state transitions, terminal behavior, errors, and exact bytes are materially different; keeping those rules local prevents a common abstraction from becoming a protocol switchboard and limits cross-protocol regressions.

--- a/docs/adr/0002-file-backed-secret-store.md
+++ b/docs/adr/0002-file-backed-secret-store.md
@@ -1,0 +1,3 @@
+# Store secrets in protected files
+
+GHC Gateway stores credentials in a dedicated, atomically replaced regular file under a protected `~/.ghc-gateway` directory, using Unix `0700`/`0600` permissions or Windows ACLs restricted to the current user and rejecting symlink or ownership mismatches. This avoids a mandatory native OS-vault dependency and works in headless environments with lower packaging and memory cost; secrets remain separate from SQLite, logs, metrics, and public errors, while a future credential-store adapter may add OS-vault support.

--- a/docs/adr/0003-clean-break-rename.md
+++ b/docs/adr/0003-clean-break-rename.md
@@ -1,0 +1,3 @@
+# Make the GHC Gateway rename a clean break
+
+The refactor publishes `@ljie-pi/ghc-gateway`, installs the `ghcg` executable, uses `~/.ghc-gateway` and `GHC_GATEWAY_`, and ultimately renames the GitHub repository to `ljie-PI/ghc-gateway`. It does not import old local state or retain `ghcp-ollama`, `ghcp-gateway`, `ghcpo`, or `ghcpo-server` runtime aliases; users authenticate and configure the new application again, which keeps the new storage and command contracts free of permanent migration branches.

--- a/docs/adr/0004-self-managed-daemon.md
+++ b/docs/adr/0004-self-managed-daemon.md
@@ -1,0 +1,3 @@
+# Use a self-managed daemon
+
+The `ghcg` executable provides foreground `serve` plus `start`, `stop`, `restart`, and `status` commands backed by one detached process, a PID file, process start time, instance nonce, and authenticated local control endpoint. It does not require an external or operating-system supervisor and does not keep a watchdog process for automatic restart, trading crash recovery for simpler installation and a lower memory footprint while protecting against stale-PID process termination.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1090,6 +1090,10 @@ History tests 对 temporary SQLite 运行与 production 相同的 implementation
 - Loopback test server 覆盖 streaming、disconnect、redirect、timeout 和 exact bytes。
 - Vitest 覆盖 modules、protocol contracts 和 Admin API；Playwright 用 5–8 个关键流程覆盖 Admin
   bootstrap、六个视图、config update、SSE reconnect 和 destructive confirmation。
+- CI 使用 lockfile-pinned `openai`、`@anthropic-ai/sdk` 和 `ollama` clients 向真实 loopback listener
+  发请求，上游仍为 scripted Copilot；SDK 不 mock，外部网络在 test phase 禁止。
+- Pre-release maintainer 另行运行 guarded `npm run test:live:sdk`，让三个 SDK 通过本地 gateway 请求真实
+  GitHub Copilot；它不进入普通 CI/golden，也不保存模型内容。
 - 正式支持 Node.js 24 的 Windows x64、Linux x64/arm64、macOS x64/arm64。CI 至少覆盖 Windows x64、
   Linux x64、macOS arm64；Linux arm64 与 macOS x64 通过 install/start smoke artifacts。
 - Memory tests验证 repeated request/abort 后 active scope 归零且 RSS 达到稳定平台。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1090,10 +1090,10 @@ History tests 对 temporary SQLite 运行与 production 相同的 implementation
 - Loopback test server 覆盖 streaming、disconnect、redirect、timeout 和 exact bytes。
 - Vitest 覆盖 modules、protocol contracts 和 Admin API；Playwright 用 5–8 个关键流程覆盖 Admin
   bootstrap、六个视图、config update、SSE reconnect 和 destructive confirmation。
-- CI 使用 lockfile-pinned `openai`、`@anthropic-ai/sdk` 和 `ollama` clients 向真实 loopback listener
-  发请求，上游仍为 scripted Copilot；SDK 不 mock，外部网络在 test phase 禁止。
-- Pre-release maintainer 另行运行 guarded `npm run test:live:sdk`，让三个 SDK 通过本地 gateway 请求真实
-  GitHub Copilot；它不进入普通 CI/golden，也不保存模型内容。
+- Official-client integration tests are manual-only：lockfile-pinned `openai`、`@anthropic-ai/sdk` 和
+  `ollama` clients 向真实 loopback listener 发请求，上游可为 scripted Copilot 或显式 live GitHub
+  Copilot。两种 suites 都不进入 CI、default tests、implementation acceptance 或 implement/code-review
+  loop，并分别要求显式 opt-in environment flag。
 - 正式支持 Node.js 24 的 Windows x64、Linux x64/arm64、macOS x64/arm64。CI 至少覆盖 Windows x64、
   Linux x64、macOS arm64；Linux arm64 与 macOS x64 通过 install/start smoke artifacts。
 - Memory tests验证 repeated request/abort 后 active scope 归零且 RSS 达到稳定平台。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,15 +1,17 @@
-# ghcp-gateway 目标架构
+# ghc-gateway 目标架构
 
 ## 1. 文档定位
 
-本文定义 ghcp-gateway 重构后的模块、接口、状态归属、路由、依赖方向和运行时技术栈。
+本文定义 ghc-gateway 重构后的模块、接口、状态归属、路由、依赖方向和运行时技术栈。
 它不重复协议字段映射；以下生产规范仍是可观察行为的唯一来源：
 
 - [Ollama Chat → Chat Completions](./ollama_chat_to_chat_completions.md)
 - [Anthropic Messages → Chat Completions](./claude_messages_to_chat_completions.md)
+- [OpenAI Chat Completions native proxy](./openai_chat_completions.md)
 - [OpenAI Responses → Chat Completions](./codex_response_to_chat_completions.md)
 - [OpenAI Responses 上游路由](./openai_responses_routing.md)
 - [GitHub Copilot 模型列表](./github_copilot_model_listing_apis.md)
+- [Gateway HTTP contracts](./gateway_http_contracts.md)
 
 `docs/cc-switch/` 和 `docs/litellm/` 是来源说明，不是运行时 profile。架构与生产规范冲突时，
 生产规范优先。
@@ -26,7 +28,8 @@
 | 持久化 | SQLite WAL + `better-sqlite3`，显式 SQL migration |
 | 流模型 | `AsyncIterable` + Web `ReadableStream`，pull-based backpressure |
 | JSON | 保留 object member 顺序和 number lexeme 的 wire JSON module |
-| 日志 | 结构化日志；固定容量的运行时日志和指标快照 |
+| Runtime validation | Protocol 使用显式 WireJson decoder；Admin/config 使用 TypeBox，不 coercion |
+| 日志 | 结构化 JSONL；10 MiB × 5，且文件最长保留 7 天 |
 | 分发 | npm；运行时只有一个 Node.js 进程 |
 
 选择 Hono 的原因是它以 Web Standard `Request`/`Response` 为 interface，TypeScript 支持好，
@@ -38,36 +41,59 @@ middleware；协议精确字节输出不使用会改变序列化结果的便捷 
 
 ### 2.1 项目身份与命令
 
-- 项目名称：`ghcp-gateway`。
-- npm package：`@ljie-pi/ghcp-gateway`。
-- npm 只发布一个 executable：`ghcp-gateway`。
-- 新实现不保留 `ghcpo`、`ghcpo-server` 或同名 alias。
-- 配置、日志、PID/service metadata 和 user data directory 使用 `ghcp-gateway` namespace。
+- 项目名称：`ghc-gateway`。
+- npm package：`@ljie-pi/ghc-gateway`，初始版本 `0.1.0`。
+- npm 只发布一个 executable：`ghcg`。
+- 新实现不保留 `ghcp-ollama`、`ghcp-gateway`、`ghcpo`、`ghcpo-server` 或同名 alias。
+- 默认 data directory 为 `~/.ghc-gateway`，环境变量统一使用 `GHC_GATEWAY_` 前缀。
 
 CLI 使用一个 executable 和分组 subcommands：
 
 ```text
-ghcp-gateway serve
-ghcp-gateway status
-ghcp-gateway auth login
-ghcp-gateway auth logout
-ghcp-gateway auth status
-ghcp-gateway models list
-ghcp-gateway models current
-ghcp-gateway models set <model>
-ghcp-gateway admin open
+ghcg serve
+ghcg start
+ghcg stop
+ghcg restart
+ghcg status
+ghcg auth login [--host <domain>]
+ghcg auth login poll <flow-id>
+ghcg auth logout [--account <account-id>]
+ghcg auth status
+ghcg accounts list
+ghcg accounts use <account-id>
+ghcg accounts remove <account-id>
+ghcg models list [--account <account-id>]
+ghcg models current
+ghcg models set <model-id>
+ghcg config get [key]
+ghcg config set <key> <value>
+ghcg admin open
 ```
 
-`serve` 在前台运行并处理 graceful shutdown。后台常驻由 systemd、launchd、Windows Service 或调用方
-process manager 管理，不再维护一个跨平台 PID-file `serverctl` executable。Web 管理页面是配置与
-监控的主要交互界面；CLI 只保留启动、诊断、认证和自动化需要的操作。
+所有 commands 接受 global `--data-dir`，locator priority 为
+`--data-dir > GHC_GATEWAY_DATA_DIR > ~/.ghc-gateway`；不扫描其他目录或端口。只有 `serve/start` 接受
+`--port` 与 `--log-level`。
 
-旧 package、命令和 data path 的一次性迁移策略在实现阶段单独确定，不在运行时长期保留双名称。
-README 在代码、CLI 和迁移行为完成后统一更新，避免文档先于可运行行为。
+`serve` 在前台运行并处理 graceful shutdown。`start` 自行启动一个 detached daemon；
+`stop/restart/status` 使用 PID、process start time、instance nonce 和认证的 loopback control
+endpoint 验证进程身份，不能只凭 PID 终止进程。只有一个 daemon 进程，不保留 watchdog，也不自动
+重启。Web 管理页面是配置与监控的主要交互界面；CLI 负责进程、认证、账号、模型、配置和自动化。
+Foreground `serve` 写 stderr；daemon 写结构化 JSONL，单文件最大 10 MiB，最多 5 个文件且最长
+保留 7 天。Admin Events 读取 SQLite Operational Events，不直接 tail log files。
+
+Control routes 与 public routes 共用同一个 loopback listener，使用 protected
+`X-GHCG-Control-Token`/`X-GHCG-Instance-Nonce`。Linux、Windows、macOS 的 process-start identity、
+stale/conflict/unreachable 状态和 10 秒 graceful-then-verified-force-stop 算法由 master spec 固定。
+Foreground `serve` 与 managed daemon 都发布 protected runtime identity；auth/accounts/models/config/
+admin CLI commands 只调用运行中 gateway 的 control transport，不在第二个进程中打开 SQLite 或 secret
+file。`stop/restart` 只管理 detached daemon。
+
+这是 clean break：不读取或导入旧 data path，用户必须重新登录和配置。README 在代码、CLI 和
+cutover 行为完成后统一更新，避免文档先于可运行行为。
 
 ## 3. 设计目标
 
-1. 完整支持五份生产规范，不用公共抽象改写协议特有语义。
+1. 完整支持七份生产规范，不用公共抽象改写协议特有语义。
 2. raw HTTP/SSE、typed Chat chunks、协议状态机和 downstream wire serialization 各自有明确归属。
 3. 每个请求的状态独占；跨请求状态只能通过显式 interface 修改。
 4. 同一 GitHub Copilot backend 提供 Chat Completions 与 native Responses；Responses planner 决定
@@ -111,27 +137,38 @@ README 在代码、CLI 和迁移行为完成后统一更新，避免文档先于
 - 不注册 `/models`、`/responses`、`/openai/v1/responses`、`/claude/v1/messages`、
   `/v1/responses/compact` 或尾斜杠 alias。
 - Query string 不参与 route 匹配；是否允许具体 query 由对应生产规范决定。
-- `/v1/*`、`/api/chat` 和 `/api/tags` 使用同一个 inference authentication middleware；
-  `/api/version`、`/healthz` 和 `/readyz` 不接收 inference credential。
+- 首版 listener 固定为 loopback；全部 inference routes 不要求 gateway API key。
+- 所有首字节前的解析、限制、admission、timeout 和 error presenter 行为由
+  [Gateway HTTP contracts](./gateway_http_contracts.md) 统一定义。
 
 ### 5.2 管理与运行状态路由
 
 | Method | Route | 用途 |
 | --- | --- | --- |
 | `GET` | `/admin/*` | Svelte 静态管理页面 |
+| `POST` | `/admin/api/v1/auth/bootstrap` | 一次性 token 换取 Admin Session |
+| `GET` | `/admin/api/v1/auth/session` | 当前 Admin Session 与 CSRF metadata |
+| `POST` | `/admin/api/v1/auth/logout` | 注销当前 Admin Session |
 | `GET` | `/admin/api/v1/status` | 版本、uptime、认证状态、活动请求和资源概览 |
-| `GET/PUT` | `/admin/api/v1/config` | 读取和原子更新可公开配置 |
-| `GET/POST` | `/admin/api/v1/accounts` | 账号列表，以及启动 github.com/GHES device flow |
-| `DELETE` | `/admin/api/v1/accounts/:accountId` | 删除指定账号及其关联状态 |
+| `GET` | `/admin/api/v1/usage` | 按小时聚合的 request/token/error/latency 数据 |
+| `GET`/`PUT` | `/admin/api/v1/config` | 读取和 revision-CAS 更新 runtime config |
+| `GET` | `/admin/api/v1/accounts` | 账号与默认账号列表 |
+| `POST` | `/admin/api/v1/device-flows` | 启动 github.com/GHES device flow |
+| `GET` | `/admin/api/v1/device-flows/:flowId` | 轮询 device flow |
+| `DELETE` | `/admin/api/v1/accounts/:accountId` | 移除 credential/preference/cache，保留 identity/usage |
 | `PUT` | `/admin/api/v1/accounts/default` | 原子切换默认账号 |
+| `GET` | `/admin/api/v1/models` | 指定账号的 catalog 与 preferred model |
 | `POST` | `/admin/api/v1/models/refresh` | 显式失效指定账号的 model catalog |
-| `GET/DELETE` | `/admin/api/v1/history` | history 使用量和显式清理 |
-| `GET` | `/admin/api/v1/events` | 管理页面单向监控 SSE |
+| `PUT` | `/admin/api/v1/models/preferred` | revision-CAS 更新账号 preferred model |
+| `GET`/`DELETE` | `/admin/api/v1/history` | Responses History 使用量和显式清理 |
+| `GET` | `/admin/api/v1/events` | 分页读取 Operational Events |
+| `GET` | `/admin/api/v1/events/stream` | 管理页面单向监控 SSE |
 | `GET` | `/healthz` | 进程存活 |
 | `GET` | `/readyz` | SQLite、配置和必要依赖是否完成初始化 |
 
 管理接口使用独立的 `/admin/api/v1` namespace，不能与兼容协议 route 混用 middleware 或错误
-envelope。
+envelope。UI 固定提供 Overview、Accounts、Models、Configuration、Responses History 和 Events
+六个视图。
 
 ## 6. 系统上下文
 
@@ -176,7 +213,7 @@ wire pivot，不是把所有下游协议统一成同一种 domain model。
 ```mermaid
 flowchart TD
     Main[Composition root]
-    Gateway[Gateway module]
+    Gateway[Gateway Foundation]
     Http[Hono host]
     OpenAI[OpenAI Chat module]
     Responses[Responses module]
@@ -211,9 +248,9 @@ flowchart TD
 
 依赖只能沿箭头方向。Protocol modules 不 import Hono、SQLite、`process.env` 或具体 HTTP client。
 
-### 7.1 Gateway module
+### 7.1 Gateway Foundation
 
-Gateway 是进程对外的深 module：
+Gateway Foundation 是进程对外的 deep module：
 
 ```ts
 export interface Gateway {
@@ -223,6 +260,8 @@ export interface Gateway {
 
 export async function createGateway(
   config: Readonly<GatewayConfig>,
+  routes: readonly RouteRegistration[],
+  dependencies: Readonly<GatewayDependencies>,
 ): Promise<Gateway>;
 ```
 
@@ -242,20 +281,40 @@ SQLite 和日志资源。
 
 ### 7.2 Protocol endpoint modules
 
-每个公开推理协议只导出一个 endpoint factory：
+每个公开推理协议导出 endpoint 与 failure presenter，并由 Gateway Foundation 显式注册：
 
 ```ts
+export interface DecodedHttpRequest {
+  readonly url: URL;
+  readonly headers: Headers;
+  readonly body?: WireJsonObject;
+}
+
 export type ProtocolEndpoint = (
-  request: Request,
+  request: Readonly<DecodedHttpRequest>,
   scope: Readonly<RequestScope>,
 ) => Promise<Response>;
+
+export type FailurePresenter = (
+  failure: Readonly<GatewayFailure>,
+  requestId: string,
+) => Response;
+
+export interface RouteRegistration {
+  readonly method: "GET" | "POST" | "PUT" | "DELETE";
+  readonly path: string;
+  readonly admission: "none" | "inference";
+  readonly body: "none" | "wire-json-object";
+  readonly presentFailure: FailurePresenter;
+  readonly endpoint: ProtocolEndpoint;
+}
 ```
 
 ```ts
-createOpenAiChatEndpoint(dependencies): ProtocolEndpoint;
-createResponsesEndpoint(dependencies): ProtocolEndpoint;
-createAnthropicMessagesEndpoint(dependencies): ProtocolEndpoint;
-createOllamaChatEndpoint(dependencies): ProtocolEndpoint;
+createOpenAiChatRoute(dependencies): RouteRegistration;
+createResponsesRoute(dependencies): RouteRegistration;
+createAnthropicMessagesRoute(dependencies): RouteRegistration;
+createOllamaChatRoutes(dependencies): readonly RouteRegistration[];
 ```
 
 这四个 factories 具有相同调用形状，但不继承 `BaseAdapter`，也不要求内部实现同一组
@@ -272,11 +331,12 @@ createOllamaChatEndpoint(dependencies): ProtocolEndpoint;
 6. protocol公开错误映射；
 7. exact clock/UUID/token-counter 调用时机。
 
-Hono route 只做显式注册：
+Gateway Foundation 拥有 body read、WireJson parse、admission 和 commit boundary。各 Protocol Endpoint
+Module 拥有自己的 failure presenter；需要 single header 的协议以 exact value 校验，Fetch 合并后的
+duplicate value 无法通过。Hono route 只做显式注册：
 
 ```ts
-app.post("/v1/responses", (context) =>
-  responsesEndpoint(context.req.raw, createRequestScope(context)));
+registerRoute(app, createResponsesRoute(dependencies));
 ```
 
 固定 route 数量较少，显式注册比 protocol registry 更易读。增加第五种协议时新增一个纵向 module 和
@@ -287,54 +347,29 @@ app.post("/v1/responses", (context) =>
 ```ts
 export interface RequestScope {
   readonly requestId: string;
-  readonly principal: InferencePrincipal;
   readonly signal: AbortSignal;
+  readonly config: Readonly<RuntimeConfigSnapshot>;
 }
 ```
 
-Scope 只包含所有请求都真正需要的宿主信息。Protocol-specific context、ToolContext、reasoning
+Scope 只包含所有请求都真正需要的宿主信息，并在 admission 时捕获 immutable runtime config。
+Protocol-specific context、ToolContext、reasoning
 configuration、original request 和 stream cursors 留在对应 protocol module，不能加入
 `RequestScope`。
 
 ### 7.4 Responses request planning
 
 Responses module 内部必须有一个明确的 request-planning seam；不能让 converter 自行读取 model
-catalog、默认模型或全局配置：
+catalog、默认模型或全局配置。[Responses 上游路由规范](./openai_responses_routing.md) 独占
+`planResponsesExecution(request, resolvedModel, target)` 与
+`NativeResponsesPlan | ChatBridgePlan` 的 canonical definitions；本文件不重新定义 prepared plan。
 
-```ts
-interface ResponsesRequestPlanner {
-  prepare(
-    request: Readonly<ResponsesRequest>,
-    boundCopilot: Readonly<BoundCopilot>,
-    catalog: Readonly<CatalogSnapshot>,
-    signal: AbortSignal,
-  ): Promise<PreparedResponsesRequest>;
-}
+Execution order 是：decode request → bind one account → capture its catalog → resolve one model → bind the same
+account's Copilot target → plan once。Alias、默认模型或 deployment mapping 不得在 planning 后再次改变
+model；不得按 `gpt-*`、vendor 或 hostname 猜测。
 
-type PreparedResponsesRequest =
-  | PreparedNativeResponsesRequest
-  | PreparedChatBridgeRequest;
-
-interface PreparedNativeResponsesRequest {
-  readonly kind: "native_responses";
-  readonly responsesRequest: ResponsesRequest;
-}
-
-interface PreparedChatBridgeRequest {
-  readonly kind: "chat_bridge";
-  readonly chatRequest: ChatRequest;
-  readonly responseContext: ResponseContext;
-  readonly streamContext: StreamContext;
-}
-```
-
-Planner 先用实际 upstream model resolver 得到唯一 `ResolvedModel`，再读取该 model 的 immutable
-routing metadata，并按 [Responses 上游路由规范](./openai_responses_routing.md) 选择 plan。
-Alias、默认模型或 deployment mapping 不得在 planning 后再次改变 model；不得按 `gpt-*`、vendor
-或 hostname 猜测。
-
-Native plan 复用 planning 前的 model selection 结果，直接构造 `PreparedNativeResponsesRequest`，
-不访问本地 history 或 Chat converter。
+Native plan 复用 canonical plan 中的 original request、ResolvedModel、URL 和 stream flag，不访问本地
+history 或 Chat converter。
 
 ChatBridgePlan 继续严格执行原顺序：
 
@@ -346,6 +381,9 @@ ChatBridgePlan 继续严格执行原顺序：
 6. 调用纯 request converter；
 7. 根据已绑定 target 的 host/path 注入 prompt cache key。
 
+Chat request、ResponseContext 与 StreamContext 由 bridge request conversion slice 构造，不属于 planner
+output。Shared Responses DTO/decoder 在 planner、native、history 和 bridge 之前只有一个 owner。
+
 Request、response 和 stream contexts 保持协议规范规定的独立类型；不得合并成通用
 `ProviderContext` 或 `Capabilities`。
 
@@ -355,7 +393,10 @@ Copilot backend 是协议 modules 使用的唯一 remote seam：
 
 ```ts
 export interface CopilotBackend {
-  bindDefault(signal: AbortSignal): Promise<BoundCopilot>;
+  bind(
+    account: Readonly<BoundAccount>,
+    signal: AbortSignal,
+  ): Promise<BoundCopilot>;
 }
 
 export interface BoundCopilot {
@@ -365,15 +406,16 @@ export interface BoundCopilot {
   completeChat(request: Readonly<ChatRequest>): Promise<ChatResponse>;
   openChatStream(request: Readonly<ChatRequest>): Promise<UpstreamByteStream>;
   completeResponses(
-    request: Readonly<ResponsesRequest>,
-  ): Promise<NativeResponsesResponse>;
+    request: Readonly<NativeResponsesUpstreamRequest>,
+  ): Promise<UpstreamByteResponse>;
   openResponsesStream(
-    request: Readonly<ResponsesRequest>,
+    request: Readonly<NativeResponsesUpstreamRequest>,
   ): Promise<UpstreamByteStream>;
 }
 ```
 
-`bindDefault()` 在一次请求内只执行一次默认账号解析。返回的 `BoundCopilot` 固定 account、credential
+`AccountDirectory.bindDefault()` 在一次请求内先选择并固定 `BoundAccount`；model catalog 与
+`CopilotBackend.bind(account, signal)` 必须消费同一个 account。返回的 `BoundCopilot` 固定 credential
 和 target；请求执行期间默认账号变化不能影响它。
 
 Production adapter 隐藏：
@@ -469,7 +511,7 @@ Async iterator 正常结束与 `kind:"done"` 是不同信号。这样可以同�
 - Ollama 对 `[DONE]`、truncation 和唯一 terminal owner 的要求；
 - Anthropic 的 `start/consume/finish` lifecycle；
 - Responses ChatBridgePlan 的 typed chunk iterator 与 item lifecycle；
-- OpenAI Chat 对 raw SSE 的低开销透传。
+- OpenAI Chat 对 shared typed Chat frames 的低开销 OpenAI SSE re-encoding。
 
 Raw SSE module 只处理 bytes、UTF-8、BOM、换行、field、multi-data、error frame 和 `[DONE]`。
 它不生成 Ollama、Anthropic 或 Responses object。Bridge typed converters 永远不读取 `data:` 或
@@ -513,7 +555,8 @@ Stream writer 显式跟踪 `responseCommitted`：
 - Responses Chat bridge converter 独立维护 response、reasoning、message、tool item、output index
   和 `sequence_number`。
 - Responses native stream 不创建 bridge state machine，也不读写本地 Responses history。
-- OpenAI Chat stream 采用 raw fast path；不为透传请求创建其他协议的状态机。
+- OpenAI Chat stream 采用 native fast path，但仍经过 shared incremental Chat SSE parser 和 OpenAI
+  re-encoder；不做 byte-blind passthrough，也不创建其他协议的状态机。
 
 这些状态机不能合并成通用 `StreamTransformer`。
 
@@ -591,7 +634,7 @@ Wire JSON module 是 in-process deep module，负责：
 
 | Module | Request-local state | Shared state | Downstream wire |
 | --- | --- | --- | --- |
-| OpenAI Chat | stream passthrough 与 request metadata | 无 | JSON / OpenAI SSE |
+| OpenAI Chat | request planning、incremental Chat SSE parser 与 terminal | 无 | JSON / normalized OpenAI SSE |
 | Responses native | resolved model、native request、output-index item-ID map | 无 | Native Responses JSON/SSE |
 | Responses Chat bridge | original request、ToolContext、reasoning config、item states、IDs、sequence | Responses history | Converted Responses JSON/SSE |
 | Anthropic | original model、active block、tool partial JSON、pending finish/usage、UUID | 无 | JSON / Anthropic SSE |
@@ -629,14 +672,13 @@ Admin 使用单独的 `ResponsesHistoryAdmin` interface 查询统计和清理，
 
 - SQLite 是 source of truth，重启后 history 仍可恢复。
 - 整个 store 最多 512 个 responses，按全局插入顺序淘汰。
-- TTL 可配置，初始默认 7 天；过期记录在 lookup 时视为不存在。
+- TTL 可配置，默认 7 天；过期记录在 lookup 时视为不存在。
 - `previous_response_id` lookup 优先；call-ID fallback 只在全部未过期记录中唯一命中时使用。
 - Response、ordered call items 和 call-ID index 在一个 transaction 中写入。
 - 启动、lookup 和 record 时清理过期项；正确性不依赖后台 timer。
 - 不增加 read-through memory cache，除非 profiling 证明 SQLite lookup 是瓶颈。
 
-TTL 是此前确认的 gateway 产品要求，但当前 Responses 生产规范只定义 512 条插入淘汰。实施前必须把
-TTL、expiry lookup 和测试写入该生产规范；architecture 不能单方面成为协议行为来源。
+TTL、expiry lookup 和测试同时写入 Responses bridge 生产规范；architecture 不单方面覆盖协议行为。
 
 建议 schema：
 
@@ -664,9 +706,10 @@ INDEX responses(expires_at)
 ```
 
 Chat bridge non-stream 在完整 Responses response 转换成功后、发送成功 body 前提交。Chat bridge
-stream 在 request-local state 中收集规范要求的 completed items，并在发送 `response.completed` 前
-提交；提交失败时不发送成功 terminal。已经发送的中间 events 不回滚，也不合成
-`response.failed`。
+stream 在每个 Semantic Checkpoint 对应的 `response.output_item.done` 发送前同步提交 minimal
+history，并在 `response.completed` 前完成最终事务；提交失败时不发送该 checkpoint 或成功 terminal。
+已经发送的更早 events 不回滚，也不合成 `response.failed`。未完成的 token、reasoning 或 tool
+argument fragments 不持久化，进程重启后不恢复当前 Stream Execution。
 
 ## 13. Model catalog
 
@@ -700,9 +743,14 @@ export interface CopilotModelCatalog {
 不排序、不去重。Responses native capability 只读取固定 routing metadata，不按模型名称或 vendor
 推断。
 
-`CatalogSnapshot.fetchedAt` 在每次成功 fetch 时只读取一次 clock。`DEFAULT_MODEL_CREATED_AT_TIME` 在
-module 初始化时读取十进制环境值，缺失时使用 `1677610602`；该值只影响 `/v1/models` 的兼容字段，
-不参与 cache key。
+OpenAI Chat、Anthropic Messages 和 Responses 共用一次性 model resolution：missing model 只使用当前
+Bound Account 的 valid、仍可见 preferred model；显式 model 必须是 non-empty string 且精确存在于
+captured catalog，否则返回 protocol-native 404 model-not-found，不静默 fallback。Ollama 保持其生产
+规范要求的显式 non-empty model，不使用该 preference fallback。
+
+`CatalogSnapshot.fetchedAt` 在每次成功 fetch 时只读取一次 clock。Logical
+`DEFAULT_MODEL_CREATED_AT_TIME` 在 production 固定为 `1677610602`；tests 可注入替代值。该值只影响
+`/v1/models` 的兼容字段，不参与 cache key，也不是 runtime config。
 
 ## 14. GitHub.com 与 GHES 环境
 
@@ -776,13 +824,20 @@ vision header。它仍使用上表的新 client identity versions，不继承 Li
 
 ### 14.3 Token 与 endpoint 生命周期
 
+- Stable `AccountId` 由 normalized GitHub host 与 immutable numeric user ID 组成；login/display name
+  变化不改变 identity。
+- 默认最多保存 8 个 accounts，配置硬上限为 32。
+- 每个 account 独立保存 preferred model。Catalog refresh 后该 model 不再可见时标记 invalid，并要求
+  用户重新选择，不能静默选择第一项。
 - github.com 使用有效 Copilot session token；剩余时间 `< 60s` 时按账号刷新，恰好 60 秒仍有效。
 - GHES 使用保存的 GitHub OAuth token，不执行 Copilot token exchange。
 - 同账号 token refresh 和 endpoint discovery 分别使用 mutex，并在锁内二次检查。
 - 不使用全局 30 秒 refresh interval；按需刷新减少后台工作和常驻状态。
 - endpoint discovery 的 cache/fallback 规则严格遵守模型目录生产规范。
-- 删除账号或全量退出时清除 credential、endpoint 和 model catalog。Responses history 当前为全局
-  store，只能通过 retention policy 或显式 history clear 删除。
+- 删除账号时清除 credential、preferred model、endpoint 和 model catalog，但保留稳定 account
+  metadata 与 Usage Buckets；同一 identity 再次登录时继续关联原统计。Responses History 当前为全局
+  store，只能通过 retention policy 或显式 history clear 删除。Removed identity 在最后一个 retained
+  Usage Bucket 过期后可清理；deterministic AccountId 仍保证未来重新登录得到同一 key。
 
 ## 15. Persistence 与配置
 
@@ -794,17 +849,22 @@ vision header。它仍使用上表的新 client identity versions，不继承 Li
 - 非 secret account metadata；
 - 默认账号和模型 preference；
 - Web 可修改配置及 revision；
-- Responses history。
+- Responses History；
+- Usage Buckets；
+- Operational Events。
 
-使用 WAL、foreign keys、busy timeout 和短事务。不使用 ORM。`better-sqlite3` 直接位于 persistence
-implementation 内；不创建只有一个 adapter 的 `DatabasePort`。
+使用 WAL、`synchronous=FULL`、foreign keys、busy timeout、单一主线程 connection、prepared
+statements 和短事务。不使用 ORM。事务内禁止网络 I/O 与大型 JSON transformation。
+`better-sqlite3` 直接位于 persistence implementation 内；不创建只有一个 adapter 的
+`DatabasePort`。
 
-`node:sqlite` 达到 stable 前不作为 production dependency。若实测同步 SQLite 操作造成可见
-event-loop stall，可将同一个 history implementation 移入 worker thread；对 protocol module 的
-interface 不变。
+`node:sqlite` 达到 stable 前不作为 production dependency。若真实 workload 的 event-loop delay
+p95 超过 10 ms，才评估将同一个 persistence implementation 移入 worker thread；迁移后必须重新通过
+RSS gate，且 protocol interfaces 不变。
 
 OAuth token、Copilot token 和其他 secrets 不存入普通 settings table。Secret storage 使用独立
-`CredentialStore` seam，production adapter 采用 OS credential vault；tests 使用 memory adapter。
+`CredentialStore` seam；production adapter 在 `~/.ghc-gateway` 使用 atomic replace、Unix `0600`
+或 Windows current-user-only ACL，tests 使用 memory adapter。
 
 ### 15.2 Runtime config
 
@@ -822,6 +882,33 @@ parse
 失败时继续使用旧 snapshot，不能部分应用。Protocol stream 在开始时捕获 snapshot；请求进行中配置
 变化不改变其行为。
 
+配置来源分为：
+
+- Startup config：`CLI > environment > default`，包括 port、data directory 和 log level，只在重启后
+  生效。
+- Runtime config：SQLite 是唯一 source of truth；环境变量只在首次初始化时 seed，包括资源限制与
+  retention。Default account 与 per-account preferred model 使用独立 revisioned stores，不属于
+  `RuntimeConfigSnapshot`。
+
+### 15.3 Usage 与运行事件
+
+Usage Bucket key：
+
+```text
+UTC hour + accountId + protocol + resolvedModel + outcome
+```
+
+每个 bucket 只保存 request/error counts、input/output/cache tokens、latency sum/max 和可计算的聚合
+字段；不保存 request ID、prompt、response、tool arguments 或任意高基数 label。默认保留 90 天，
+最多 100,000 rows，任一限制先到即清理。删除 credential 不删除 bucket；同一 stable account identity
+重新登录后继续关联。
+
+Operational Event 是脱敏 diagnostic metadata，写入 SQLite，默认保留 7 天且最多 512 条。它与
+Responses History 不同，不能用于恢复协议上下文。
+
+Semantic Checkpoint 同步等待 transaction commit。Usage Buckets 和 Operational Events 可由单 writer
+合并为短批次；graceful shutdown 在有界时间内 flush，hard crash 可以丢失尚未提交的非关键批次。
+
 ## 16. 管理页面
 
 ### 16.1 技术栈
@@ -834,7 +921,7 @@ parse
 - 页面较少时不增加 client router，以 tabs/state 切换视图。
 
 构建产物随 npm package 发布，由 Hono 提供 `/admin/*`。浏览器内存不计入 gateway daemon RSS；
-关闭页面后后台不保留前端 session。
+关闭页面后后台不新增持久状态；Admin Session 仍按 idle/absolute timeout 管理。
 
 ### 16.2 功能
 
@@ -844,18 +931,21 @@ parse
 - model catalog 查看和显式 refresh；
 - Responses history 数量、最旧/最新时间、TTL 和清理；
 - 活动请求、活动 streams、请求/错误计数和延迟；
-- 最近固定数量的脱敏日志。
+- 最近 7 天且最多 512 条 Operational Events。
 
-实时状态使用 `/admin/api/v1/events` SSE，不使用 WebSocket。事件只携带聚合状态，不携带 prompt、
+实时状态使用 `/admin/api/v1/events/stream` SSE，不使用 WebSocket。事件只携带聚合状态，不携带 prompt、
 response body、Authorization、OAuth token、Copilot token 或完整 upstream endpoint。
 
 ### 16.3 安全默认值
 
-- 默认只监听 `127.0.0.1`。
-- Public inference routes 使用同一个 inference authentication middleware。
-- Admin routes 使用独立 admin session 和 CSRF token。
-- 一旦允许非 loopback bind，必须配置 admin authentication；TLS 由内置配置或可信 reverse proxy
-  提供。
+- Bind host 固定且仅允许 literal `127.0.0.1`；port 默认 `31400`，可由 startup config 设置。首版显式
+  拒绝 non-loopback bind。
+- Public inference routes 在 loopback 上不要求 gateway API key。
+- 首次启动生成长期 random admin secret。`ghcg admin open` 取得 60 秒、一次性 bootstrap token，
+  换取 `HttpOnly`、`SameSite=Strict` 的内存 Admin Session。
+- Admin Session idle timeout 为 30 分钟，absolute timeout 为 12 小时，daemon 重启后全部失效。
+- Bootstrap exchange 不要求已有 Admin Session/CSRF，但要求精确 Origin 与 valid one-use token；其他所有
+  Admin 写请求同时验证 Admin Session、CSRF token 和精确 Origin。
 - Static catch-all 只能位于 `/admin/*`，不能吞掉 `/v1/*`、`/api/*`、`/healthz` 或 `/readyz`。
 
 ## 17. Error ownership
@@ -867,6 +957,7 @@ type GatewayFailure =
   | { kind: "invalid_request"; cause: unknown }
   | { kind: "unsupported_semantics"; cause: unknown }
   | { kind: "authentication"; cause: unknown }
+  | { kind: "model_not_found"; cause: unknown }
   | { kind: "upstream_http"; status: number; retryAfter?: string }
   | { kind: "upstream_timeout"; cause: unknown }
   | { kind: "upstream_network"; cause: unknown }
@@ -880,31 +971,46 @@ type GatewayFailure =
 规范要求的 HTTP status、body 或 post-commit 行为。转换异常必须保留 `cause`，不能被 broad catch
 改写成成功 response。
 
-Anthropic 和 Responses 转换规范把 pre-commit HTTP status、headers 与 error body 明确交给宿主，
-OpenAI Chat 的宿主错误 contract 也不在现有四份规范中。对应 endpoint 必须各自拥有
-`AnthropicHttpErrorPresenter`、`ResponsesHttpErrorPresenter` 和 `OpenAiHttpErrorPresenter`，但在
-实现前应先补充各 route 的 HTTP error contract。不能用 architecture 文档或一个通用 error envelope
-替代缺失的可观察行为规范。
+首字节前的 HTTP status、headers、request IDs、limits、admission 与各协议 error presenter 由
+[Gateway HTTP contracts](./gateway_http_contracts.md) 定义。各 endpoint 仍分别拥有
+`AnthropicHttpErrorPresenter`、`ResponsesHttpErrorPresenter`、`OpenAiHttpErrorPresenter` 和
+Ollama presenter；共同 failure taxonomy 不能演化成一个公开通用 error envelope。
 
 日志只记录分类、request ID、protocol、status 和脱敏 upstream host。不得记录 token、完整 headers、
 完整 request/response body 或非 2xx upstream body。
 
-## 18. 资源约束
+## 18. 资源与性能约束
 
-- JSON body、单个 SSE event、non-stream response 和 protocol accumulator 都有配置上限。
-- 超限显式失败，不截断、不返回部分成功。
-- 并发 streams 使用有界 semaphore；等待者响应客户端取消。
+以下为可配置默认值：
+
+| Resource | Default |
+| --- | ---: |
+| JSON request body | 32 MiB |
+| Single upstream SSE event | 4 MiB |
+| Non-stream body | 32 MiB |
+| Per-request protocol accumulator | 32 MiB |
+| Active inference requests | 4 |
+| Admission queue | 16 |
+| Admission wait | 30 seconds |
+| Connect timeout | 30 seconds |
+| First-byte timeout | 120 seconds |
+| Stream idle timeout | 120 seconds |
+| Total request timeout | 30 minutes |
+
+Queue full 或等待超时使用协议原生 overload error；等待者响应 client abort。超限显式失败，不截断、
+不返回部分成功。具体 status 与 wire body 由 Gateway HTTP contracts 定义。
+
 - Stream pipeline 不预取，不保存 raw chunk 历史。
 - Responses Chat bridge 只保留生成 terminal response 与 history record 所需的聚合状态；native
   stream 不缓存完整 response。
-- Model catalog cache 按账号有界；账号数量由本地配置约束。
-- Responses history 固定全库最多 512 条并有 TTL。
+- Model catalog cache 由 32 accounts 的硬上限约束。
+- Responses History 固定全库最多 512 条，默认 TTL 7 天。
 - Metrics label 集合固定，不把 request ID、prompt、任意 model string 作为无界 label。
-- 管理日志 ring buffer 和监控订阅者数量有界。
+- Operational Events 与管理监控订阅者数量有界。
 - Token 和 endpoint 采用按需刷新，不使用常驻 polling interval。
 - SQLite cleanup 在启动/read/write 时执行，初版不增加只为 cleanup 存在的 timer。
 
-实现进入迁移前需要使用真实 fixtures 建立 RSS benchmark，至少测量：
+实现进入迁移前需要使用真实 fixtures 建立 benchmark，至少测量：
 
 1. idle；
 2. 单 stream；
@@ -913,8 +1019,24 @@ OpenAI Chat 的宿主错误 contract 也不在现有四份规范中。对应 end
 5. history 从空到 512 条及 cleanup 后；
 6. 管理页面关闭与打开时。
 
-以进程 RSS/Private Bytes/PSS 为主要指标，不能把 V8 `heapUsed`、npm 磁盘大小或浏览器进程内存混为
-gateway 常驻内存。
+验收 gates：
+
+- Idle RSS 不超过 64 MiB。
+- 完成或取消 1,000 个 Stream Executions 并进入稳定状态后，RSS 不超过预热 baseline + 16 MiB。
+- Scripted local upstream 下，buffered request gateway overhead p95 不超过 5 ms。
+- Stream event conversion/forwarding overhead p95 不超过 2 ms。
+- Semantic Checkpoint SQLite commit p95 不超过 5 ms。
+- Event-loop delay p95 不超过 10 ms。
+- 每项 benchmark 连续运行三次均通过。
+
+以进程 RSS/Private Bytes/PSS 为主要内存指标，不能把 V8 `heapUsed`、npm 磁盘大小或浏览器进程内存
+混为 daemon 常驻内存。
+
+Runtime 使用 5 分钟 rolling window。任一 latency gate 连续三个窗口超限时标记 `degraded`，在 Admin
+Overview 显示实际值、阈值和开始时间，并写入一个 Operational Event；连续三个窗口恢复后清除。
+Performance degradation 不使 `/healthz` 或 `/readyz` 失败，也不自动调参或降级协议。Runbook 按原因
+选择批量 noncritical writes、优化 serializer、由用户降低并发，或评估 persistence worker；任何 worker
+变化必须重新通过 RSS gate。
 
 ## 19. Testing architecture
 
@@ -935,7 +1057,7 @@ wire behavior 不需要通过 private methods 测试。
 
 必须包含：
 
-- 五份生产规范要求的 differential/golden fixtures；
+- 七份生产规范要求的 differential/golden fixtures；
 - Ollama Go-compatible byte golden；
 - Anthropic Python JSON/SSE text golden；
 - Responses item lifecycle、ToolContext、sequence 和 history round-trip；
@@ -946,13 +1068,15 @@ wire behavior 不需要通过 private methods 测试。
 - abort、timeout、post-commit failure 和零 upstream call；
 - missing/null/false/0/empty 与 object member order；
 - deterministic clock 和 UUID。
+- 全部 CI fixtures 离线运行，不读取本机 LiteLLM/cc-switch checkout，也不调用真实 remote API。
+- Differential/golden generators 只作为显式维护命令运行；生成的完整 expected outputs 提交到仓库。
 
 ### 19.2 Ports 与 adapters
 
 | Seam | Production adapter | Test adapter |
 | --- | --- | --- |
 | Copilot backend | Fetch/Undici | Scripted in-process backend |
-| Credential store | OS credential vault | Memory store |
+| Credential store | Protected secret file | Memory store |
 | Responses history | SQLite WAL | SQLite temporary database |
 | Clock | System clock | Fixed/sequence clock |
 | UUID | `crypto.randomUUID()` | Sequence UUID |
@@ -964,7 +1088,10 @@ History tests 对 temporary SQLite 运行与 production 相同的 implementation
 
 - Hono `app.request()` 覆盖 route、middleware、headers 和 buffered responses。
 - Loopback test server 覆盖 streaming、disconnect、redirect、timeout 和 exact bytes。
-- Windows、Linux、macOS CI 覆盖 npm package 与 native SQLite dependency。
+- Vitest 覆盖 modules、protocol contracts 和 Admin API；Playwright 用 5–8 个关键流程覆盖 Admin
+  bootstrap、六个视图、config update、SSE reconnect 和 destructive confirmation。
+- 正式支持 Node.js 24 的 Windows x64、Linux x64/arm64、macOS x64/arm64。CI 至少覆盖 Windows x64、
+  Linux x64、macOS arm64；Linux arm64 与 macOS x64 通过 install/start smoke artifacts。
 - Memory tests验证 repeated request/abort 后 active scope 归零且 RSS 达到稳定平台。
 
 ## 20. 建议目录
@@ -972,6 +1099,11 @@ History tests 对 temporary SQLite 运行与 production 相同的 implementation
 ```text
 src/
   main.ts
+  version.ts
+  cli/
+    main.ts
+    daemon.ts
+    commands/
   gateway/
     create_gateway.ts
     request_scope.ts
@@ -1015,6 +1147,9 @@ src/
     database.ts
     account_store.ts
     responses_history.ts
+    usage_buckets.ts
+    operational_events.ts
+    credential_store.ts
     migrations/
 
   serialization/
@@ -1025,6 +1160,7 @@ src/
     api.ts
     auth.ts
     metrics.ts
+    contracts.ts
 
 web/
   src/
@@ -1095,21 +1231,25 @@ Web Stream 集成，同时让 protocol modules 保持 Fetch-standard interface�
 - 不在 `main` 上直接 commit 或 push 重构改动。
 - 重构完成、协议 contracts 和 migration 验收通过后，再单独创建 `refactor -> main` 的最终 PR。
 - README 更新属于最后阶段的独立改动，与最终代码和命令行为一起进入 `refactor`。
+- 最终 release 完成后再把 GitHub repository 重命名为 `ljie-PI/ghc-gateway`；implementation agents
+  不提前修改 remote repository identity。
 
 ### 23.2 实施顺序
 
-建议按以下顺序实施，但每一步都以对应生产规范 tests 为完成条件：
+实施 slice、dependency DAG、每项 tests 和 cutover gates 由
+[Refactor master spec](./specs/refactor_master_spec.md) 定义。总体 tracer-bullet 顺序为：
 
-1. strict TypeScript、Wire JSON 和 composition root；
-2. Copilot environment、credential 和 backend；
-3. model catalog、Responses routing metadata、`/v1/models` 三种 serializers 和 `/api/tags`；
-4. raw SSE framing、cancellation 和 backpressure；
-5. OpenAI Chat raw path；
-6. Ollama endpoint；
-7. Anthropic endpoint；
-8. Responses native/bridge planner、native transport、Chat bridge 与 SQLite history；
-9. Admin API 和 Svelte UI；
-10. 删除旧 JavaScript adapters、callbacks 和重复配置。
+1. Specification Closure；
+2. RSS/toolchain gate；
+3. Gateway Foundation；
+4. Credentials 与 Model Catalog；
+5. OpenAI Chat；
+6. Ollama；
+7. Anthropic；
+8. Responses native、Chat bridge 与 Responses History；
+9. CLI/daemon 与 Admin；
+10. final cutover、legacy removal、README 和 release。
 
-迁移期间不长期维护两套生产行为。一个 route 的新 contract tests 完成后整体切换该 route，并删除旧
-implementation。
+迁移期间新 TypeScript app 使用非默认入口，且不能 fallback 到 legacy handlers。Legacy default runtime
+在 final cutover 前保持完整可运行；cutover 一次切换 package/bin/scripts 并删除全部旧
+implementation，不逐 route 修改默认生产入口。

--- a/docs/claude_messages_to_chat_completions.md
+++ b/docs/claude_messages_to_chat_completions.md
@@ -31,6 +31,14 @@
 本文转换核心不解析 HTTP body 或原始 SSE bytes。宿主负责 JSON/SSE framing、解压、body limit、
 认证、重试和路由；转换核心接收本节规定的已解析值。
 
+`POST /v1/messages` 的宿主必须按
+[Gateway HTTP contracts](./gateway_http_contracts.md) 要求恰好一个
+`anthropic-version: 2023-06-01`；该 header 不进入 Chat request。
+
+进入 converter 前，宿主按 captured Bound Account catalog 解析 model：property 缺失时只使用 valid
+preferred model；显式 model 必须是 non-empty string 且精确可见，未知显式 ID 返回 404，且不 fallback
+preference。Resolved model 写入 converter input，并在请求期间保持不变。
+
 ## 2. 逻辑接口
 
 ```text

--- a/docs/codex_response_to_chat_completions.md
+++ b/docs/codex_response_to_chat_completions.md
@@ -36,6 +36,10 @@
 
 转换核心不接收原始 HTTP body 或 SSE bytes。宿主负责 JSON/SSE framing、压缩、body limit、
 认证、重试和路由。本文 stream converter 接收上游已经解析的 typed Chat chunks。
+首字节前的 HTTP limits、admission、timeout 和公开 errors 由
+[Gateway HTTP contracts](./gateway_http_contracts.md) 定义。
+Typed Responses events 的 downstream media type、`event:`/`data:` bytes、terminal 与 EOF behavior 由
+[Responses 上游路由规范](./openai_responses_routing.md#75-downstream-responses-sse-wire) 定义。
 
 ## 2. 逻辑接口与上下文
 
@@ -562,6 +566,10 @@ model catalog 或目标仓库全局配置。
 HistoryStore：
 
 - 最多 512 个 response，按插入顺序淘汰；
+- 默认 TTL 为 7 天，可由 runtime config 修改；
+- TTL 从 response 首次记录时间计算，不因 lookup 滑动；
+- 启动、lookup 和 record 前清理过期 response；过期项不参与 scoped lookup 或全局唯一 fallback；
+- TTL 缩短时立即按首次记录时间清理现有数据；延长不能恢复已删除数据；
 - 每个 response 保存有序 call items 和 `call_id -> item`；
 - 全局保存 `call_id -> response IDs`；
 - 只缓存 `function_call`、`custom_tool_call`、`tool_search_call`；
@@ -584,9 +592,10 @@ Enrichment：
 
 原 input 是单 object 且未变化时保持 object；发生恢复后可变为 array。
 
-非流成功后从完整 Responses response 记录。流式路径从已转换的
-`response.output_item.done`/`response.completed` 记录。由于响应采用 LiteLLM，能记录的类型受
-第 12 节组合损失限制。
+非流成功后从完整 Responses response 记录。流式路径把每个已转换
+`response.output_item.done` 视为 Semantic Checkpoint，在向客户端发送该 event 前同步提交 minimal
+history；`response.completed` 前提交最终 response state。未完成的 delta/fragments 不记录。由于
+响应采用 LiteLLM，能记录的类型受第 12 节组合损失限制。
 
 ## 9. 非流式 Chat response
 
@@ -991,7 +1000,7 @@ HTTP status、error body、raw SSE error event 和 credential redaction 由宿�
 | Tool output media | depth 32、8 KiB threshold、parallel flush |
 | Tools | trimmed names、function schema、namespace hash、custom/tool-search精确description、collision |
 | Reasoning config | null/defaults、explicit disable、supportsEffort override、unknown effort、五种 mode |
-| History | 512 eviction、scoped lookup、unique global fallback、ambiguous call ID |
+| History | 512 eviction、7-day/default configurable TTL、启动/read/write cleanup、scoped lookup、unique global fallback、ambiguous call ID、Semantic Checkpoint durability |
 
 ### 14.2 Response differential
 

--- a/docs/gateway_http_contracts.md
+++ b/docs/gateway_http_contracts.md
@@ -1,0 +1,706 @@
+# Gateway HTTP 公开契约
+
+> 状态：normative production contract
+>
+> 本文定义公开 HTTP wire behavior。除本文明确交给协议生产规范的部分外，实现、测试和后续重构都必须
+> 遵守本文；当前或历史 JavaScript 实现不是行为来源。
+
+## 1. 范围、术语与优先级
+
+本文只规定公开兼容路由的：
+
+- listener 与 route surface；
+- request media type、JSON parsing、版本 header 和 body limit；
+- inference admission、timeout 与 response commit boundary；
+- 首字节前的 failure taxonomy、HTTP status、headers 和协议 error presenter；
+- 首字节后的 failure/abort closure；
+- `Retry-After`、request ID 与公开错误的安全边界。
+
+本文不重复 request/response conversion mapping。成功 response、SSE/NDJSON event、字段顺序、tool、
+reasoning、usage、terminal 和 exact protocol bytes 仍分别由以下生产规范定义：
+
+- [OpenAI Responses 上游路由](./openai_responses_routing.md)
+- [Responses → Chat Completions](./codex_response_to_chat_completions.md)
+- [OpenAI Chat Completions native proxy](./openai_chat_completions.md)
+- [Anthropic Messages → Chat Completions](./claude_messages_to_chat_completions.md)
+- [Ollama Chat → Chat Completions](./ollama_chat_to_chat_completions.md)
+- [GitHub Copilot 模型列表](./github_copilot_model_listing_apis.md)
+
+发生冲突时使用以下优先级：
+
+1. 本文对 HTTP host、pre-commit error、limits、admission、timeouts、request IDs 和
+   `Retry-After` 的明确规定；
+2. route 对应的生产规范对 success、conversion、protocol stream 和本文明确引用的 error behavior
+   的规定；
+3. [目标架构](./architecture.md) 对 module ownership 与内部依赖的规定；
+4. 固定 primary source 只作为上述规范的行为出处，不形成可在运行时切换的 profile。
+
+`pre-commit` 指 downstream response body 的第一个 byte 尚未写给 client；`post-commit` 指至少一个
+downstream response body byte 已写出。设置内部状态、取得 upstream headers 或构造 `Response`
+object 不得被当成已经 commit。
+
+本文是公开 wire contract，不是稳定的内部 `GatewayFailure`、`TransformError` 或 `BridgeError`
+DTO。实现可以重构内部 discriminated union，但不得因此改变本文的 status、headers、body 或
+post-commit closure。
+
+当本文和被引用规范都没有确认某项行为时，不得从 SDK、旧代码或相似 route 猜测。特别是 scheduler
+公平性、未匹配 route 的 error body、HTTP/1.1 与 HTTP/2 选择、CORS，以及未明确允许的 query
+semantics，不属于本文的稳定契约。
+
+## 2. Listener 与 route matrix
+
+### 2.1 Listener
+
+- 唯一允许的 bind host 是 literal `127.0.0.1`；startup port 默认 `31400`，可配置为 `1..65535`。
+- 首个 production release 必须拒绝 non-loopback bind，而不是在 non-loopback 上降级运行。
+- 下表中的公开兼容路由不要求 gateway API key。缺少 `Authorization`、`x-api-key` 或其他 client
+  credential header 不能触发 gateway authentication error。
+- GitHub/Copilot credential 由 gateway 自己的 Bound Account 提供。入站 header 不得覆盖或成为
+  upstream credential。
+
+这里的“无 gateway key”不等于 gateway 必有可用 GitHub/Copilot account。账号不存在、credential
+无效或 upstream 拒绝仍按各 presenter 返回 authentication/permission failure。
+
+### 2.2 受本文约束的 routes
+
+| Method | Path | Request | Success wire owner | Pre-commit error owner | Inference admission |
+| --- | --- | --- | --- | --- | --- |
+| `POST` | `/v1/chat/completions` | OpenAI Chat JSON object | OpenAI Chat native proxy spec | OpenAI presenter | 是 |
+| `POST` | `/v1/responses` | OpenAI Responses JSON object | native Responses 或 Chat bridge 规范 | OpenAI presenter | 是 |
+| `POST` | `/v1/messages` | Anthropic Messages JSON object | Anthropic JSON/SSE 规范 | Anthropic presenter | 是 |
+| `POST` | `/api/chat` | Ollama Chat JSON object | Ollama JSON/NDJSON 规范 | Ollama presenter | 是 |
+| `GET` | `/v1/models` | 无 JSON request contract | Model listing 规范；header presence 可选择 Anthropic success serializer | 始终为 OpenAI model-list presenter | 否 |
+| `GET` | `/api/tags` | 无 JSON request contract | Ollama model-list serializer | Ollama model-list presenter | 否 |
+
+`GET /api/version`、`GET /healthz`、`GET /readyz` 与 `/admin/*` 由 architecture 注册，但其 success
+payload、admin authentication 和管理错误不由本文定义，也不进入 inference admission。
+
+不得注册 `/models`、`/responses`、`/openai/v1/responses`、`/claude/v1/messages`、
+`/v1/responses/compact`、`/v1/ollama/*` 或尾斜杠 alias。上述 alias 必须为未匹配 route；除已有生产
+规范明确要求 404 外，未匹配 route 的 body 不在本文中稳定化。
+
+`GET /v1/models` 和 `GET /api/tags` 的 query string 不得绕过 model catalog cache 或改变结果。其他
+route 的 query semantics 只有在对应生产规范明确规定时才成立。
+
+### 2.3 Probe routes
+
+Probe routes do not bind an account、consume inference admission or contact upstream。All responses use
+`Content-Type: application/json; charset=utf-8` and `Cache-Control: no-store`。
+
+| Route | Status | Exact compact body |
+| --- | ---: | --- |
+| `GET /api/version` | 200 | `{"version":"0.1.0"}` |
+| `GET /healthz` | 200 | `{"status":"ok","version":"0.1.0"}` |
+| `GET /readyz` when ready | 200 | `{"status":"ready"}` |
+| `GET /readyz` when not ready | 503 | `{"status":"not_ready"}` |
+
+Version is the target `ghc-gateway` package version from the refactor build's single version source；it is not an Ollama
+compatibility version and must equal `package.json` at final cutover。
+
+Ready means startup config is valid、SQLite is open at the current migration set、the protected credential-store path
+has passed permission checks、runtime config snapshot exists and the host can accept requests。It does not require an
+authenticated account or successful remote probe。Runtime performance `degraded` remains ready。A functional loss of any
+required local dependency changes readiness to not-ready；the body never exposes which dependency failed。
+
+Only exact GET routes are registered。Other methods and trailing-slash variants are unmatched。Probe bodies do not
+include public request-ID headers。
+
+## 3. Request parsing、版本与 media type
+
+### 3.1 JSON requests
+
+四个 `POST` route 只支持 JSON object：
+
+1. 支持的 request media type 是 `application/json`；`application/json; charset=utf-8` 也是受支持
+   的明确形式。Media type 与 parameter name/value 按 HTTP 规则大小写不敏感。
+2. 其他 media type、显式非 UTF-8 charset 或无法解析的 `Content-Type` 是
+   `unsupported_media_type`。不得把 `text/plain`、`application/*+json` 或缺少 JSON media type
+   的 body 猜成 JSON。
+3. `Content-Encoding` 只允许缺失或单个 `identity`；gzip、brotli、deflate、重复/合并值和未知
+   encoding 都是 `unsupported_media_type`，gateway 不解压 inbound body。
+4. 空 body、malformed JSON、JSON root 不是 object，以及 route schema validation failure 都是
+   `invalid_request`。
+5. Gateway 必须先得到一个完整、合法、受限的 wire JSON value，之后才进入 route conversion。Member
+   order、number lexeme、missing/null/false/0/empty 的处理继续由 Wire JSON module 与对应协议规范
+   决定。
+6. 同一 request 同时具有多个错误时，除本文明确规定外不稳定其检查先后；contract tests 必须用单一
+   fault 验证 presenter。
+
+JSON request body 默认上限为 `32 MiB`，即 `33,554,432` bytes。当前 snapshot 上限值本身合法；读取第
+`33,554,433` 个 byte 时必须停止处理，取消尚未完成的读取，并以 `body_too_large` 失败。不得截断后
+继续 parse，也不得调用 upstream。
+
+普通 JSON success 与所有 pre-commit error response 都必须设置：
+
+```http
+Content-Type: application/json; charset=utf-8
+```
+
+所有 error response 还必须设置：
+
+```http
+Cache-Control: no-store
+```
+
+Stream success 的 media type 与 exact bytes 由对应协议规范定义；stream request 在 pre-commit 失败
+时仍返回普通 JSON，而不是 SSE/NDJSON error framing。
+
+### 3.2 `anthropic-version`
+
+`POST /v1/messages` 必须在 raw inbound headers 中恰好有一个大小写不敏感的
+`anthropic-version` field，去除 HTTP optional whitespace 后其值必须恰好为：
+
+```text
+2023-06-01
+```
+
+Missing、empty、其他版本、重复 field 或由多个值合并而成的 field 都返回 Anthropic
+`400 invalid_request_error`，且零 upstream call。该 header 只用于 inbound version validation，
+不得转发到 Chat Completions upstream。
+
+`GET /v1/models` 的规则有意不同：只要 `anthropic-version` header 存在，就选择 Anthropic success
+serializer；不校验 value，empty、未知或合并 value 也只表示“存在”。它不改变任何 failure 的 status、
+headers 或 body；model-list failure 始终使用 OpenAI model-list presenter。
+
+## 4. Admission、limits 与 timeouts
+
+本节数值是 runtime config defaults，不是 immutable constants。每个 request 在 admission 时捕获一个
+immutable snapshot；同一 Stream Execution 不观察后续修改。Config keys、hard min/max 与 fixed
+process capacities 由 [Master Spec](./specs/refactor_master_spec.md#72-config) 的 registry 定义。
+本节所有 boundary assertions 同时适用于 default 和一个非默认合法 snapshot。
+
+### 4.1 Inference admission
+
+四个 inference `POST` route 共用一个 process-wide admission gate：
+
+| Resource | Default |
+| --- | ---: |
+| Active inference requests | 4 |
+| Queued inference requests | 16 |
+| Maximum queue wait | 30 seconds |
+
+- Active slot 覆盖一次 inference execution 的完整生命周期，包括 non-stream response 完成或 stream
+  结束、失败、timeout、client abort。
+- 在默认配置下，第 5 个到第 20 个尚未取得 slot 的 request 可以等待；已有 16 个 waiter 时，新 request 立即
+  `queue_full`。
+- Waiter 自进入 queue 起等待达到 captured `timeouts.queueMs` 仍未取得 slot 时为 `queue_timeout`。它是 overload，不是
+  upstream timeout。
+- Client abort 必须从 queue 移除 waiter、释放 listener/timer，并产生零 response bytes。
+- Active request 完成、失败或 abort 后必须恰好释放一次 slot。
+- 本文不规定 FIFO、LIFO 或跨协议公平性；实现不得让该内部选择改变容量、30 秒期限或 abort 语义。
+
+Overload wire behavior：
+
+| Route family | `queue_full` / `queue_timeout` status | Error type/shape |
+| --- | ---: | --- |
+| OpenAI Chat / Responses | 503 | `api_error` |
+| Anthropic Messages | 529 | `overloaded_error` |
+| Ollama Chat | 503 | `{"error":"server overloaded"}` |
+
+这些都是 local、非 429 failure。即使 gateway 能估计等待时间，也不得生成 `Retry-After`。
+
+Model-list routes 不消费 inference slot；它们的 account binding、model fetch、cache、cancellation
+与错误完全服从 model listing 规范。
+
+### 4.2 Buffer limits
+
+| Buffer | Default maximum |
+| --- | ---: |
+| JSON request body | 32 MiB |
+| Single upstream SSE event | 4 MiB |
+| Upstream non-stream body | 32 MiB |
+| Per-request protocol accumulator | 32 MiB |
+
+所有上限均为 inclusive。Inbound 不支持压缩，request limit 按收到的 body bytes 计数；upstream
+limit 按 transport 解码后交给 protocol layer 的 bytes 计数。超限必须立即失败、停止继续积累并取消
+相应 upstream body；不得截断、丢 event 后继续，或返回部分成功。
+
+- Request body 超限按各协议的 request presenter 处理。
+- 在 downstream commit 前发现 upstream SSE event、non-stream body 或 protocol accumulator 超限，
+  对 OpenAI/Anthropic 属于 invalid upstream response；Ollama 必须使用其生产规范对应的
+  `upstream_stream_error`、`upstream_invalid_response` 等分类，不得被通用名称覆盖。
+- 在 downstream commit 后发现 stream event 或 accumulator 超限，按第 5.2 节的 protocol-local
+  post-commit behavior 处理，不能改写已经发送的 HTTP status。
+- Model-list CAPI non-stream body 也受 32 MiB 上限约束；超限按 model listing 规范的 CAPI
+  parse/fetch failure，以 model-list presenter 返回 502。
+
+单个 SSE event 上限针对 framer 在一个 event boundary 内必须保留的全部 bytes；byte split、CRLF/LF、
+多个 `data:` line 或 multibyte UTF-8 不能绕过限制。Protocol accumulator 指为生成当前 protocol
+terminal/history 所保留的 request-local aggregate，不允许通过分片形成无界内存。
+
+### 4.3 Inference timeouts
+
+| Timer | Default | Failure |
+| --- | ---: | --- |
+| Upstream connect | 30 seconds | `upstream_timeout` |
+| Upstream first byte | 120 seconds | `upstream_timeout` |
+| Upstream stream idle | 120 seconds | `upstream_timeout` |
+| Active inference total | 30 minutes | `upstream_timeout` |
+
+- Connect timer 限制建立 upstream connection；即时 DNS、connection 或 TLS failure 是
+  `upstream_network`，timer 到期才是 `upstream_timeout`。
+- First-byte timer 要求 upstream 在期限内开始 response；它不能因先向 downstream commit SSE headers
+  或 comment 而被规避。
+- Stream idle timer 在每次收到 upstream body bytes 后重新计时。它只适用于尚未结束的 stream。
+- Total timer 从 request 取得 active slot 并开始 execution 时计时，到完整 success、failure 或 abort
+  为止；queue wait 使用独立的 30 秒期限。
+- 任一 timer 触发都必须 abort 同一个 upstream operation并释放 timer、body、socket 与 active slot。
+- Client abort 不是 timeout，并始终抑制新增 response bytes。
+
+Model catalog transport 是明确例外：它继续使用 model listing 规范中的 30 秒 connect timeout 与
+600 秒 total timeout，并按该规范映射为 model-list error；不得套用 inference 的 120 秒/30 分钟
+presenter。
+
+## 5. Response commit boundary
+
+### 5.1 Pre-commit
+
+Host 必须延迟 downstream commit，直到：
+
+1. upstream HTTP status 已知；
+2. 对 non-stream，完整 body 已在 32 MiB 内读取、解析并验证；
+3. 对 stream，首个准备写出的 protocol payload 已通过必要 framing/validation；
+4. 没有 parsing、admission、timeout、network、upstream status 或 conversion failure。
+
+在第一个 downstream body byte 之前发生的任何 failure 都必须由相应 presenter 返回普通 JSON
+response。即使 client 请求了 stream，也不得预先 flush `200`, SSE headers、SSE comment、空 event
+或 NDJSON whitespace，导致后续只能在 stream 内报错。
+
+### 5.2 Post-commit
+
+HTTP status 与 headers 一旦 commit 不得替换。Transport、timeout、framing 或 conversion failure
+遵守以下规则：
+
+| Stream | Post-commit non-abort failure |
+| --- | --- |
+| OpenAI Chat | 关闭连接；不合成 `[DONE]` |
+| Responses `ChatBridgePlan` | 关闭连接；不合成 `response.failed` 或其他 terminal |
+| Responses `NativeResponsesPlan` | 关闭连接；不改写成 Chat bridge event，不合成 terminal |
+| Anthropic Messages | 关闭连接；不合成 `event:error`、`message_delta` 或 `message_stop` |
+| Ollama Chat | 按 Ollama 规范恰好追加一个安全 NDJSON error object并关闭；不再输出 `done:true` |
+
+Ollama error line 是其生产规范明确要求的 stream error，不是 success terminal。所有协议在 client abort
+后都直接关闭并写零个新增 bytes。
+
+上表只处理 gateway/upstream failure。一个由对应协议定义且解析合法的 error event/object 是协议
+内容，不得误分类：
+
+- Native Responses 的 HTTP 2xx response，即使包含 `response.failed`、`status:"failed"` 或
+  `type:"error"`，仍是合法 Responses success transport content，不得改为非 2xx HTTP error。
+- Native stream 收到的合法 `response.failed` event 可以按 native 规范处理，但 gateway 不自行生成。
+- `ChatBridgePlan` 在任何 failure path 都不得合成 `response.failed`。
+
+## 6. Failure taxonomy
+
+下表是语义分类，不是公开 DTO，也不要求内部使用相同 identifier：
+
+| Failure | Definition | Pre-commit safe message |
+| --- | --- | --- |
+| `invalid_request` | empty/malformed/non-object JSON、schema 或 version validation failure | `invalid request` |
+| `body_too_large` | inbound JSON body 超过 32 MiB | `request body too large` |
+| `unsupported_media_type` | request `Content-Type` 不受支持 | `unsupported media type` |
+| `unsupported_semantics` | source-valid request 无法由目标协议等价表达 | `unsupported semantics` |
+| `authentication` | Bound Account/credential 不存在、无效或明确 authentication failure | `authentication failed` |
+| `permission` | 明确 permission failure | `permission denied` |
+| `model_not_found` | client 显式 model 不在 Bound Account captured catalog | `model not found` |
+| `queue_full` / `queue_timeout` | local inference admission overload | `server overloaded` |
+| `upstream_network` | DNS、connection、TLS 或其他非-timeout transport failure | `upstream request failed` |
+| `upstream_timeout` | connect、first-byte、idle 或 total timer 到期 | `upstream timeout` |
+| `upstream_http` | final upstream status 为 400–599 | `upstream request failed` |
+| `invalid_upstream_response` | malformed/错型 2xx、超限 body/event/aggregate 或不合法 protocol data | `invalid upstream response` |
+| `internal` | 未分类 gateway bug/failure | `internal error` |
+| `aborted` | downstream client cancellation/disconnect | 无 response |
+
+公开 message 必须使用表中的固定低信息文本或被引用的 Ollama/model-list 固定文本，不能拼接 exception、
+URL、header、upstream body、request content 或 tool content。
+
+## 7. Protocol error presenters
+
+### 7.1 OpenAI Chat 与 Responses
+
+所有 pre-commit error body 恰好使用：
+
+```json
+{
+  "error": {
+    "message": "<safe message>",
+    "type": "<error type>",
+    "param": null,
+    "code": null
+  }
+}
+```
+
+最终 status 决定 `type`：
+
+| Final HTTP status | `error.type` |
+| ---: | --- |
+| 400, 409, 413, 415, 422 | `invalid_request_error` |
+| 401 | `authentication_error` |
+| 403 | `permission_error` |
+| 404 | `not_found_error` |
+| 429 | `rate_limit_error` |
+| 其他 | `api_error` |
+
+Local mapping：
+
+| Failure | Status | Type | Message |
+| --- | ---: | --- | --- |
+| `invalid_request` | 400 | `invalid_request_error` | `invalid request` |
+| `body_too_large` | 413 | `invalid_request_error` | `request body too large` |
+| `unsupported_media_type` | 415 | `invalid_request_error` | `unsupported media type` |
+| `unsupported_semantics` | 422 | `invalid_request_error` | `unsupported semantics` |
+| `authentication` | 401 | `authentication_error` | `authentication failed` |
+| `permission` | 403 | `permission_error` | `permission denied` |
+| `model_not_found` | 404 | `not_found_error` | `model not found` |
+| `queue_full` / `queue_timeout` | 503 | `api_error` | `server overloaded` |
+| `upstream_network` | 502 | `api_error` | `upstream request failed` |
+| `upstream_timeout` | 504 | `api_error` | `upstream timeout` |
+| `invalid_upstream_response` | 502 | `api_error` | `invalid upstream response` |
+| `internal` | 500 | `api_error` | `internal error` |
+
+Final upstream 400–599 status 必须原样保留，但 body 必须安全重建为上述 envelope：
+
+- `type` 只按 final status table 选择；
+- `message` 固定为 `upstream request failed`；
+- `param` 与 `code` 都为 JSON null；
+- 不透传 upstream error object、headers 或 body。
+
+Exact invalid-request example（JSON whitespace 不具有语义）：
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json; charset=utf-8
+Cache-Control: no-store
+x-request-id: req_01example
+
+{"error":{"message":"invalid request","type":"invalid_request_error","param":null,"code":null}}
+```
+
+Exact local overload example；不得带 `Retry-After`：
+
+```http
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json; charset=utf-8
+Cache-Control: no-store
+x-request-id: req_02example
+
+{"error":{"message":"server overloaded","type":"api_error","param":null,"code":null}}
+```
+
+Exact safe rebuild of an upstream 429 with one valid delta-seconds：
+
+```http
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json; charset=utf-8
+Cache-Control: no-store
+Retry-After: 120
+x-request-id: req_03example
+
+{"error":{"message":"upstream request failed","type":"rate_limit_error","param":null,"code":null}}
+```
+
+### 7.2 Anthropic Messages
+
+每个 pre-commit error body 恰好使用：
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "<error type>",
+    "message": "<safe message>"
+  },
+  "request_id": "req_..."
+}
+```
+
+Response `request-id` header 必须与 body `request_id` 完全相同。
+
+Local mapping：
+
+| Failure | Status | `error.type` | Message |
+| --- | ---: | --- | --- |
+| `invalid_request`，含缺失/错误/重复 `anthropic-version` | 400 | `invalid_request_error` | `invalid request` |
+| `body_too_large` | 413 | `request_too_large` | `request body too large` |
+| `unsupported_media_type` | 415 | `invalid_request_error` | `unsupported media type` |
+| `unsupported_semantics` | 400 | `invalid_request_error` | `unsupported semantics` |
+| `authentication` | 401 | `authentication_error` | `authentication failed` |
+| `permission` | 403 | `permission_error` | `permission denied` |
+| `model_not_found` | 404 | `not_found_error` | `model not found` |
+| `queue_full` / `queue_timeout` | 529 | `overloaded_error` | `server overloaded` |
+| `upstream_network` | 502 | `api_error` | `upstream request failed` |
+| `upstream_timeout` | 504 | `timeout_error` | `upstream timeout` |
+| `invalid_upstream_response` | 502 | `api_error` | `invalid upstream response` |
+| `internal` | 500 | `api_error` | `internal error` |
+
+Final upstream 400–599 status 必须原样保留、安全重建，并按下表选择 type；未列出的 status 使用
+`api_error`：
+
+| Final upstream status | `error.type` |
+| ---: | --- |
+| 400, 415, 422 | `invalid_request_error` |
+| 401 | `authentication_error` |
+| 402 | `billing_error` |
+| 403 | `permission_error` |
+| 404 | `not_found_error` |
+| 413 | `request_too_large` |
+| 429 | `rate_limit_error` |
+| 504 | `timeout_error` |
+| 529 | `overloaded_error` |
+| 500, 502, 503 及其他未列出 status | `api_error` |
+
+Upstream safe-rebuild message 固定为 `upstream request failed`。不得把 upstream Anthropic error body
+原样返回。
+
+Exact invalid-version example：
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json; charset=utf-8
+Cache-Control: no-store
+request-id: req_04example
+
+{"type":"error","error":{"type":"invalid_request_error","message":"invalid request"},"request_id":"req_04example"}
+```
+
+Exact local overload example；不得带 `Retry-After`：
+
+```http
+HTTP/1.1 529
+Content-Type: application/json; charset=utf-8
+Cache-Control: no-store
+request-id: req_05example
+
+{"type":"error","error":{"type":"overloaded_error","message":"server overloaded"},"request_id":"req_05example"}
+```
+
+### 7.3 Ollama Chat
+
+除本文明确增加的 local admission overload 外，`POST /api/chat` 的 request、upstream、stream 和
+post-commit errors 必须逐项遵守
+[Ollama 生产规范](./ollama_chat_to_chat_completions.md)第 9 节，不得套用 OpenAI 或 Anthropic
+type。
+
+规范表如下，作为 presenter 的完整引用：
+
+| Ollama error | Status | Exact safe text |
+| --- | ---: | --- |
+| `invalid_request` | 400 | `invalid request` |
+| `unsupported_semantics` | 422 | `unsupported semantics` |
+| `upstream_http_error` | upstream 400–599 | `upstream request failed` |
+| `upstream_timeout` | 504 | `upstream timeout` |
+| `upstream_stream_error` | 502 | `upstream stream error` |
+| `upstream_invalid_response` | 502 | `invalid upstream response` |
+| `upstream_stream_truncated` | 502 | `upstream stream truncated` |
+| `invalid_tool_arguments` | 502 | `invalid tool arguments` |
+| `invalid_logprobs` | 502 | `invalid logprobs` |
+| `internal_error` | 500 | `internal error` |
+| Gateway `queue_full` / `queue_timeout` | 503 | `server overloaded` |
+
+Host-level malformed/empty/non-object/schema、media type 和 request body limit 都必须在进入 converter 或
+upstream 前作为 Ollama `invalid_request` 呈现；不得为 Ollama 发明 OpenAI error type。
+
+Pre-commit body 只有 `error` string：
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json; charset=utf-8
+Cache-Control: no-store
+
+{"error":"invalid request"}
+```
+
+Post-commit non-abort stream failure 只追加一个以下形式的 NDJSON line，末尾恰好一个 LF，然后关闭：
+
+```ndjson
+{"error":"upstream stream error"}
+```
+
+该 line 后不得有 `done:true`。Client abort 不追加 error 或 terminal。Local overload 的 exact body 是：
+
+```json
+{"error":"server overloaded"}
+```
+
+### 7.4 Model-list routes
+
+`GET /v1/models` 与 `GET /api/tags` 的 status、body 和 cancellation 必须引用
+[model listing 生产规范](./github_copilot_model_listing_apis.md)第 11–12 节，而不是推理 presenter。
+
+Status mapping：
+
+| Condition | Status |
+| --- | ---: |
+| 无 Bound Account、账号不存在、credential 无效、token endpoint 明确 401 | 401 |
+| Token refresh network/connect/TLS/timeout、其他 HTTP 或 parse failure | 502 |
+| Final CAPI 401 或 403 | 保留 401 或 403 |
+| Final CAPI 429 | 429 |
+| Final CAPI 其他 4xx/5xx | 保留 upstream status |
+| CAPI 3xx、network/connect/TLS/timeout | 502 |
+| CAPI success body malformed、endpoint 无法构造 request | 502 |
+| Internal failure | 500 |
+| Client abort | 零 response bytes |
+
+`/v1/models` exact error body：
+
+```json
+{
+  "error": {
+    "message": "Failed to list GitHub Copilot models",
+    "type": "api_error",
+    "param": null,
+    "code": "502"
+  }
+}
+```
+
+- 401/403 的 `type` 为 `authentication_error`；
+- 429 的 `type` 为 `rate_limit_error`；
+- 其他 status 的 `type` 为 `api_error`；
+- `code` 是 final status 的十进制 string，不是 null；
+- `anthropic-version` presence 不改变此 error。
+
+`/api/tags` exact error body：
+
+```json
+{"error":"Failed to list GitHub Copilot models"}
+```
+
+它使用同一 status mapping。两个 route 只有在 final CAPI status 为 429 且满足第 8 节时才透传
+`Retry-After`。
+
+## 8. `Retry-After`
+
+公开 response 只有同时满足以下全部条件时才能包含 `Retry-After`：
+
+1. final upstream response status 恰好为 429；
+2. final response 中恰好有一个 `Retry-After` field value；
+3. value 是 [RFC 9110 §10.2.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3) 合法的
+   non-negative `delay-seconds` 或 `HTTP-date`。
+
+满足时透传该合法 value。以下情况必须删除：
+
+- final status 不是 429；
+- missing、empty 或语法非法；
+- duplicate field；
+- 多值被 comma-merge，例如 `120, 240`；
+- redirect/intermediate response 上存在，但 final response 不满足规则。
+
+单个合法 `HTTP-date` 自身包含 weekday comma，不得被误判为 merged value。例如：
+
+```http
+Retry-After: Sun, 06 Nov 1994 08:49:37 GMT
+```
+
+Local admission 使用 503/529，不生成 `Retry-After`；其他 local failure 也不生成。不得从 body、rate-limit
+header、queue depth 或估算 delay 合成该 header。
+
+## 9. Request IDs
+
+Gateway 必须在第 2.2 节每个 matched compatibility request 入口生成新的、不可由 client 控制的 opaque
+request ID。第 2.3 节 probes 是明确例外。
+Anthropic-visible ID 必须具有 `req_` prefix；其余内部编码不在本文中稳定化。
+
+| Route family | Public exposure |
+| --- | --- |
+| OpenAI Chat / Responses | `x-request-id` response header |
+| `/v1/models`，包括 Anthropic success serializer | `x-request-id` response header |
+| Anthropic Messages | `request-id` response header；error body 的 `request_id` 与它完全相同 |
+| Ollama Chat / Tags | 只在内部 scope 使用；不向 Ollama body 增加字段 |
+
+- Success、pre-commit error 与已成功 commit 的 stream headers 使用该 request 自己的 ID。
+- 入站 `x-request-id`、`request-id` 或其他 correlation ID 不得作为 gateway ID、不得原样 echo，也不得
+  覆盖 outbound Copilot identity headers。
+- Upstream 返回的 request ID 不得覆盖 gateway ID。
+- Client 在 gateway 生成 ID 前就断开，或任何 abort 导致零 response 时，不为暴露 header 而额外写
+  response。
+- Request ID 可以进入脱敏日志，但不得成为 metrics 的无界 label，也不得编码 credential、
+  endpoint、request/response/tool content。
+
+## 10. 安全与信息披露
+
+公开 error status、headers 和 body 必须能只由 failure category、final upstream status 与本地生成的
+request ID 构造。任何公开 error 都不得包含：
+
+- GitHub、Copilot、OpenAI 或 Anthropic credential；
+- 完整 upstream endpoint、path、query 或 account metadata；
+- upstream headers，唯一例外是第 8 节允许的 `Retry-After`；
+- upstream request/response body 或 exception dump；
+- client request/response content、messages、images、tool declaration、tool arguments 或 tool result；
+- stack、filesystem path、SQLite content 或内部 DTO。
+
+日志与 Operational Events 同样不得记录上述内容。允许的最小诊断字段是 sanitized category、protocol、
+final status、gateway request ID、timing 与不能还原完整 endpoint 的脱敏 host label。
+
+所有 error response 使用 `Cache-Control: no-store`。错误重建不得复制 upstream `Set-Cookie`、
+authentication challenge、server identity 或 hop-by-hop headers。
+
+## 11. Normative test matrix
+
+实现至少必须使用 deterministic clock、timer、UUID/request-ID source 与 scripted upstream 覆盖：
+
+| Area | Required cases | Required assertions |
+| --- | --- | --- |
+| Listener/routes | default `127.0.0.1:31400`、alternate valid port、non-loopback config、每条 method/path、禁止 aliases 与 trailing slash | host 固定 loopback、port snapshot 生效；无 gateway key 仍可到达 route；禁止 route 未注册 |
+| Probes | version/health、ready/not-ready、missing account、performance degraded、wrong method/trailing slash | exact status/headers/compact body；no account/upstream/admission；package version equality |
+| JSON parsing | empty、malformed、array/scalar/null root、schema failure、valid object | 零 upstream call；对应 presenter、status 与 safe body |
+| Media type/encoding | `application/json`、UTF-8 parameter、missing/wrong/malformed/non-UTF-8；missing/identity/gzip/duplicate Content-Encoding | accepted forms 成功进入 route；其他按协议失败且不解压 |
+| Anthropic version | exact value、missing、empty、wrong、duplicate/merged；models 上 arbitrary/empty presence | Messages 只接受恰好一个固定版本且不转发；models 只改变 success serializer |
+| Model resolution | missing with valid/invalid/no preference；explicit visible/empty/wrong-type/unknown；catalog mutation after capture | missing uses only valid preference；explicit unknown 404；no silent fallback；one immutable resolved model |
+| Body limit | `32 MiB` 与 `32 MiB + 1`，含 chunked byte splits | boundary accepted；超限不截断、零 upstream call、资源释放 |
+| Admission | 4 active、16 queued、第 17 个 waiter、slot release、30 秒前后、queued abort | 容量、503/529 shapes、无 local `Retry-After`、slot/timer 恰好释放 |
+| Timeouts | connect 30s、first byte 120s、idle 120s、total 30min、immediate network/TLS、abort | timeout 与 network 分类不同；pre-commit status 正确；post-commit 不改 status |
+| Buffer limits | single SSE event 4 MiB/+1、non-stream 32 MiB/+1、accumulator 32 MiB/+1、任意 byte split | 不截断；pre-commit 502/协议 error；post-commit closure 符合第 5.2 节 |
+| Commit | 每种 failure 在首 byte 前/后各一例 | pre-commit 一定是普通 JSON；不得提前 SSE commit；不得合成 terminal |
+| OpenAI presenter | 所有 local rows；upstream 400–599，至少覆盖 400/401/403/404/409/413/415/422/429/500/529 | status preserved、type table、四个 envelope fields、`code:null` |
+| Anthropic presenter | 所有 local rows；upstream 400/401/402/403/404/413/415/422/429/500/502/503/504/529/other | type table、header/body ID 相同、local unsupported 为 400 |
+| Ollama presenter | 生产规范第 9 节所有 rows、post-commit error、admission overload、abort | exact safe string、一个 LF error line、无后续 `done:true` |
+| Model errors | model spec 全部 status、OpenAI/Anthropic success selection、Ollama body | errors 不随 Anthropic header 改变；`code` 为 status string |
+| Responses 2xx | native non-stream/stream 中合法 failed/error protocol content；bridge failure | 保持 2xx protocol content；bridge 不生成 `response.failed` |
+| `Retry-After` | delta-seconds、HTTP-date、missing、empty、invalid、duplicate、merged、non-429、redirect-only、local overload | 只透传 final 429 的单个合法 value |
+| Request IDs | concurrent requests、success/error/stream、client-supplied IDs、Anthropic body equality | server-generated、每请求唯一、入站值不可信、正确 header/body |
+| Redaction | 在 credential、URL、headers、body、message 与 tool fields 植入 canary | response、log、event 均找不到 canary |
+| Cancellation | queued、connecting、pre-first-byte、mid-stream、model fetch | abort 传播；零个新增 response bytes；无 timer/listener/body/socket leak |
+
+Protocol success tests 还必须继续运行被引用生产规范要求的 Ollama Go-compatible byte golden、Anthropic
+Python `json.dumps` SSE golden、OpenAI Chat ordered JSON/SSE terminal、Responses item lifecycle/sequence、
+native item-ID normalization 和 model serializer fixtures。本文的 presenter tests 不替代 protocol success
+tests。
+
+## 12. 完成标准
+
+实现只有同时满足以下条件才完成：
+
+1. Route matrix 中每条 route 都通过 Fetch-level contract test 和 loopback integration test。
+2. 四个 inference routes 共用规定容量与期限的 admission gate，但各自保留 protocol-local presenter
+   与 stream terminal ownership。
+3. 所有 request/upstream/accumulator limits 在 boundary 与 boundary + 1 byte 上可重复验证，且无
+   truncation 或部分 success。
+4. 所有 timeout 与 abort 都取消同一个 upstream operation，释放 slot、timer、listener、body 与
+   socket；abort 不产生额外 wire bytes。
+5. 所有 pre-commit failures 都是本文规定的普通 JSON；所有 post-commit failures 都符合第 5.2 节。
+6. OpenAI/Anthropic SDK 能按其 native error class/header 读取 presenter；Ollama 与 model-list errors
+   与各自固定生产规范一致。
+7. `Retry-After`、request ID 和 redaction matrix 全部通过，且 fuzz/duplicate-header cases 不绕过
+   validation。
+8. 内部 failure DTO 可以被替换而不改变任何 golden；不存在公开的通用 `BridgeError` shape。
+9. Conversion mapping 仍只有对应生产规范一份行为来源；本文未产生第二套 field mapping。
+
+## 13. Primary sources
+
+固定源码提交：
+
+- [BerriAI/litellm@ae7e50f096a8722bad14d63b6a0d4634d59bf475](https://github.com/BerriAI/litellm/commit/ae7e50f096a8722bad14d63b6a0d4634d59bf475)
+- [farion1231/cc-switch@3217f72596f2d1c0f879f0a05f83803825d9809f](https://github.com/farion1231/cc-switch/commit/3217f72596f2d1c0f879f0a05f83803825d9809f)
+- [ollama/ollama@f96e7aa0513b9973a0ccc71be414c2ecb9d65b1a](https://github.com/ollama/ollama/commit/f96e7aa0513b9973a0ccc71be414c2ecb9d65b1a)
+
+SDK compatibility references：
+
+- [OpenAI Node SDK — handling errors](https://github.com/openai/openai-node#handling-errors)
+- [OpenAI Node SDK — request IDs](https://github.com/openai/openai-node#request-ids)
+- [Anthropic TypeScript SDK — handling errors](https://github.com/anthropics/anthropic-sdk-typescript#handling-errors)
+- [Anthropic TypeScript SDK — request IDs](https://github.com/anthropics/anthropic-sdk-typescript#request-ids)
+
+这些 SDK 链接用于验证 client compatibility；它们的 future drift 不得静默改变本文已经固定的 wire
+contract。

--- a/docs/github_copilot_model_listing_apis.md
+++ b/docs/github_copilot_model_listing_apis.md
@@ -47,6 +47,10 @@ GET /api/tags
 - 不执行模型 ID alias、dash/dot 改写或 family fallback。
 - 不按名称合并不同 model item。
 
+共同 loopback access、request ID、timeout 和首字节前 failure taxonomy 由
+[Gateway HTTP contracts](./gateway_http_contracts.md) 定义；本文件第 11 节的模型列表 presenter
+shape 与 status mapping 优先。
+
 ## 3. 非目标
 
 本实现不负责：
@@ -370,7 +374,8 @@ clear() -> void
 GET /v1/models
 ```
 
-该 route 使用与 Chat/Responses inference routes 相同的 inbound authentication middleware。
+该 route 使用与 Chat/Responses inference routes 相同的 loopback access policy；首版不要求 gateway
+API key。
 
 不要求注册 `/models` alias。
 
@@ -420,8 +425,8 @@ Cache-Control: no-store
 | `data[].max_output_tokens` | 第 4.3 节 coercion 结果，存在时 |
 | `object` | 固定 `"list"` |
 
-`DEFAULT_MODEL_CREATED_AT_TIME` 在模块初始化时读取同名环境变量并转十进制 integer；缺失时为
-`1677610602`。
+Production `DEFAULT_MODEL_CREATED_AT_TIME` 固定为 `1677610602`。Tests 可以通过 serializer dependency
+注入其他值验证格式，但不存在可由用户设置的 environment/config override。
 
 不得输出：
 
@@ -502,7 +507,8 @@ Anthropic content negotiation 在 `/v1/models` 完整提供。
 
 ### 10.1 成功响应
 
-该 route 使用与 Chat/Responses inference routes 相同的 inbound authentication middleware。
+该 route 使用与 Chat/Responses inference routes 相同的 loopback access policy；首版不要求 gateway
+API key。
 
 成功响应设置：
 
@@ -671,7 +677,7 @@ Service 在调用 serializer 前完成第 4.3 节 lookup，并传入只读
 负责：
 
 - 注册两个 GET route；
-- 对两个 route应用 inference authentication middleware；
+- 对两个 route 应用统一 loopback access policy；
 - 取得 caller cancellation signal；
 - 调用同一个 Copilot model catalog service；
 - `/v1/models` 根据 `anthropic-version` header presence 选择 OpenAI 或 Anthropic serializer；
@@ -732,11 +738,11 @@ Service 在调用 serializer 前完成第 4.3 节 lookup，并传入只读
 
 ### 14.5 `/v1/models`
 
-- 使用与 inference routes 相同的 inbound authentication middleware。
+- 使用与 inference routes 相同的 loopback access policy。
 - 成功响应固定 `Content-Type: application/json; charset=utf-8` 和 `Cache-Control: no-store`。
 - 无 `anthropic-version` 时，非空和空目录与第 9.2–9.3 节深度等值。
 - 每项至少有 `id`、`object`、`created`、`owned_by`；第 4.3 节有值时追加对应 metadata fields。
-- `created` 使用可由环境覆盖的 `DEFAULT_MODEL_CREATED_AT_TIME`。
+- `created` 使用固定 logical `DEFAULT_MODEL_CREATED_AT_TIME`。
 - `owned_by` 固定为 `"openai"`。
 - 错误 envelope、type、param 和 code 与第 11 节一致。
 - 任意值的 `anthropic-version` header（包括 empty string）触发第 9.4 节 Anthropic shape。
@@ -749,7 +755,7 @@ Service 在调用 serializer 前完成第 4.3 节 lookup，并传入只读
 ### 14.6 `/api/tags`
 
 - 成功响应 `Content-Type` 为 `application/json; charset=utf-8`。
-- 使用与 inference routes 相同的 inbound authentication middleware。
+- 使用与 inference routes 相同的 loopback access policy。
 - 成功响应 `Cache-Control` 为 `no-store`。
 - 非空和空目录与第 10 节深度等值。
 - `name` 和 `model` 相同。
@@ -766,7 +772,8 @@ Service 在调用 serializer 前完成第 4.3 节 lookup，并传入只读
 - 连接关闭后不写响应。
 - 所有 timer、listener、body 和 socket 被释放。
 
-Golden fixtures 必须固定 clock、`DEFAULT_MODEL_CREATED_AT_TIME` 环境值和 model metadata，并覆盖：
+Golden fixtures 必须固定 clock、test-injected `DEFAULT_MODEL_CREATED_AT_TIME` 和 model metadata，并
+覆盖：
 
 - 完整 endpoint DTO 与每个 malformed branch；
 - redirect host/effective-port 变化和五个敏感 header；

--- a/docs/ollama_chat_to_chat_completions.md
+++ b/docs/ollama_chat_to_chat_completions.md
@@ -46,6 +46,9 @@ Copilot 是否接受全部字段是外部部署约束，不得通过模型名、
   `stream_options:{"include_usage":true}`。
 
 本文不规定 token/endpoint 获取、认证 header、重试或 timeout。
+共同 request parsing、resource limits、admission 和 timeout 由
+[Gateway HTTP contracts](./gateway_http_contracts.md) 定义；Ollama error body 与 stream
+post-commit 行为仍以第 9 节为准。
 
 ## 3. 固定 DTO
 

--- a/docs/openai_chat_completions.md
+++ b/docs/openai_chat_completions.md
@@ -1,0 +1,758 @@
+# OpenAI Chat Completions 原生代理规范
+
+> 状态：normative production spec
+>
+> 本文是 `POST /v1/chat/completions` 的唯一协议行为规范。当前或历史 JavaScript
+> implementation、tests 和 fixtures 都不是行为来源。
+
+## 1. Scope、source priority 与 non-goals
+
+本文定义 OpenAI Chat Completions route 的：
+
+1. `WireJson` request decoding 与 duplicate-member policy；
+2. Bound Account、catalog snapshot 与 model resolution；
+3. `stream`、`stream_options`、vision analysis 与 request reserialization；
+4. GitHub Copilot native Chat upstream execution；
+5. non-stream JSON success；
+6. shared incremental Chat SSE parsing、OpenAI SSE encoding 与 successful terminal；
+7. route-specific errors、commit、abort、telemetry 和验收要求。
+
+发生冲突时，先按责任范围选择 source：
+
+1. [Gateway HTTP contracts](./gateway_http_contracts.md) 独占 listener、loopback access、
+   request media type/body limit、inference admission、timeouts、shared buffer limits、
+   response commit definition、request ID、`Retry-After`、OpenAI error presenter 和公开
+   redaction。
+2. 本文独占 OpenAI Chat request planning、model resolution、rewritten upstream body、
+   native Chat success JSON、Chat SSE parsing、OpenAI SSE bytes 和 `[DONE]` terminal。
+3. [GitHub Copilot model listing](./github_copilot_model_listing_apis.md) 独占 account-scoped
+   CAPI catalog、catalog cache/generation、credential、endpoint discovery 和 catalog item
+   filtering。其 model-list public presenter 不用于本 route。
+4. [Architecture](./architecture.md)、[Refactor master spec](./specs/refactor_master_spec.md)、
+   [CONTEXT](../CONTEXT.md) 和
+   [ADR-0001](./adr/0001-protocol-endpoint-modules.md) 独占 module interface、state
+   ownership、canonical vocabulary、delivery order 和 file ownership。
+5. [AGENTS](../AGENTS.md) 独占 repository delivery workflow。
+6. 其他 protocol specs 只在其自身 route 生效。尤其是
+   [Ollama](./ollama_chat_to_chat_completions.md) 的 model default、response reducer 和
+   NDJSON rules，
+   [Anthropic](./claude_messages_to_chat_completions.md) 的 conversion/event rules，以及
+   [Responses routing](./openai_responses_routing.md) 和
+   [Responses bridge](./codex_response_to_chat_completions.md) 的 planning/conversion/history
+   rules，都不得进入本 route。
+
+Architecture 或 master spec 中的 “raw fast path” 只表示“不经过其他 downstream protocol
+converter”。它不允许 byte-blind SSE passthrough；第 10–11 节的 incremental parser 和
+OpenAI SSE re-encoder 对本 route 优先。
+
+只注册：
+
+```text
+POST /v1/chat/completions
+```
+
+不得为本 module 注册 `/chat/completions`、`/v1/chat/completions/`、其他 method、旧名称或
+provider-specific alias。Route matching 与 unmatched-route behavior 服从 Gateway HTTP
+contracts。Inbound query 不参与 model resolution，不改变 body，也不得复制到 upstream target。
+
+本 route 是 native Chat path：
+
+```text
+OpenAI Chat request
+  -> request-local validation and model resolution
+  -> GitHub Copilot /chat/completions
+  -> OpenAI Chat JSON or OpenAI Chat SSE
+```
+
+它不得调用 Ollama、Anthropic、Responses request/response converter，不得建立 canonical
+message model，不得读写 Responses History，也不得 fallback 到 legacy handler、native Responses
+或另一个 protocol。
+
+## 2. Logical interfaces 与 immutable request context
+
+以下是 logical interfaces；implementation 可以把小型 helper 合并在同一 file，但不得丢失其
+语义边界：
+
+```text
+createOpenAiChatEndpoint(dependencies) -> ProtocolEndpoint
+
+decodeOpenAiChatRequest(root: WireJsonObject)
+  -> DecodedOpenAiChatRequest | InvalidRequest
+
+resolveOpenAiChatModel(
+  decoded: DecodedOpenAiChatRequest,
+  account: BoundAccount,
+  catalog: CatalogSnapshot
+) -> ResolvedModel | InvalidRequest | ModelNotFound
+
+prepareOpenAiChatRequest(
+  decoded: DecodedOpenAiChatRequest,
+  resolved: ResolvedModel
+) -> PreparedOpenAiChatRequest | InvalidRequest
+```
+
+```text
+PreparedOpenAiChatRequest {
+  body: WireJsonObject
+  bytes: Uint8Array
+  stream: boolean
+  hasVisionInput: boolean
+  resolvedModel: string
+}
+
+OpenAiChatRequestContext {
+  requestId: string
+  signal: AbortSignal
+  config: RuntimeConfigSnapshot
+  account: BoundAccount
+  copilot: BoundCopilot
+  catalog: CatalogSnapshot
+  model: ResolvedModel
+}
+```
+
+`PreparedOpenAiChatRequest.body` 必须仍是 ordered `WireJsonObject`，不能先转成会重排
+integer-like keys、折叠 duplicate members 或改变 number lexeme 的普通 JavaScript object。
+`ResolvedModel` 使用 master spec 的 shared model resolver contract；本 route 只消费 immutable
+`source` 与 `upstreamModel`，不使用其 Responses routing metadata 做第二次 planning。
+
+一次 admitted request 的 execution order 是：
+
+1. Gateway Foundation 捕获一个 immutable `RuntimeConfigSnapshot` 并完成 shared HTTP body
+   parsing。
+2. OpenAI Chat decoder 完成所有可在 account binding 前判断的 local validation。
+3. `AccountDirectory` 恰好 bind 一次默认 `BoundAccount`。
+4. 对该 `accountId` 恰好取得一个 current `CatalogSnapshot`。
+5. 只在该 snapshot 上执行一次 model resolution。
+6. `CopilotBackend` 对同一 Bound Account 恰好 bind 一个 `BoundCopilot`，固定 credential 与
+   target。
+7. 只构造一次 final request、vision flag 和 serialized bytes。
+8. 根据 `stream` 恰好调用一次 `completeChat` 或 `openChatStream`。
+
+步骤 3–8 一旦完成，对应值在 request lifetime 内不变。Default account、preferred model、
+catalog cache、credential、target 或 runtime config 的 concurrent update 只影响后续 request。
+不得在 upstream failure 后重新 bind、重新取 catalog、重新 resolve model 或改变 execution path。
+
+“一次 upstream call”在本文指一次 Chat inference invocation。Catalog service 在 cache miss 时是否
+执行其自身 CAPI fetch，完全由 model-listing spec 管理；OpenAI Chat module 不复制、绕过或重试该
+逻辑。
+
+## 3. `WireJson` request decoder
+
+Gateway 按 Gateway HTTP contracts 先得到一个完整、合法、受限且 root 为 object 的
+`WireJson`。本 module 只能从该 object decode，不能对 raw bytes 再调用 `JSON.parse()`。
+
+### 3.1 Top-level duplicate policy
+
+所有 top-level decoded member names 必须唯一。任何 duplicate 都是
+`400 invalid_request_error`，包括：
+
+- duplicate `model`、`stream`、`stream_options` 或 `messages`；
+- duplicate unknown member；
+- 不同 JSON spelling 解码为同一 string，例如 `"model"` 与 `"\u006dodel"`。
+
+比较使用解码后的、大小写敏感的完整 member name；`Model` 与 `model` 是不同 keys。该规则在读取
+任何 control member 前执行，因此 implementation 不得采用 first-wins、last-wins 或普通 object
+parse 的隐式结果。
+
+Nested objects 不应用通用 duplicate rejection。唯一额外 control-member rule 是第 6.2 节对
+`stream_options.include_usage` 的规定。
+
+### 3.2 Local schema boundary
+
+除本文明确规定的 `model`、`stream` 和 stream-true `stream_options` 外，本 module 不建立
+top-level allowlist，也不对 Chat fields 做会丢失 forward-compatible values 的 normalization。
+
+因此：
+
+- missing `messages`、未知 Chat fields 或 provider extension fields 可以进入 upstream；
+- 它们的 upstream acceptance 由 GitHub Copilot Chat endpoint 决定；
+- local decoder 不 trim strings、不 coerce number/string/bool，也不注入 Chat defaults；
+- malformed JSON、non-object root、media type、encoding 和 request byte limit 仍由 Gateway HTTP
+  contracts 在进入本 decoder 前拒绝。
+
+## 4. Model resolution
+
+Model lookup 始终使用第 2 节捕获的 Bound Account 和该 account 的单一 current
+`CatalogSnapshot`。Catalog membership 只比较 `CatalogSnapshot.models[].id`；不得使用 model
+name、vendor、routing metadata、静态 allowlist 或其他 account 的 catalog。
+
+### 4.1 Explicit `model`
+
+当 top-level `model` property 存在时：
+
+1. value 必须是 string；
+2. string length 必须大于 0；
+3. 不 trim、不改大小写、不执行 alias、dash/dot rewrite、family fallback 或 deployment mapping；
+4. 必须与 captured catalog 中至少一个 `id` 完全相等。
+
+Non-string 或 `""` 是 `400 invalid_request_error`，safe message 为 `invalid request`。
+一个 nonempty string 若没有 exact catalog match，是 route-local
+`404 not_found_error`，safe message 为 `model not found`。Whitespace-only string 是 nonempty；
+若 catalog 没有同值 ID，它属于 `404 model not found`，不能 trim 后变成另一个 model。
+
+Explicit model 不读取 preferred model，也不得在 not-found 时 fallback。
+
+### 4.2 Missing `model`
+
+只有 top-level property 完全 missing 时才使用 Bound Account 的 preferred model。`null`、`false`、
+number、object、array 和 empty string 都不是 missing。
+
+Preferred model 必须同时满足：
+
+1. account 有一个 nonempty string captured preferred model；
+2. preference state 是 `valid`；
+3. preferred model ID 与 captured catalog 中至少一个 `id` 完全相等。
+
+满足时 `source="preferred"`，并使用该 exact ID。Preference missing、已标记 invalid 或不再存在于
+captured catalog 时，返回 `400 invalid_request_error` 与 safe `invalid request`。不得选择 catalog
+第一项、上次成功 model 或全局 default，也不得把该情况呈现为 explicit-model 404。
+
+Catalog fetch/parse/auth/network failure 不是 “model not found”；它保持原 failure category，并由
+Gateway OpenAI presenter 映射。
+
+### 4.3 Resolved value
+
+`ResolvedModel.upstreamModel` 对 explicit model 是原 string value，对 preferred model 是
+preference 中的 exact catalog ID。Final upstream body 的 `model` 必须替换为该值；downstream
+response 中的 `model` 不做反向重写。
+
+## 5. `stream` selection
+
+Top-level `stream` 使用严格 JSON boolean rules：
+
+| Inbound value | Execution path |
+| --- | --- |
+| missing | non-stream |
+| `false` | non-stream |
+| `true` | stream |
+| null、string、number、array、object | `400 invalid_request_error` |
+
+Missing 时不向 final body 注入 `stream:false`。Explicit `false` 或 `true` 保持原 member position 和
+boolean value。Truthiness、string `"true"`、number `1` 和 coercion 均禁止。
+
+## 6. `stream_options.include_usage`
+
+### 6.1 Non-stream
+
+当 `stream` missing 或为 `false` 时，`stream_options` 不参与 local validation 或 mutation：
+
+- missing 时不创建；
+- present 时保留原 `WireJson` value 和 member position；
+- GitHub Copilot 可以按 upstream semantics 接受或拒绝它。
+
+### 6.2 Stream
+
+当且仅当 `stream === true` 时，final body 必须具有：
+
+```json
+{"stream_options":{"include_usage":true}}
+```
+
+处理规则：
+
+1. `stream_options` missing：创建 object，并添加 `include_usage:true`；
+2. `stream_options` 是 object：保留其他 members 的 source order 和 values；
+3. object 中没有 `include_usage`：在该 object 的末尾追加；
+4. object 中恰好一个 `include_usage`：在原 position 把 value 覆盖为 boolean `true`，不论原类型；
+5. object 中 duplicate decoded `include_usage`：`400 invalid_request_error`；
+6. `stream_options` 为 null、boolean、string、number 或 array：
+   `400 invalid_request_error`。
+
+Unknown nested members，包括它们的 ordered values，不得因 gateway 注入 usage 而丢失。
+
+## 7. Request reserialization 与 vision analysis
+
+### 7.1 Ordered reserialization
+
+所有 valid request 都必须重新序列化；不得把 inbound raw body 原样转发。Final body 使用 compact
+UTF-8 JSON，无 BOM、无 trailing LF、无 insignificant whitespace。
+
+按 original top-level members 顺序逐项处理：
+
+1. Existing `model` 在原 position 输出，value 替换为 resolved model；
+2. Existing stream-true `stream_options` 在原 position 按第 6.2 节输出；
+3. 其他所有 members，包括 unknown 和 provider extension fields，保持相对 source order 和
+   `WireJson` value；
+4. Missing `model` 在所有 original members 之后追加；
+5. Stream-true 且 missing `stream_options` 时，在所有 original members 和可能追加的 `model`
+   之后追加；若 model 也 missing，append order 是 `model` 后 `stream_options`。
+
+Serializer 必须保留：
+
+- object member order；
+- array order；
+- string、boolean 与 null values；
+- number lexeme，包括 exponent、large integer 和 `-0`；
+- nested unknown objects/arrays。
+
+只允许改变 `model` 和 stream-true `stream_options.include_usage`，以及为缺失的这两个 gateway-owned
+members执行上述 insertion。不得按字段白名单重建 request，也不得修改 `messages`、tools、tool
+arguments、sampling fields 或 provider extensions。
+
+### 7.2 Vision flag
+
+Vision analysis 是只读 side analysis。`hasVisionInput=true` 仅当 top-level `messages` array 中至少
+一个 message 的 `content` array 含 OpenAI Chat `image_url` part，即 part object 的 decoded
+`type` 为 exact string `"image_url"` 且存在 `image_url` member。
+
+Rules：
+
+- 只扫描 `messages[*].content[*]`，不扫描 tools、metadata、unknown fields 或 arbitrary strings；
+- 不 fetch URL、不 decode base64、不验证 MIME type；
+- 不改变、删除、规范化或重新排序任何 message/content/image member；
+- 不因无法识别的 message shape 产生额外 local schema error；它只是不设置 flag；
+- inbound `copilot-vision-request` 或同名大小写变体 header 不能设置、清除或覆盖该 flag。
+
+Backend 在 flag 为 true 时加入 typed outbound header：
+
+```http
+copilot-vision-request: true
+```
+
+Flag 为 false 时不发送该 header。
+
+## 8. Native Chat upstream
+
+OpenAI Chat module 只能调用 captured `BoundCopilot` 的 Chat methods。Production backend 按
+`BoundCopilot.target` 的 target-construction contract 构造最终 URL，并追加 exact
+`/chat/completions` path；不得从 inbound `Host`、path、query、body extension 或 header 构造
+target。
+
+Examples：
+
+```text
+https://api.githubcopilot.com
+  -> https://api.githubcopilot.com/chat/completions
+
+https://copilot.example.com/capi
+  -> https://copilot.example.com/capi/chat/completions
+```
+
+Target normalization 和 credential lifecycle 由 BoundCopilot/Copilot backend ownership 管理；
+protocol module 不重复 endpoint discovery。
+
+Outbound request 使用：
+
+```http
+Content-Type: application/json
+copilot-integration-id: vscode-chat
+editor-version: vscode/1.110.1
+editor-plugin-version: copilot-chat/0.38.2
+user-agent: GitHubCopilotChat/0.38.2
+x-github-api-version: 2025-10-01
+```
+
+Authorization/credential 由 captured BoundCopilot 生成；vision header 只来自第 7.2 节 typed flag。
+Inbound `Authorization`、`x-api-key`、Copilot identity/version、vision、request-ID 或 forwarding
+headers 都不得覆盖 fixed outbound values或成为 upstream credential。Arbitrary upstream
+response headers 也不得覆盖 gateway-generated public request ID。
+
+对 prepared request 恰好选择一个：
+
+```text
+stream == false -> BoundCopilot.completeChat(...)
+stream == true  -> BoundCopilot.openChatStream(...)
+```
+
+Endpoint 不执行 application-level retry，不改发 `/responses`，不切换 account/model/target，也不在
+failure 后调用另一个 method。Transport 自身的 connection management 必须遵守 Copilot backend
+contract，但不能使 endpoint 产生第二个 logical Chat inference attempt。
+
+Final non-2xx status 不进入 success parser。其 status、safe error rebuild 和唯一允许的
+`Retry-After` 按 Gateway HTTP contracts。
+
+## 9. Non-stream success
+
+Final upstream status 为任意 `2xx` 时，必须在 downstream commit 前：
+
+1. 在 captured `limits.nonstreamBodyBytes` 内完整读取 decoded body；default 是 32 MiB；
+2. 验证 bytes 是合法 UTF-8 JSON；
+3. 验证 root 是 object；
+4. 使用 ordered `WireJson` compact serializer 重新生成 UTF-8 bytes；
+5. 从 `usage` 做第 13 节 side observation，但不改变 body。
+
+Empty body、whitespace-only body、malformed JSON、invalid UTF-8、null、array、string、number 或
+boolean root 都是 `invalid_upstream_response`。超过 shared limit 也按该 category 失败；不得截断、
+返回 partial object 或尝试 stream parser。
+
+Valid object success：
+
+- 保留全部 upstream top-level/nested fields、member order、array order、values 和 number lexemes；
+- 不建立 response field allowlist；
+- 不删除 unknown/provider fields；
+- 不重写 `id`、`object`、`created`、`model`、`choices`、tool calls、reasoning 或 `usage`；
+- inbound resolved model 不用于覆盖 response model；
+- final upstream `2xx` status 原样作为 downstream success status；
+- response body 是 compact JSON，无 BOM 或 trailing LF；
+- response `Content-Type` 固定为：
+
+```http
+Content-Type: application/json; charset=utf-8
+```
+
+Gateway 另加入该 request 的 `x-request-id`。Upstream `Content-Type`、`Content-Length`、
+`Content-Encoding` 和 hop-by-hop headers 不决定重新序列化后的 downstream representation。
+
+## 10. Shared incremental Chat SSE parser
+
+Stream path 必须使用 shared incremental Chat SSE parser，输出：
+
+```text
+ChatStreamFrame =
+  | { kind: "chunk", chunk: ChatChunk }
+  | { kind: "error", value: WireJson | string }
+  | { kind: "done" }
+```
+
+OpenAI Chat endpoint 只消费该 union；不得扫描 arbitrary raw chunks寻找 `[DONE]`，也不得把 upstream
+bytes直接写给 downstream。
+
+### 10.1 Framing
+
+Final upstream `2xx` body 按以下 grammar 增量处理：
+
+1. 使用一个 fatal incremental UTF-8 decoder；multibyte code point 可跨任意 transport chunk；
+2. 只允许 stream 最开头一个 UTF-8 BOM，并忽略它；
+3. 接受 LF、CRLF 和 CR line endings，跨 byte split 正确识别；
+4. 空行结束当前 SSE event；
+5. `:` 开头的 comment line 被忽略；
+6. Field line 在第一个 `:` 分隔；value 只移除开头至多一个 U+0020 SPACE；
+7. 多个 `data` fields 按出现顺序用单个 LF 连接；
+8. 没有 `data` 的 event 被忽略；
+9. `event`、`id`、`retry` 和 unknown SSE fields 不进入 `ChatChunk`；
+10. 一个 event 的全部 buffered bytes 受 captured `limits.sseEventBytes` 约束，default 是
+    4 MiB。
+
+Comments、unknown fields、line endings 和 transport chunks 都不是 downstream payload。
+
+### 10.2 Frame decoding
+
+Event data 完成后按顺序分类：
+
+1. Data 精确等于 `[DONE]` 时产生 `kind:"done"`；
+2. Final SSE event type 精确等于 `error` 时产生 `kind:"error"`；
+3. 其他 data 必须是一个合法 JSON object；
+4. Object root 含 decoded top-level `error` member 时产生 `kind:"error"`；
+5. 其他 object 必须通过 shared `ChatChunk` decoder，并产生 `kind:"chunk"`。
+
+`[DONE]` 比较不 trim。` [DONE]`、`[DONE] `、JSON string `"[DONE]"` 或不同大小写都不是 terminal。
+Malformed JSON、non-object JSON、invalid Chat chunk、event limit overflow 或 serializer failure 是
+invalid upstream stream response。
+
+Parser 在 first `done` 或 `error` 后进入 absorbing terminal state；endpoint 停止拉取并释放 upstream
+body。Normal iterator exhaustion 不是 `done`。
+
+### 10.3 EOF
+
+只有收到 `kind:"done"` 才能成功结束。以下全部是 failure：
+
+- clean EOF 但从未收到 `done`；
+- EOF 时有 incomplete UTF-8 code point；
+- EOF 时有 residual line、field、data 或 unterminated event；
+- EOF 前最后一个 event 是 malformed/invalid；
+- transport 在 event 中途关闭。
+
+即使先前 chunk 已含 non-null `finish_reason`，也不能把 EOF 当成 `[DONE]`。
+
+## 11. OpenAI downstream SSE wire 与 terminal
+
+Stream success 使用：
+
+```http
+Content-Type: text/event-stream; charset=utf-8
+```
+
+Gateway 另加入该 request 的 `x-request-id`。Final upstream `2xx` status 保持为 downstream
+success status。
+
+每个 `kind:"chunk"` 独立使用 ordered compact JSON serializer，并恰好输出：
+
+```text
+data: <compact-json>\n\n
+```
+
+也就是 bytes：
+
+```text
+64 61 74 61 3a 20 <json bytes> 0a 0a
+```
+
+Rules：
+
+- 保留 chunk 的全部 fields、member order、values 和 number lexemes；
+- 不建立 choice/delta/provider field allowlist；
+- usage-only chunk，例如 `choices:[]`，仍完整输出；
+- upstream comments、`event:`、`id:`、`retry:`、unknown SSE fields、blank events 和原 line
+  endings 均不输出；
+- 不复制 upstream framing whitespace；downstream framing 永远使用上述 exact LF bytes；
+- 不调用 Ollama、Anthropic 或 Responses reducer/encoder。
+
+First `kind:"done"` 是唯一 successful terminal。Endpoint 恰好输出一次：
+
+```text
+data: [DONE]\n\n
+```
+
+然后结束 stream、停止读取 upstream 并释放 parser。Zero-chunk 后直接 `done` 是合法 empty success。
+Duplicate `[DONE]`、post-DONE data 或 comments 不得产生第二个 terminal 或其他 bytes。
+
+`kind:"error"` 永远是 failure；其 data 不得作为 OpenAI chunk 或 public error body 下发。EOF/no-Done、
+parser error、event overflow、transport error 或 timeout 也都是 failure。任何 failure 都不得合成
+`data: [DONE]\n\n` 或 `data: {"error":...}\n\n`。
+
+## 12. Errors、commit、backpressure 与 abort
+
+### 12.1 Pre-commit presenter
+
+所有 pre-commit failure 使用 Gateway HTTP contracts 的 OpenAI presenter：
+
+```json
+{"error":{"message":"<safe message>","type":"<error type>","param":null,"code":null}}
+```
+
+Explicit unknown model 产生 Gateway HTTP contracts 已定义的 shared `model_not_found` failure：
+
+| Condition | Status | `error.type` | Safe message |
+| --- | ---: | --- | --- |
+| Explicit nonempty model 不在 captured account catalog | 404 | `not_found_error` | `model not found` |
+
+对应 exact compact body 是：
+
+```json
+{"error":{"message":"model not found","type":"not_found_error","param":null,"code":null}}
+```
+
+以下 Chat-specific failures 使用已有 mapping：
+
+| Condition | Failure category | Status | Safe message |
+| --- | --- | ---: | --- |
+| Duplicate top-level member | `invalid_request` | 400 | `invalid request` |
+| Explicit model non-string/empty | `invalid_request` | 400 | `invalid request` |
+| Missing model 且 preference missing/invalid/not-in-catalog | `invalid_request` | 400 | `invalid request` |
+| `stream` wrong type | `invalid_request` | 400 | `invalid request` |
+| Stream-true `stream_options` wrong type或 duplicate `include_usage` | `invalid_request` | 400 | `invalid request` |
+| Invalid/oversized upstream `2xx` non-stream body | `invalid_upstream_response` | 502 | `invalid upstream response` |
+| Pre-commit SSE error frame、parse error、overflow、EOF without Done | `invalid_upstream_response` | 502 | `invalid upstream response` |
+
+Account、credential、catalog transport、admission、timeout、network 和 final upstream non-2xx
+继续使用 Gateway HTTP contracts 的 category/status rules。Local 400/404 不生成 `Retry-After`。
+Final upstream 429 只有满足 shared single-valid-value rule 才能保留它。
+
+即使 request 的 `stream` 为 true，pre-commit error 仍是普通 JSON，不是 SSE。所有 error response
+具有 shared `Content-Type`、`Cache-Control: no-store` 与 gateway-generated `x-request-id`。
+Public body/log 不得包含 requested model、account metadata、catalog content、credential、target URL、
+upstream headers/body、messages、images、tools 或 exception text。
+
+### 12.2 Commit boundary
+
+Non-stream 只有在完整 body 读完、limit 检查、UTF-8/JSON/object validation、usage observation 和 final
+serialization 都成功后才能 commit。
+
+Stream 只有在：
+
+1. final upstream status 已知为 `2xx`；
+2. first downstream payload 对应的完整 frame 已 framing、decoded、validated；
+3. 该 payload 的 exact downstream bytes 已成功构造；
+
+之后才能 commit。Upstream headers、SSE comment、blank/no-data event 或预先 flush 的 SSE headers 都
+不能触发 commit。
+
+First payload 可以是 Chat chunk 或 `[DONE]`。First frame 若是 error，或 EOF/timeout 在 first payload
+前发生，必须返回普通 HTTP error。
+
+### 12.3 Post-commit failure
+
+第一个 downstream body byte 写出后，HTTP status/headers 不得替换。任何 non-abort failure：
+
+1. abort/cancel same upstream operation；
+2. 调用 active iterator 的 `return()`；
+3. 释放 body、decoder、timer、listener、request state 和 admission permit；
+4. 直接关闭 downstream connection；
+5. 不追加 error frame、JSON body、SSE comment 或 `[DONE]`。
+
+因此，一个已输出 chunks 但没有 `[DONE]` 的 response 在 wire 上保持 truncated；不得伪装为 success。
+
+### 12.4 Pull backpressure
+
+Pipeline 必须是 pull-based：
+
+```text
+downstream pull
+  -> OpenAI SSE encoder
+  -> ChatStreamFrame iterator
+  -> incremental SSE parser
+  -> upstream body pull
+```
+
+一次最多保留一个尚未被 downstream 消费的 emit-ready frame。Parser 为跨 chunk UTF-8、line 和 current
+event保存的 bounded state 不算预取。Comments/no-data events 可以在一次 pull 内被跳过，但不得启动
+background reader、callback pump 或 unbounded queue。
+
+### 12.5 Client abort
+
+Client disconnect/cancellation 在 queue、body read、account/catalog/credential wait、connect、
+pre-first-byte、mid-stream 或 terminal write 的任意阶段都必须：
+
+- abort 同一个 upstream/catalog operation；
+- 从 queue 移除 waiter 或恰好释放一次 active permit；
+- 调用 iterator `return()`；
+- 释放 timer、listener、body、socket、decoder 和 request-local state；
+- 从 abort 时刻起写零个新增 bytes；
+- 不记录 public error，不合成 `[DONE]`。
+
+Abort 不是 timeout，也不能触发 account/model retry。
+
+## 13. Usage 与 telemetry ownership
+
+OpenAI Chat module 可以从 valid upstream object/chunk 的 top-level `usage` 生成 content-free
+`ChatUsageObservation`，但 wire body/event 始终保留原始 `usage` value。
+
+```text
+ChatUsageObservation {
+  promptTokens?: nonnegative integer
+  completionTokens?: nonnegative integer
+  cachedTokens?: nonnegative integer
+}
+```
+
+Mapping：
+
+- `usage.prompt_tokens` -> `promptTokens`；
+- `usage.completion_tokens` -> `completionTokens`；
+- `usage.prompt_tokens_details.cached_tokens` -> `cachedTokens`。
+
+Telemetry extraction 不 coerce string/bool/float，不从 `total_tokens` 推导缺失字段。它不增加第 9 节
+root-object validation 或第 10 节 shared `ChatChunk` decoder 之外的 validation。一个已被对应 success
+decoder 接受的 malformed、duplicate 或不可表示 usage member只使对应 observation 缺失；不得修改或
+删除该 member。
+
+Non-stream 最多产生一个 observation。Stream 中每个含 usage 的 typed chunk 都仍按第 11 节输出；
+request-local telemetry state 对每个 valid counter采用 last-valid-wins，后续 missing/invalid value
+不清除先前 valid value。Request terminal 时向 `UsageRecorder` 提交至多一个 content-free sample。
+
+`UsageRecorder`/telemetry module 独占 batching、SQLite retention、outcome counters 和 bounded overflow
+policy。OpenAI Chat endpoint 只提供：
+
+```text
+accountId
+protocol = "openai_chat"
+resolvedModel
+outcome
+latency
+observed token counters
+```
+
+它不得提供 prompt、response、message、image URL/data、tool name/arguments/result、credential、完整
+target、catalog 或 arbitrary inbound fields。Gateway request ID 可以进入 sanitized operational log，
+但不能成为 Usage Bucket label。Telemetry enqueue/flush failure 是 noncritical，不得改变 success
+bytes、commit boundary 或 terminal。
+
+## 14. Normative test matrix
+
+全部 tests 必须 offline，使用 scripted `AccountDirectory`、`CopilotModelCatalog`、
+`CopilotBackend`、deterministic request ID/config 和可控制 byte boundaries 的 upstream。不得读取
+developer credential、本机 provider checkout 或 remote API。
+
+### 14.1 Route、decoder 与 immutable context
+
+- 只有 exact `POST /v1/chat/completions` registered；method、trailing slash 和 aliases 不进入
+  endpoint。
+- Gateway JSON/media/body-limit/admission/timeout/request-ID cases 继续运行 shared contract suite。
+- 每个 top-level duplicate case，包括 unknown 与 escaped-equivalent key，返回 exact 400，且零
+  account/catalog/Chat calls。
+- Unknown fields、integer-like keys、large/exponent/`-0` numbers、nested arrays/objects 保持 order、
+  lexeme 和 value。
+- Account、catalog、resolved model 与 config snapshot 各捕获一次；在 request 中途切换 default
+  account、preference、catalog generation 或 config 不改变 captured request。
+
+### 14.2 Model resolution
+
+- Explicit exact model 命中当前 account catalog；
+- Explicit model 为 null、bool、number、array、object、`""`；
+- Whitespace/case/dash/dot 差异不 normalization；
+- Explicit unknown model exact 404 body/header，且零 Chat call；
+- Missing model 使用 valid preferred model；
+- Missing/invalid/not-in-catalog preference exact 400，且不选择 first catalog item；
+- Catalog empty、duplicate IDs、另一个 account 有同名 model；
+- Catalog retrieval failure 保持真实 failure category，不伪装 404；
+- Final captured upstream body 中只有一个 resolved `model`。
+
+### 14.3 Stream selection、options、vision 与 request capture
+
+- `stream` missing/false/true 与每种 wrong type；
+- Non-stream `stream_options` missing、object、null/scalar 保持不变；
+- Stream-true options missing、empty object、existing false/null/scalar `include_usage`、
+  unknown members before/after、duplicate `include_usage` 和 non-object options；
+- Existing replacement position、missing append position、model + options 双 missing 的 append order；
+- Vision match/non-match、invalid message shapes、image fields outside messages；body逐 value不变；
+- Inbound credential/identity/vision/request-ID headers不能覆盖 outbound headers；
+- Captured URL、headers 和 exact compact request bytes；
+- 每个 successful prepared request恰好一次 `completeChat` 或 `openChatStream` call，且不调用任何
+  protocol converter/fallback。
+
+### 14.4 Non-stream
+
+- 每个 representative `2xx`，包括非 200 status；
+- Empty、malformed、invalid UTF-8、null/array/scalar root；
+- Shared non-stream limit boundary 与 boundary + 1，default fixture 使用 32 MiB；
+- All upstream fields、duplicates、unknown/provider fields、member order、number lexeme 和 compact
+  exact bytes；
+- Response model/ID/choices/reasoning/tools 不改写；
+- Usage absent/valid/malformed/duplicate：wire不变，side observation符合第 13 节；
+- Invalid response 在 commit 前为 exact 502，且不返回 partial body。
+
+### 14.5 Stream parser 与 exact wire
+
+同一 fixture 必须在 every byte split point 运行，包括 multibyte UTF-8 内部，并覆盖：
+
+- BOM、LF、CRLF、CR；
+- comment、blank event、unknown fields、`id`/`retry`、multiple `data` lines；
+- role/content/tool/reasoning/provider-extension chunks；
+- usage-only chunk 与 multiple usage observations；
+- exact compact `data: <json>\n\n` bytes；
+- exact `[DONE]`、zero-chunk Done、duplicate Done 和 post-Done data；
+- `[DONE]` 前后 whitespace、wrong case 和 JSON string；
+- `event:error`、root `error` object 和 confidential error payload redaction；
+- malformed/non-object JSON、invalid UTF-8、residual line/event/code point；
+- clean EOF without Done 和 finish-reason-without-Done；
+- SSE event limit boundary 与 boundary + 1，default fixture 使用 4 MiB；
+- upstream comments/other fields 不出现在 downstream；
+- parser/transport/timeout failure 在 first byte 前返回 JSON 502，在 first byte 后只关闭；
+- success terminal恰好一次，failure/abort terminal 为零次。
+
+### 14.6 Backpressure、abort 与 resource closure
+
+- Slow downstream 不触发 upstream background reads，最多一个 unconsumed emit-ready frame；
+- Abort while queued、reading body、binding account/catalog、connecting、before first frame、mid-frame、
+  between frames、during terminal write；
+- 每个 abort 从该时刻起新增 bytes 为零；
+- Same upstream operation 被取消，iterator `return()` 被调用；
+- Permit、timer、listener、body、socket、decoder 与 request state 恰好释放；
+- Repeated success/failure/abort 后 active counters 归零且不存在 unbounded retained chunks。
+
+Request capture fixtures 必须断言 complete URL、fixed identity headers、vision header presence、exact body
+bytes 和 logical Chat call count；只做 parsed-object deep equality 不足以替代 wire golden。
+
+## 15. Completion criteria
+
+Implementation 只有同时满足以下条件才完成：
+
+1. 本 route 是唯一 registered OpenAI Chat route，且始终使用 native Chat upstream path。
+2. Decoder 使用 `WireJson`，拒绝全部 top-level duplicates，并保留非-owned fields 的 order、
+   values 和 number lexemes。
+3. Explicit model exact-match、preferred-model fallback、404/400 distinction 与 captured account catalog
+   完全符合第 4 节；不存在 silent fallback。
+4. Account、catalog、model、BoundCopilot target 与 config 对一次 request immutable。
+5. Final request只按第 6–7 节修改 `model`/stream-true `stream_options`；vision 只产生 typed flag。
+6. Non-stream 对任意 valid `2xx` object 保留全部 fields并 compact reserialize；invalid/oversized body 在
+   commit 前失败。
+7. Stream 经过 shared incremental parser和 OpenAI encoder；comments/other SSE fields不下发，usage
+   chunk保留，success必须且只输出一个 exact `[DONE]`。
+8. EOF/no-Done、error frame、truncation、timeout 与 parser failure 不会合成 success terminal；
+   pre-commit 使用普通 OpenAI HTTP error，post-commit只关闭。
+9. Pull backpressure、same-operation cancellation、abort零新增 bytes与 resource release全部通过。
+10. Usage 只做 content-free side aggregation，不改变 body/event或成为 response success 的前置依赖。
+11. 全部 fixtures offline，并覆盖 every byte split、request capture、exact wire、shared limit
+    boundaries、abort和 one Chat upstream call。
+12. Local links、Markdown fences与 tables有效，`git diff --check -- docs/openai_chat_completions.md` 通过。

--- a/docs/openai_responses_routing.md
+++ b/docs/openai_responses_routing.md
@@ -24,6 +24,8 @@ ChatBridgePlan
 4. 明确 native 与 Chat bridge 的 history 归属。
 
 本文不重新定义 Responses → Chat 的字段转换，也不定义 `/responses/compact`。
+首字节前的 HTTP limits、admission、timeout、request ID 和公开 error envelope 由
+[Gateway HTTP contracts](./gateway_http_contracts.md) 定义。
 
 只注册：
 
@@ -38,15 +40,16 @@ POST /v1/responses
 ```text
 planResponsesExecution(
   request: ResponsesRequest,
-  model: ResolvedModel,
+  resolvedModel: ResolvedModel,
   target: BoundCopilotTarget
 ) -> NativeResponsesPlan | ChatBridgePlan
 ```
 
 ```text
 ResolvedModel {
-  requestedModel: string
+  requestedModel?: string
   upstreamModel: string
+  source: "explicit" | "preferred"
   routing: ResponsesRoutingMetadata
 }
 
@@ -57,16 +60,16 @@ ResponsesRoutingMetadata {
 
 NativeResponsesPlan {
   kind: "native_responses"
-  request: ResponsesRequest
-  upstreamModel: string
+  originalRequest: ResponsesRequest
+  resolvedModel: ResolvedModel
   upstreamUrl: string
   stream: boolean
 }
 
 ChatBridgePlan {
   kind: "chat_bridge"
-  request: ResponsesRequest
-  upstreamModel: string
+  originalRequest: ResponsesRequest
+  resolvedModel: ResolvedModel
 }
 ```
 
@@ -76,6 +79,32 @@ Planning 发生在 request converter 之前。Planner 可以读取已绑定账�
 调用 planner 前必须用与实际 upstream request 相同的 model resolver 得到一个
 `ResolvedModel`。Capability gate 只读取该 resolved model 的 metadata；alias、默认模型或
 deployment mapping 不得在 planning 后再次改变 model。
+
+以上 signature 与 two plan shapes 是唯一 canonical definition。Architecture、master spec 和
+implementation 只引用它们，不重新定义另一种 prepared plan。
+
+Model property 缺失时只使用 Bound Account 的 valid、仍存在于 captured catalog 的 preferred model。
+显式 model 必须是 non-empty string 且精确存在于 catalog；未知显式 ID 返回 HTTP 404，不 fallback
+preference。缺失且无 valid preference 或显式类型/空值错误返回 HTTP 400。具体 presenter 由 Gateway
+HTTP contract 定义。
+
+### 2.1 `WireJson` request decoder
+
+Gateway 先按 HTTP contract 取得一个 bounded `WireJsonObject`。Responses decoder 规则：
+
+1. 所有 decoded top-level member names 必须唯一；duplicate known/unknown/escaped-equivalent key 都是
+   HTTP 400 `invalid_request`。Nested duplicate policy 留给对应 field conversion/native preservation。
+2. `model` missing 允许进入 preferred-model resolution；present 时必须是 non-empty string。Null、其他
+   type 或 empty string 是 HTTP 400；whitespace 不 trim，通常在 catalog exact lookup 得到 404。
+3. `stream` missing 等价 execution `false`，但不向原 request 注入字段；present 时只接受 JSON boolean。
+   Null/string/number/array/object 是 HTTP 400。
+4. Decoder 不对白名单外 field 做 schema coercion、default 或丢弃；它保留 source member order、number
+   lexeme、nested values 和明确的 missing/null/false/0/empty。
+5. Native plan reserializes this ordered request under section 5；ChatBridgePlan 把同一个 decoded request
+   交给 bridge conversion spec。两条路径不能各自定义第二套 top-level decoder。
+
+Decoder output contains the ordered original request、typed `model` presence/value and boolean execution `stream`。
+任何 decoder failure 都发生在 account/CAPI/upstream call 前。
 
 ## 3. Native capability
 
@@ -87,7 +116,9 @@ deployment mapping 不得在 planning 后再次改变 model。
    string `"/v1/responses"`：native；
 4. 其他情况：Chat bridge。
 
-Model metadata lookup error、unknown model 或 malformed routing metadata 都安全回退到 Chat bridge。
+只有已经按第 2 节成功 catalog-resolve 的 model 才进入 capability lookup。该 resolved model 的 private
+routing metadata lookup error、missing 或 malformed 时安全回退到 Chat bridge；显式 model 不在 catalog
+是前置 404，不属于本 fallback。
 
 不得使用以下条件推断 native：
 
@@ -232,6 +263,61 @@ event。
 - 未来的跨账号或跨 deployment retry 必须重新 planning，不能在同一 attempt 中改变 wire mode。
 - 已开始 native stream 后不合成 Chat bridge event 或 `response.failed`。
 
+### 7.4 Native usage observation
+
+Native wire 不因 telemetry 改变。Side observation 只接受 nonnegative integer：
+
+```text
+response.usage.input_tokens                    -> inputTokens
+response.usage.output_tokens                   -> outputTokens
+response.usage.input_tokens_details.cached_tokens -> cachedTokens
+```
+
+Non-stream 从完整 response 读取一次。Stream 只从具有 `response` object 的 typed terminal event 读取，
+每个 counter last-valid-wins；missing/invalid 不清除早先 valid value。不得 coerce、从 total 推导或
+修改 event。`response.failed`/`status:"failed"`/native `type:"error"` 仍按第 7 节作为合法 2xx protocol
+content 转发，但 Usage Bucket outcome 记为 `upstream_error`；其他合法 terminal 为 `success`。
+
+### 7.5 Downstream Responses SSE wire
+
+Both execution plans use one route-owned encoder：
+
+```http
+Content-Type: text/event-stream; charset=utf-8
+Cache-Control: no-cache
+x-request-id: <gateway-request-id>
+```
+
+Each typed Responses event must have a non-empty string `type` and is encoded exactly as：
+
+```text
+event: <type>\n
+data: <ordered-compact-json>\n\n
+```
+
+There is no `[DONE]` marker、SSE `id:`/`retry:` field、extra blank event or synthetic heartbeat in protocol output。
+Bridge events retain their constructed member order；native events retain upstream member order except the section 7.2
+item-ID normalization。
+
+Native upstream `2xx` stream must have `text/event-stream` media type and is parsed with the shared incremental UTF-8/SSE
+framer：one initial BOM allowed，LF/CRLF/CR、comments and multi-`data` lines behave as in the OpenAI Chat SSE spec，
+and each complete event is bounded by the captured SSE-event limit。Data must be one JSON object with a non-empty string
+`type`。An optional upstream `event:` field must exactly equal object `type`；missing is allowed and downstream derives
+it from the object。`[DONE]`、malformed/non-object data、type mismatch、invalid UTF-8 or incomplete EOF is invalid
+upstream response。
+
+Terminal ownership：
+
+- `ChatBridgePlan` succeeds only after encoding its single `response.completed` event。
+- `NativeResponsesPlan` succeeds after forwarding one of `response.completed`、`response.failed`、
+  `response.incomplete` or `error`；the first terminal is absorbing。
+- Clean EOF before a terminal is truncated failure。No plan synthesizes a terminal on EOF。
+- Pre-commit failure returns the ordinary Responses HTTP error。Post-commit failure closes the connection without an
+  additional event。
+
+The stream is pull-based and reads at most one unconsumed emit-ready event。Client abort cancels the same upstream
+operation、calls iterator `return()` and writes zero additional bytes。
+
 ## 8. History ownership
 
 Native plan 使用 GitHub Copilot Responses 自身的 `previous_response_id`、reasoning
@@ -264,10 +350,14 @@ response ID。
 
 必须覆盖：
 
+- top-level duplicate known/unknown/escaped key；
+- model missing/explicit type/empty/unknown 与 preferred resolution；
+- stream missing/false/true/wrong type；
 - `mode:"responses"` native；
 - `mode:"chat"` 即使 endpoints 包含 Responses 仍 bridge；
 - mode missing + `/v1/responses` native；
-- unknown/malformed/lookup error bridge；
+- catalog-resolved model 的 routing metadata missing/malformed/lookup error bridge；catalog-unknown explicit
+  model 404；
 - `gpt-*`、vendor、hostname 不参与推断；
 - planning 后 metadata 变化不改变当前 request；
 - native URL 精确为 normalized base + `/responses`；
@@ -275,6 +365,7 @@ response ID。
 - native non-stream 不重写 IDs/usage；
 - native stream 不经过 Chat decoder/converter，但按 `output_index` 统一 added/sub-event/done item IDs；
 - 每个 native stream 的 item-ID map 相互隔离；
+- native/bridge exact `event:` + `data:` LF wire、terminal set、no `[DONE]`、EOF truncation；
 - native failure 不进行 same-provider protocol fallback；
 - native 不读写 local history；
 - bridge path 与原转换规范 fixtures 完全一致；

--- a/docs/research/native_responses_and_anthropic_models.md
+++ b/docs/research/native_responses_and_anthropic_models.md
@@ -6,7 +6,7 @@
 
 1. OpenAI Responses 请求何时可以直接调用上游 `/responses`，而不是转换为
    `/chat/completions`；
-2. LiteLLM Proxy 如何在模型列表接口返回 Anthropic-compatible shape，以及当前 ghcp-gateway
+2. LiteLLM Proxy 如何在模型列表接口返回 Anthropic-compatible shape，以及当前 ghc-gateway
    文档是否覆盖。
 
 固定源码：
@@ -182,7 +182,7 @@ LiteLLM 注册 `/v1/responses/compact`、`/responses/compact` 和
 没有源码证据证明 GitHub Copilot CAPI 支持 compact。cc-switch 在 Chat/Anthropic 模式下把 compact
 请求改发普通生成 endpoint，这不等同于真实 compaction primitive。
 
-### 2.7 对 ghcp-gateway 的结论
+### 2.7 对 ghc-gateway 的结论
 
 - 应支持 `NativeResponsesPlan | ChatBridgePlan`。
 - Native gate 应使用明确 model metadata，不按 `gpt-*` 或 vendor 猜测。
@@ -227,7 +227,7 @@ Anthropic formatter 接收与默认 OpenAI model list 相同的、已经按当�
 - `BerriAI/litellm@ae7e50f:litellm/proxy/auth/model_checks.py:97-244`
 - `BerriAI/litellm@ae7e50f:tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py:2076-2105`
 
-在 ghcp-gateway 中，这对应同一份已经按默认 GitHub Copilot 账号取得并过滤的 CAPI catalog。
+在 ghc-gateway 中，这对应同一份已经按默认 GitHub Copilot 账号取得并过滤的 CAPI catalog。
 
 ### 3.3 Response shape
 
@@ -268,7 +268,7 @@ Header 只改变成功 serializer。认证、invalid scope 或内部错误不自
 
 ### 3.4 `/models` alias
 
-LiteLLM 同时注册 `/v1/models` 与 `/models`。ghcp-gateway 当前文档明确只注册 `/v1/models`。
+LiteLLM 同时注册 `/v1/models` 与 `/models`。ghc-gateway 当前文档明确只注册 `/v1/models`。
 
 Anthropic-compatible response 不依赖 `/models` alias；在 `/v1/models` 上进行 header content
 negotiation 即可满足 Claude 客户端 discovery。是否增加 alias 是独立兼容性决策。

--- a/docs/specs/refactor_master_spec.md
+++ b/docs/specs/refactor_master_spec.md
@@ -1,0 +1,2161 @@
+# ghc-gateway 重构 Master Spec
+
+> 状态：实现与交付的可执行 contract
+> 目标项目：`ghc-gateway`
+> npm package：`@ljie-pi/ghc-gateway@0.1.0`
+> executable：`ghcg`
+> 实现分支：`refactor`
+> 本规范分支：`refactor-master-spec`
+
+## 1. 使用方式与合并纪律
+
+本文只固定跨模块约束、交付顺序、文件所有权、接口、状态归属与验收门槛。协议字段、event
+ordering 和 wire bytes 不在这里重写；实现 agent 必须按第 3 节的 context pointer 读取对应生产规范。
+
+`RM-00` 是当前 master-spec PR 代表的 virtual pre-implementation gate，不创建 GitHub issue。该 PR
+合并到 `refactor` 后，维护者才可：
+
+1. 按第 12 节模板创建 `RM-01` 至 `RM-22` 的 GitHub issues；
+2. 按第 11 节表建立 native dependency edges；
+3. 从最新 `refactor` 创建实现分支；
+4. 为每个 issue 提交一个以 `refactor` 为 base 的 coherent PR。
+
+`RM-01` issue 记录 `RM-00` merge commit 作为 `Spec baseline`，但不创建不存在的 native issue
+dependency。后续 native dependency graph 只包含 `RM-01` 至 `RM-22`。
+
+依赖 issue 未合并时，不创建 stacked implementation PR。实现期间 `main` 不动；所有 coding-agent PR
+都以 `refactor` 为 base。最终 promotion、npm publish 与 repository rename 是第 15 节的维护者操作，
+不是 implementation slice。
+
+每个 slice 以可观察行为和测试完成，不以代码行数、文件数或“主体已写完”作为完成标准。非默认的新
+TypeScript app 可以只注册已经完成的 routes；任何默认 entrypoint 都不得包含 `TODO`、stub handler，
+也不得 fallback 到 legacy JavaScript handler。
+
+## 2. Scope 与 non-goals
+
+### 2.1 In scope
+
+- Node.js 24、ESM、strict TypeScript、Hono、`@hono/node-server`、Undici。
+- 单一 npm package、单一 gateway process；Svelte 5 + Vite 构建为同进程提供的静态 Admin SPA。
+- `better-sqlite3`、WAL、`synchronous=FULL`、显式 migrations。
+- 以下完整 public routes：
+
+| Method | Route | Owner |
+| --- | --- | --- |
+| `POST` | `/v1/chat/completions` | `OpenAiChatEndpoint` |
+| `POST` | `/v1/responses` | `ResponsesEndpoint` |
+| `POST` | `/v1/messages` | `AnthropicMessagesEndpoint` |
+| `GET` | `/v1/models` | `ModelCatalogRoutes` |
+| `POST` | `/api/chat` | `OllamaChatEndpoint` |
+| `GET` | `/api/tags` | `ModelCatalogRoutes` |
+| `GET` | `/api/version` | `OllamaVersionRoute` |
+| `GET` | `/healthz` | `GatewayFoundation` |
+| `GET` | `/readyz` | `GatewayFoundation` |
+| `GET` | `/admin/*` | `AdminStaticRoute` |
+| varies | `/admin/api/v1/*` | `AdminApi` |
+
+- `ghcg serve/start/stop/restart/status`；`auth`、`accounts`、`models`、`config`、`admin open`
+  command groups。
+- GitHub.com 与 GHES accounts、file-backed secrets、model catalog、native Responses 与 Chat bridge。
+- Responses History、Usage Buckets、Operational Events、JSONL log rotation、resource/performance gates。
+- Windows x64、Linux x64/arm64、macOS x64/arm64 上的 Node.js 24 delivery。
+- clean-break rename、legacy removal、pack/install smoke、README 与 release handoff。
+
+### 2.2 Non-goals
+
+- 不提供 `ghcg chat`、protocol plugins、provider profiles、runtime behavior profiles 或 arbitrary
+  third-party providers。
+- 不注册 `/models`、`/responses`、`/openai/v1/responses`、`/claude/v1/messages`、
+  `/v1/responses/compact`、尾斜杠或旧名称 aliases。
+- 不导入 `ghcp-ollama`/`ghcp-gateway` 的 data、config、credentials 或 process state。
+- 不保留 `ghcp-ollama`、`ghcp-gateway`、`ghcpo`、`ghcpo-server` runtime aliases。
+- 不引入 OS supervisor、watchdog、automatic restart、multi-process gateway、Redis、ORM、WebSocket
+  或 SvelteKit server。
+- 不把协议转换成可逆的 canonical message model，不建立通用 `BaseAdapter`、`StreamTransformer`
+  或统一 public error envelope。
+- 不按 model name、vendor、hostname 或历史成功结果猜测 capability。
+- 不因 performance degradation 使 `/healthz` 或 `/readyz` 失败，不自动调参。
+
+## 3. Sources of truth 与 context pointers
+
+### 3.1 Priority by scope
+
+来源不是一条模糊的全局覆盖链；先按责任范围选唯一来源，再解决冲突：
+
+| Scope | Normative source | 何时必须读取 |
+| --- | --- | --- |
+| 已确认的名称、技术栈、全局 limits、security、DAG、cutover gates | 本文 | 每个 slice 开始与交接时 |
+| Shared HTTP admission、limits、timeouts、pre-commit errors、headers | [Gateway HTTP contracts](../gateway_http_contracts.md) | 修改任何 route、middleware、body/stream pump 或 error presenter 前 |
+| OpenAI Chat native success behavior | [OpenAI Chat](../openai_chat_completions.md) | 修改 `/v1/chat/completions` request、model resolution、JSON/SSE success 前 |
+| Module/interfaces/state ownership | [Architecture](../architecture.md) | 修改 composition、module seam、state、persistence、CLI/Admin 前 |
+| OpenAI Responses plan/native behavior | [Responses routing](../openai_responses_routing.md) | 修改 Responses planning、native URL/body/stream/history ownership 前 |
+| Responses Chat bridge | [Responses bridge](../codex_response_to_chat_completions.md) | 修改 request/history/tool/reasoning/nonstream/stream conversion 前 |
+| Anthropic Messages bridge | [Anthropic bridge](../claude_messages_to_chat_completions.md) | 修改 `/v1/messages` object/event/wire behavior 前 |
+| Ollama Chat bridge | [Ollama bridge](../ollama_chat_to_chat_completions.md) | 修改 `/api/chat` object/NDJSON behavior 前 |
+| CAPI catalog与三种 model serializers | [Model listing](../github_copilot_model_listing_apis.md) | 修改 credentials/CAPI cache、`/v1/models`、`/api/tags` 前 |
+| Canonical vocabulary | [CONTEXT](../../CONTEXT.md) | 命名 module、state、history、checkpoint、telemetry 前 |
+| Durable decisions | [ADR-0001](../adr/0001-protocol-endpoint-modules.md), [ADR-0002](../adr/0002-file-backed-secret-store.md), [ADR-0003](../adr/0003-clean-break-rename.md), [ADR-0004](../adr/0004-self-managed-daemon.md) | 修改相应决策前 |
+| Delivery workflow | [AGENTS](../../AGENTS.md) | 创建 issue、branch、PR 或修改规范前 |
+
+`docs/gateway_http_contracts.md` 与本文同属 `RM-00` merge prerequisite。实现 agent 不得自行填补其
+空白。它与协议规范冲突时：shared pre-first-byte
+HTTP behavior 由该文件负责，协议 object/event/terminal/wire behavior 由对应协议规范负责。无法按
+scope 消解的冲突必须阻塞 issue，由 spec-only PR 修正文档，不能由 implementation PR 选择。
+该文件中的 resource/time numeric values 必须在 `RM-00` 合并前标明为第 7.2、8.1 节的 configurable
+defaults，listener 必须表达为 fixed host `127.0.0.1` + configurable default port `31400`；不能把
+已确认的 startup/runtime config 写成 immutable constants。
+
+Legacy source、legacy tests、`docs/cc-switch/` 与 `docs/litellm/` 都不是可选 production profile。
+只有上述生产规范明确指向的 pinned upstream commit 才可用于核对；固定 commit 与说明文字冲突时，
+遵守生产规范写明的优先级。
+
+### 3.2 `RM-00` 必须关闭的 normative gaps
+
+Master-spec PR 必须在创建实现 issues 前同步：
+
+- `docs/architecture.md` 中的项目名、file-backed `CredentialStore`、并行 build/cutover 命名；
+- `CONTEXT.md` 的 canonical terms；
+- `docs/adr/*.md` 的 clean-break、secret file、self-managed daemon 决策；
+- `docs/openai_chat_completions.md` 的 OpenAI Chat success behavior；
+- `docs/gateway_http_contracts.md` 的 probes、header validation、overload bodies、timeout/abort 与 exact
+  route behavior；
+- 本文的 slice IDs、paths、test names 与 dependency edges。
+
+这些是 spec PR 的决定，不是后续 agent 的设计任务。实现中发现新 gap 时，当前 slice 标记
+`blocked`，先合并 spec-only correction，再恢复实现。
+
+`/api/version` 的 closure 必须固定为无需 Bound Account、无需 inference admission 的
+`200 application/json; charset=utf-8`，body 为 compact UTF-8
+`{"version":"0.1.0"}`，其中 version 来自 RM-01 target build version source，并在 RM-22 与
+`package.json` 强制一致；它不读取 Ollama model catalog。
+OpenAI Chat success 的唯一 model-resolution、request reserialization、nonstream validation 与
+successful SSE terminal rules 必须在 `docs/openai_chat_completions.md` 落地，不能只存在于 issue 描述。
+
+### 3.3 Fixture closure
+
+每个 golden case 使用稳定英文 `caseId`，并在相邻 `manifest.json` 记录：
+
+```json
+{
+  "caseId": "ollama.stream.sparse-tool-indexes",
+  "owner": "RM-10",
+  "source": "docs/ollama_chat_to_chat_completions.md#73-tool-calls",
+  "input": "stream/sparse-tool-indexes.input.jsonl",
+  "expected": "stream/sparse-tool-indexes.expected.ndjson",
+  "encoder": "go-reference"
+}
+```
+
+Fixture families 与唯一 owner：
+
+| Family | Owner | Required categories |
+| --- | --- | --- |
+| `wire-json` | `RM-02` | number lexemes、member order、duplicate members、Unicode、canonical sort、limits |
+| `gateway-http-host` | `RM-03` | body read、admission、generic limits/timeouts、commit boundary、raw headers、abort、route registration |
+| `accounts` | `RM-06` | host normalization、stable identity、login/remove/relogin、ACL failures |
+| `copilot-transport` | `RM-07` | token refresh、endpoint discovery、redirect、SSE byte splits、cancel |
+| `model-catalog` | `RM-08` | strict CAPI DTO、cache generations、three serializers、model-list presenter |
+| `openai-chat` | `RM-09` | buffered、SSE、usage/presenter、model resolution、abort |
+| `ollama` | `RM-10` | request、nonstream、stream reducer/presenter、Go byte goldens |
+| `anthropic` | `RM-11` | request、nonstream、stream lifecycle/presenter、Python SSE text goldens |
+| `responses-core-history` | `RM-12` | request DTO/decoder、enrichment、unique/ambiguous call lookup、TTL/eviction/checkpoint |
+| `responses-native` | `RM-13` | routing matrix、native request/JSON/SSE、stable item IDs |
+| `responses-bridge-request` | `RM-14` | input/tools/media/reasoning/history/canonical JSON |
+| `responses-bridge-nonstream` | `RM-15` | envelope/items/tools/images/usage/managed IDs |
+| `responses-bridge-stream` | `RM-16` | item lifecycle、sequence、late tools、terminal/checkpoints |
+| `responses-endpoint` | `RM-17` | native/bridge integration、presenter、commit、post-commit failure、aliases |
+
+Golden 更新只能由显式 `npm run fixtures:generate -- --case <caseId> --accept` 产生并在 PR 中人工审阅。
+CI 运行 `npm run fixtures:verify`，不得隐式更新 snapshots，不访问网络，不把随机 UUID/clock 写入 expected。
+
+## 4. System invariants
+
+1. **Parallel app, atomic cutover**：legacy JavaScript 保持默认可运行；新 TypeScript app 使用
+   `*:refactor` scripts 和 `dist-refactor/`，在 `RM-22` 前不改变 `npm start`、published bins 或
+   default package entrypoint。`RM-22` 一次切换并删除 legacy。
+2. **No legacy fallback**：新 app 的 route 要么由对应 TypeScript `Protocol Endpoint Module`
+   完整处理，要么未注册而返回 404；不 import、spawn 或 proxy legacy handler。
+3. **One package/process**：生产只有一个 npm package、一个 Node.js gateway process、一个 SQLite
+   connection；Admin assets 在同一 Hono app 中提供。
+4. **Protocol locality**：OpenAI Chat、Ollama、Anthropic、Responses native、Responses bridge
+   各自拥有 decoder、state machine、terminal 与 wire encoder；shared raw SSE/WireJson 不知道下游协议。
+5. **Real seams only**：只有 production adapter 与 scripted/memory test adapter 都存在时才建立
+   swappable seam。Hono、`better-sqlite3` 与单一 serializer 直接位于 implementation 内，不增加
+   `HttpFrameworkPort`、`DatabasePort` 或 pass-through repository。
+6. **Immutable request state**：每个 request 恰好绑定一次 `Bound Account`、resolved model、
+   runtime config snapshot 与 cancellation signal；默认账号、model 或配置变化不影响在途请求。
+7. **Exact wire is behavior**：missing/null/false/0/empty、member order、number lexeme、SSE/NDJSON
+   framing、terminal ownership 与 bytes 都由 fixtures 验证。
+8. **Loopback only**：listener host 只接受 literal `127.0.0.1`，default port 为 `31400`；startup config
+   可以改变 port，但不能改变 host。`::1`、hostname 与任何其他 address 都在 socket 创建前明确失败。
+   Inference routes 无 gateway API key。
+9. **Secrets stay separate**：OAuth/Copilot/admin/control secrets 只在 protected atomic file 与内存；
+   不进 SQLite、logs、metrics、Operational Events 或 public errors。
+10. **Bounded state**：body、events、accumulators、active/queued requests、history、telemetry、logs、
+    subscribers 与 caches 都有明确上限和 cleanup。
+11. **Offline verification**：所有 fixtures、scripted upstream、OAuth/CAPI fakes、Playwright flows 和
+    benchmarks 在 outbound network blocked 时运行。
+12. **Observable degradation only**：5-minute rolling windows 连续三个超阈值进入 `degraded`；连续三个
+    恢复窗口清除。状态出现在 Admin 并各写一个 sanitized `Operational Event`，不影响 health/readiness，
+    不自动改变 concurrency、SQLite mode 或 protocol behavior。
+13. **Validation split**：每个 inference `Protocol Endpoint Module` 从 `WireJson` 使用显式 decoder；
+    Admin/config DTO 使用 TypeBox 且 coercion disabled。两者不能用 `JSON.parse()` + broad casts、
+    schema defaults 或 coercion 互相替代。
+
+## 5. Canonical target tree 与 parallel-build rule
+
+新 `.ts` files 可与 legacy `.js` files 同处 `src/`；TypeScript config 只 include `.ts`。直到
+`RM-22`，legacy `src/server.js`、`src/serverctl.js`、`src/ghcpo.js` 与 `src/utils/**/*.js` 保持默认路径。
+
+```text
+src/
+  main.ts
+  version.ts
+  cli/
+    main.ts
+    commands/
+  daemon/
+    controller.ts
+    identity_file.ts
+    local_control.ts
+  gateway/
+    create_gateway.ts
+    hono_app.ts
+    request_scope.ts
+    admission.ts
+    body_reader.ts
+    stream_response.ts
+    failures.ts
+  serialization/
+    wire_json.ts
+    canonical_json.ts
+  config/
+    startup_config.ts
+    runtime_config.ts
+    schema.ts
+  persistence/
+    database.ts
+    migrations.ts
+    migrations/
+      001_runtime_config.ts
+      010_accounts.ts
+      020_telemetry.ts
+      030_responses_history.ts
+  accounts/
+    account_directory.ts
+    credential_store.ts
+    device_flow.ts
+    github_environment.ts
+  copilot/
+    backend.ts
+    transport.ts
+    token_refresh.ts
+    endpoint_discovery.ts
+    chat_sse.ts
+    model_catalog.ts
+  protocols/
+    chat_completions/
+      types.ts
+      decoder.ts
+    openai_chat/
+      endpoint.ts
+      wire.ts
+    model_catalog/
+      routes.ts
+      wire.ts
+    ollama_chat/
+      endpoint.ts
+      bridge.ts
+      stream.ts
+      wire.ts
+      version.ts
+    anthropic_messages/
+      endpoint.ts
+      bridge.ts
+      stream.ts
+      wire.ts
+    responses/
+      endpoint.ts
+      planner.ts
+      native.ts
+      history.ts
+      bridge_request.ts
+      bridge_nonstream.ts
+      bridge_stream.ts
+      tool_context.ts
+      wire.ts
+  telemetry/
+    logger.ts
+    usage.ts
+    operational_events.ts
+    performance.ts
+  admin/
+    auth.ts
+    api.ts
+    events.ts
+    static.ts
+web/
+  src/
+    views/
+      Overview.svelte
+      Accounts.svelte
+      Models.svelte
+      Configuration.svelte
+      ResponsesHistory.svelte
+      Events.svelte
+  vite.config.ts
+tests/refactor/
+  fixtures/
+  unit/
+  contract/
+  integration/
+  e2e/
+  performance/
+scripts/refactor/
+dist-refactor/                 # generated, never committed
+dist/                          # final package output, never committed
+```
+
+目录表达 locality，不要求一 type 一文件。只有状态机或 encoder 足够复杂时再拆文件。跨 slice 修改
+他人 owned path 前，先在 issue 中记录原因并由 owner/coordinator 确认；共享 composition files
+`src/main.ts` and `package.json` 的修改由依赖顺序串行完成。`createGateway` accepts route registrations，
+so later protocol slices do not edit `src/gateway/create_gateway.ts`。
+
+## 6. Key interfaces 与 state ownership
+
+以下是调用者必须知道的最小 interface；具体 DTO 仍由生产规范定义。
+
+```ts
+export interface Gateway {
+  fetch(request: Request): Promise<Response>;
+  close(): Promise<void>;
+}
+
+export function createGateway(
+  config: Readonly<GatewayConfig>,
+  routes: readonly RouteRegistration[],
+  dependencies: Readonly<GatewayDependencies>,
+): Promise<Gateway>;
+
+export interface DecodedHttpRequest {
+  readonly url: URL;
+  readonly headers: Headers;
+  readonly body?: WireJsonObject;
+}
+
+export type ProtocolEndpoint = (
+  request: Readonly<DecodedHttpRequest>,
+  scope: Readonly<RequestScope>,
+) => Promise<Response>;
+
+export type FailurePresenter = (
+  failure: Readonly<GatewayFailure>,
+  requestId: string,
+) => Response;
+
+export interface RouteRegistration {
+  readonly method: "GET" | "POST" | "PUT" | "DELETE";
+  readonly path: string;
+  readonly admission: "none" | "inference";
+  readonly body: "none" | "wire-json-object";
+  readonly presentFailure: FailurePresenter;
+  readonly endpoint: ProtocolEndpoint;
+}
+
+export interface RequestScope {
+  readonly requestId: string;
+  readonly signal: AbortSignal;
+  readonly config: Readonly<RuntimeConfigSnapshot>;
+}
+```
+
+Gateway Foundation owns body read/WireJson parse/admission；each Protocol Endpoint Module owns one
+`FailurePresenter` adapter and endpoint。For `anthropic-version`, an exact single value is accepted；the comma-merged
+value produced by duplicate Fetch headers cannot equal `2023-06-01` and is rejected。RM-03 tests the registration seam
+with a fake presenter；exact protocol presenter fixtures belong to the endpoint slice。
+
+`Gateway.fetch` 隐藏 Hono routing、admission、account binding、upstream、protocol state、persistence 与
+wire serialization。`close()` 幂等：停止 admission、abort in-flight、在有界 grace period 内 flush
+noncritical telemetry，再关闭 pool、SQLite 与 log writer。
+
+```ts
+export interface AccountDirectory {
+  bindDefault(signal: AbortSignal): Promise<BoundAccount>;
+  list(): readonly AccountSummary[];
+  use(accountId: AccountId, expectedRevision: number): Promise<AccountRevision>;
+  remove(accountId: AccountId, expectedRevision: number): Promise<AccountRevision>;
+}
+
+export interface CredentialStore {
+  readGeneration(
+    accountId: AccountId,
+    generation: number,
+  ): Promise<SecretCredential | null>;
+  putGeneration(
+    accountId: AccountId,
+    generation: number,
+    value: SecretCredential,
+  ): Promise<void>;
+  removeAccount(accountId: AccountId): Promise<void>;
+  prune(references: ReadonlyMap<AccountId, number>): Promise<void>;
+}
+
+export interface AccountModelPreferences {
+  get(accountId: AccountId): Promise<ModelPreference | null>;
+  set(
+    accountId: AccountId,
+    candidate: Readonly<{
+      modelId: string;
+      catalogGeneration: number;
+    }>,
+    expectedRevision: number,
+  ): Promise<ModelPreference>;
+  markInvalidIfMissing(
+    accountId: AccountId,
+    visibleModelIds: ReadonlySet<string>,
+    catalogGeneration: number,
+  ): Promise<ModelPreference | null>;
+  clear(accountId: AccountId): Promise<void>;
+}
+
+export interface CopilotBackend {
+  bind(account: Readonly<BoundAccount>, signal: AbortSignal): Promise<BoundCopilot>;
+}
+
+export interface BoundCopilot {
+  readonly accountId: AccountId;
+  readonly target: Readonly<CopilotTarget>;
+  completeChat(request: Readonly<ChatRequest>): Promise<ChatResponse>;
+  openChatStream(request: Readonly<ChatRequest>): Promise<UpstreamByteStream>;
+  completeResponses(
+    request: Readonly<NativeResponsesUpstreamRequest>,
+  ): Promise<UpstreamByteResponse>;
+  openResponsesStream(
+    request: Readonly<NativeResponsesUpstreamRequest>,
+  ): Promise<UpstreamByteStream>;
+}
+
+export interface NativeResponsesUpstreamRequest {
+  readonly body: Uint8Array;
+  readonly hasVisionInput: boolean;
+  readonly initiator: "user" | "agent";
+}
+```
+
+`CredentialStore` 是真实 seam：production 使用 protected atomic file，tests 使用 memory adapter。
+`CopilotBackend` 是真实 seam：production 使用 Undici，contract tests 使用 scripted adapter。
+`AccountModelPreferences` is one deep SQLite module owned by RM-06，not a swappable persistence port；RM-08 invokes
+its invalidation method after catalog refresh。RM-08 owns `PreferredModelManager`，which validates an exact model
+against a captured catalog and passes `{modelId,catalogGeneration}` to this store；CLI/Admin use that manager and model
+resolution only reads the preference。Protocol modules 不知道 secret 格式、SQLite 或 HTTP client。
+
+```ts
+export interface CopilotModelCatalog {
+  get(accountId: AccountId, signal: AbortSignal): Promise<CatalogSnapshot>;
+  invalidate(accountId: AccountId): void;
+  clear(): void;
+}
+
+export interface ResponsesHistory {
+  enrich(
+    request: Readonly<ResponsesRequest>,
+    signal: AbortSignal,
+  ): Promise<ResponsesRequest>;
+  record(
+    record: Readonly<ResponsesHistoryRecord>,
+    signal: AbortSignal,
+  ): Promise<void>;
+}
+
+export interface ResponsesHistoryAdmin {
+  inspect(): ResponsesHistorySummary;
+  clear(expectedRevision: number): ResponsesHistorySummary;
+}
+```
+
+Admin 不获得 inference-only mutation interface；inference path 不获得 Admin clear/list interface。
+`ResponsesHistory` tests 对隔离的 SQLite database 运行 production implementation，不另写不同语义 fake。
+
+```ts
+export type WireJson =
+  | null
+  | boolean
+  | string
+  | { readonly kind: "number"; readonly lexeme: string }
+  | { readonly kind: "array"; readonly items: readonly WireJson[] }
+  | WireJsonObject;
+
+export interface WireJsonObject {
+  readonly kind: "object";
+  readonly members: readonly Readonly<{
+    key: string;
+    value: WireJson;
+  }>[];
+}
+```
+
+`WireJson` 是 deep module，不是 canonical protocol model。Protocol decoder 从它直接生成自己的 DTO。
+
+### 6.1 State ownership table
+
+| State | Owner | Lifetime/store | Invariant |
+| --- | --- | --- | --- |
+| request ID、abort、config | `RequestScope` | one request / memory | 不加入 protocol-specific cursors |
+| selected identity/credential/target | `BoundAccount` + `BoundCopilot` | one request / memory | bind once；默认变化不重绑 |
+| per-account preferred model/revision | `AccountModelPreferences` | SQLite | missing fallback only；catalog refresh marks invalid |
+| runtime config | `RuntimeConfigStore` | SQLite + immutable memory snapshot | revision compare-and-swap |
+| admission permits/queue | `AdmissionController` | process / bounded memory | 4 active、16 queued default |
+| stream/item/tool state | owning `Protocol Endpoint Module` | one `Stream Execution` | terminal 后释放，不跨协议共享 |
+| model catalog/generation | `CopilotModelCatalog` | process / per-account memory | no TTL；invalidate prevents stale writeback |
+| Responses History | `ResponsesHistory` | SQLite | only `ChatBridgePlan` |
+| Usage Buckets | `UsageRecorder` | SQLite batched | content-free、bounded |
+| Operational Events | `OperationalEventStore` | SQLite batched | sanitized、bounded |
+| admin bootstrap/session/CSRF | `AdminAuth` | process memory | restart invalidates all |
+| daemon PID/start identity/nonce/control token | `DaemonIdentityFile` | protected atomic file | authenticated control before action |
+| credentials/admin long-term secret | `FileCredentialStore` | protected atomic file | never SQLite/log |
+| JSONL files/rotation | `JsonlLogger` | data directory | 10 MiB × 5、max age 7d |
+
+### 6.2 Model resolution
+
+`ModelResolver` consumes one Bound Account、one captured Catalog Snapshot and a protocol-decoded model field。For
+OpenAI Chat、Anthropic Messages and OpenAI Responses：
+
+1. Missing model uses that account's preferred model only when preference state is `valid` and the exact ID exists in the
+   captured catalog。
+2. Explicit model must be a non-empty string and match a catalog ID exactly；type/empty failure is `invalid_request`，
+   unknown ID is `model_not_found`。
+3. Missing model with no valid visible preference is `invalid_request`；the gateway never silently chooses the first model。
+4. An explicit unknown model never falls back to preference and never reaches upstream。
+5. Resolution happens once。The returned `ResolvedModel { requestedModel, upstreamModel, source, routing }` is immutable
+   for the request；Responses planning reads its private routing metadata。
+
+`model_not_found` uses HTTP 404 `not_found_error` in OpenAI presenters and HTTP 404 `not_found_error` in Anthropic。
+Ollama does not use this shared fallback：its production spec requires an explicit non-empty model and preserves it for
+upstream handling。
+
+## 7. Persistence, migrations 与 config contract
+
+### 7.1 SQLite v1 logical schema
+
+Implementations may add indexes required by the documented queries, but may not change ownership or retention:
+
+```sql
+schema_migrations(
+  version INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  checksum TEXT NOT NULL,
+  applied_at_ms INTEGER NOT NULL
+)
+
+runtime_config(
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  revision INTEGER NOT NULL,
+  config_json TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+)
+
+accounts(
+  account_id TEXT PRIMARY KEY,
+  revision INTEGER NOT NULL,
+  normalized_host TEXT NOT NULL,
+  numeric_user_id TEXT NOT NULL,
+  environment_kind TEXT NOT NULL CHECK (environment_kind IN ('github.com', 'ghes')),
+  login TEXT,
+  display_name TEXT,
+  authenticated_at_ms INTEGER,
+  credential_generation INTEGER,
+  credential_state TEXT NOT NULL CHECK (credential_state IN ('active', 'removing', 'removed')),
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  UNIQUE(normalized_host, numeric_user_id)
+)
+
+gateway_preferences(
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  revision INTEGER NOT NULL,
+  default_account_id TEXT REFERENCES accounts(account_id),
+  updated_at_ms INTEGER NOT NULL
+)
+
+account_model_preferences(
+  account_id TEXT PRIMARY KEY REFERENCES accounts(account_id),
+  revision INTEGER NOT NULL,
+  model_id TEXT NOT NULL,
+  validity TEXT NOT NULL CHECK (validity IN ('valid', 'invalid')),
+  catalog_generation INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+)
+
+responses_history_state(
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  revision INTEGER NOT NULL,
+  next_insertion_seq INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+)
+
+responses(
+  response_id TEXT PRIMARY KEY,
+  insertion_seq INTEGER NOT NULL UNIQUE,
+  created_at_ms INTEGER NOT NULL,
+  expires_at_ms INTEGER NOT NULL
+)
+
+response_calls(
+  response_id TEXT NOT NULL REFERENCES responses(response_id) ON DELETE CASCADE,
+  ordinal INTEGER NOT NULL,
+  call_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  item_json TEXT NOT NULL,
+  PRIMARY KEY(response_id, ordinal)
+)
+
+usage_buckets(
+  utc_hour_ms INTEGER NOT NULL,
+  account_id TEXT NOT NULL,
+  protocol TEXT NOT NULL CHECK (protocol IN (
+    'openai_chat', 'openai_responses_native', 'openai_responses_bridge', 'anthropic', 'ollama'
+  )),
+  resolved_model TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK (outcome IN (
+    'success', 'client_error', 'authentication_error', 'overloaded',
+    'upstream_error', 'timeout', 'aborted', 'internal_error'
+  )),
+  request_count INTEGER NOT NULL,
+  error_count INTEGER NOT NULL,
+  input_tokens INTEGER NOT NULL,
+  output_tokens INTEGER NOT NULL,
+  cache_tokens INTEGER NOT NULL,
+  latency_sum_ms REAL NOT NULL,
+  latency_max_ms REAL NOT NULL,
+  PRIMARY KEY(utc_hour_ms, account_id, protocol, resolved_model, outcome)
+)
+
+operational_events(
+  event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  occurred_at_ms INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  severity TEXT NOT NULL CHECK (severity IN ('info', 'warning', 'error')),
+  metadata_json TEXT NOT NULL
+)
+
+telemetry_state(
+  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+  dropped_usage_updates INTEGER NOT NULL,
+  dropped_operational_events INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+)
+```
+
+Required indexes include `responses(expires_at_ms)`, `response_calls(call_id)`,
+`usage_buckets(utc_hour_ms)` and `operational_events(occurred_at_ms, event_id)`.
+`usage_buckets.account_id` intentionally has no cascading foreign key：usage remains queryable through credential/
+account cleanup and the telemetry migration can land independently of the account migration。
+
+Responses History revision changes once per transaction that changes visible history：new/updated Semantic Checkpoint、
+non-stream record、TTL cleanup、512-row eviction or non-empty clear。A no-op lookup/record/clear does not increment。
+`ResponsesHistoryAdmin.clear(expectedRevision)` compares and, when non-empty, clears rows and increments the singleton
+revision in the same transaction。`next_insertion_seq` is monotonic and never reset by clear。
+
+Retention cleanup is deterministic：
+
+- History deletes `expires_at_ms <= now_ms` before lookup/record, then evicts the lowest `insertion_seq` until at most
+  512 responses remain。
+- Usage deletes rows whose `utc_hour_ms < floorToUtcHour(now_ms - retentionDays)`；if rows still exceed 100,000, delete
+  by `utc_hour_ms, account_id, protocol, resolved_model, outcome` ascending until the cap is met。
+- Operational Events delete `occurred_at_ms <= now_ms - retentionDays`，then lowest `event_id` until at most 512 remain。
+- Cleanup runs at startup and in the owning read/write transaction；no correctness depends on a timer。
+
+Migration versions are reserved to avoid conflicts between parallel slices:
+
+| Version | Owner | Content |
+| ---: | --- | --- |
+| `001` | `RM-04` | migrations + `runtime_config` |
+| `010` | `RM-06` | accounts + preferences |
+| `020` | `RM-05` | usage + operational events |
+| `030` | `RM-12` | Responses History |
+
+Each migration file exports one immutable `{version,name,sql}` object and its filename begins with the same
+three-digit version。`scripts/refactor/generate_migrations.ts` performs build-time filesystem discovery, rejects
+filename/export mismatch or duplicate/reserved-owner violations, computes checksums and generates an ordered manifest
+under the uncommitted build directory。Production imports that generated static manifest；it does not discover runtime
+files and npm does not need to ship loose SQL assets。A later slice registers a migration only by adding its owned
+versioned `.ts` file。
+
+The runner applies every embedded-but-unapplied version in numeric order transactionally；reserved gaps are valid and
+`max(version)` is not the migration state, so a later-merged lower reserved version is still applied。It records
+checksums, refuses checksum drift or an applied version unknown to the binary, and never performs network I/O or large
+JSON conversion inside a transaction. It opens one main-thread
+`better-sqlite3` connection with WAL、`synchronous=FULL`、foreign keys、`busy_timeout=1000` ms、
+`wal_autocheckpoint=1000` pages、`journal_size_limit=67108864` bytes、prepared statements and short transactions.
+Only measured event-loop delay p95 over 10 ms may trigger a later worker evaluation; no slice may preemptively add a
+worker.
+
+### 7.2 Config
+
+- Startup config precedence is `CLI > GHC_GATEWAY_* environment > default` and contains only listener port、
+  data directory、log level。Canonical flags are `--port`、`--data-dir`、`--log-level` on `serve`/`start`；
+  canonical environment keys are `GHC_GATEWAY_PORT`、`GHC_GATEWAY_DATA_DIR`、
+  `GHC_GATEWAY_LOG_LEVEL`。Port default is 31400 and range is `1..65535`；data directory defaults to
+  `~/.ghc-gateway` and resolves to an absolute path；log level is `trace|debug|info|warn|error` with default `info`。
+  Startup config only takes effect at process start。
+- Runtime config uses SQLite as sole truth after initialization. Environment variables seed a missing row once, then
+  have no effect on later starts.
+- Admin/CLI updates decode with TypeBox without coercion, validate a complete candidate, compare expected revision in
+  one transaction, build an immutable `RuntimeConfigSnapshot`, atomically swap it, then invalidate affected caches。
+- Validation、revision conflict、write or snapshot build failure leaves the old row/snapshot active。
+- A request captures one snapshot at admission; a `Stream Execution` never observes a mid-stream update。
+- Reducing active/queue limits never cancels active requests or existing waiters。New admission pauses until active count is
+  below the new limit；existing waiters retain their captured queue deadline，while new waiters use the new snapshot。
+
+Canonical runtime registry：
+
+| Key | Default | Hard range | Unit/meaning |
+| --- | ---: | ---: | --- |
+| `limits.requestBodyBytes` | `33554432` | `1048576..67108864` | bytes |
+| `limits.sseEventBytes` | `4194304` | `65536..16777216` | bytes |
+| `limits.nonstreamBodyBytes` | `33554432` | `1048576..134217728` | bytes |
+| `limits.accumulatorBytes` | `33554432` | `1048576..134217728` | bytes |
+| `admission.activeMax` | `4` | `1..16` | active requests |
+| `admission.queueMax` | `16` | `0..64` | waiting requests |
+| `timeouts.queueMs` | `30000` | `1000..300000` | milliseconds |
+| `timeouts.connectMs` | `30000` | `1000..120000` | milliseconds |
+| `timeouts.firstByteMs` | `120000` | `5000..600000` | milliseconds |
+| `timeouts.streamIdleMs` | `120000` | `5000..600000` | milliseconds |
+| `timeouts.totalMs` | `1800000` | `60000..7200000` | milliseconds |
+| `accounts.maxAuthenticated` | `8` | `1..32` | active accounts |
+| `history.ttlDays` | `7` | `1..365` | days；global row cap fixed `512` |
+| `usage.retentionDays` | `90` | `1..365` | days；row cap fixed `100000` |
+| `events.retentionDays` | `7` | `1..30` | days；row cap fixed `512` |
+
+`ghcg config get/set` and Admin configuration use these identifiers。Startup-only port/data-dir/log-level and fixed
+row caps are readable status, not mutable runtime keys；attempting to set them or an unknown key fails without changing
+the revision。A first-seed environment name is `GHC_GATEWAY_` plus dot/camel segments converted to upper snake case，
+for example `limits.requestBodyBytes` → `GHC_GATEWAY_LIMITS_REQUEST_BODY_BYTES`。Environment text and CLI
+`config set` values are explicitly parsed to the key's primitive type before the complete candidate is validated；
+TypeBox itself always runs with coercion disabled。
+
+Fixed process capacities are not runtime-mutable：
+
+| Capacity | Hard cap | Overflow behavior |
+| --- | ---: | --- |
+| Pending telemetry mutations | `1024` | apply the type-specific coalesce/eviction policy below and increment bounded dropped counters |
+| In-memory Admin Sessions | `8` | reject a new bootstrap exchange with Admin capacity error |
+| Outstanding admin bootstrap tokens | `8` | reject minting a new token |
+| Active device flows | `8` | reject the ninth flow；each expires within 15 minutes |
+| Admin SSE subscribers | `8` | reject the ninth subscriber |
+| Per-subscriber pending events | `128` events or `1 MiB` | disconnect that slow subscriber |
+| Operational Event `metadata_json` | `16 KiB` | reject/truncate is forbidden；emit a smaller fixed `metadata_rejected` event when capacity permits |
+| One JSONL record | `64 KiB` | replace oversized metadata with a fixed sanitized overflow record |
+| Graceful shutdown | `10 seconds` | proceed to forced resource close after recording timeout when possible |
+| Daemon readiness | `30 seconds` | fail `start`, terminate the verified child and clean its identity file |
+
+Critical history/config/account/credential writes never enter the lossy telemetry queue。All overflow counters use fixed
+labels and saturate at JavaScript `Number.MAX_SAFE_INTEGER` so the counters themselves remain bounded。
+
+Telemetry saturation is deterministic：
+
+- A Usage update first coalesces into an existing pending bucket key。If the queue is full and the key is new，evict the
+  oldest pending Usage update；if no Usage update exists, drop the incoming Usage update。Increment
+  `droppedUsageUpdates` by the lost update's request count。
+- An Operational Event on a full queue evicts the oldest pending Operational Event；if none exists, drop the incoming
+  event。Increment `droppedOperationalEvents` once。
+- Neither type evicts the other。The next successful flush persists aggregate saturating counters in
+  `telemetry_state`；Admin exposes both counters and no recursive Operational Event is created for each drop。
+
+### 7.3 Account/secret cross-store commit
+
+SQLite account state is the activation authority; the secret file is storage, not proof that an account is active。
+
+1. Login validates the immutable numeric user ID, atomically adds a new secret generation while retaining the currently
+   active generation, then commits the new active generation and metadata in SQLite。After commit it atomically prunes
+   the previous generation。
+2. If SQLite commit fails, the old generation remains usable and the new generation is inert；startup reconciliation
+   removes generations not referenced by active SQLite rows。
+3. Idempotent remove compares `accounts.revision`，then marks the account `removing` and increments revision while clearing
+   default/model preference in one SQLite transaction。`bindDefault` excludes `removing` and `removed` rows。
+4. It removes credentials and invalidates token/endpoint/catalog caches，then marks the row `removed` and increments
+   revision in a second transaction。Failure leaves durable `removing` state；the command/API reports failure and a
+   repeated remove resumes cleanup without requiring the stale original revision。
+5. Startup reconciliation resumes every `removing` row and removes secret generations not referenced by an `active` row；
+   it never reactivates a row to hide cleanup failure。
+6. Identity row and Usage Buckets remain；relogin of the same host/user tuple installs a new generation, marks that row
+   active with a new revision and rejoins usage。
+   Responses History is global and is unaffected by account removal。
+7. A `removed` identity row is retained while any retained Usage Bucket references its stable account ID。After usage
+   retention removes the last bucket, cleanup may delete that tombstone；a later login deterministically recreates the same
+   account ID。Thus identity rows are bounded by active accounts plus retained usage dimensions。
+
+Removal CAS is state-specific：
+
+- `active` accepts only its exact current revision，then persists `removing` at `revision + 1`。
+- `removing` accepts only the current removing revision；it resumes external cleanup without incrementing again，then
+  persists `removed` at `revision + 1` after cleanup succeeds。The old active revision is a 409 conflict。
+- `removed` with the exact current revision is idempotent success and does not increment；any stale revision is 409。
+- Cleanup failure returns operational failure while leaving the current `removing` revision observable from account GET/
+  list。CLI retries first reads that revision；Admin clients refresh after failure。
+
+### 7.4 Preference revisions
+
+`gateway_preferences.revision` is the CAS value for changing the default account。Each
+`account_model_preferences.revision` independently protects that account's preferred model；absence is represented to
+clients as revision 0。`PreferredModelManager.setPreferred(accountId, modelId, expectedRevision, signal)` captures the account catalog，requires
+an exact model ID，then calls the store with that ID and catalog generation；the store increments revision in one
+transaction。Catalog refresh that removes the preferred model changes `valid -> invalid` and increments
+the preference revision；it never chooses another model。A later explicit set restores `valid` with another increment。
+
+## 8. Failure, commit, timeout 与 cancellation
+
+### 8.1 Configurable defaults
+
+| Limit | Default |
+| --- | ---: |
+| Request body | 32 MiB |
+| One upstream SSE event | 4 MiB |
+| Non-stream body | 32 MiB |
+| Per-request protocol accumulator | 32 MiB |
+| Active inference requests | 4 |
+| Admission queue | 16 |
+| Queue wait | 30 s |
+| Connect timeout | 30 s |
+| First-byte timeout | 120 s |
+| Stream idle timeout | 120 s |
+| Total request timeout | 30 min |
+
+Queue full and queue timeout map to OpenAI `503`、Anthropic `529`、Ollama `503`，with exact body/headers from
+`docs/gateway_http_contracts.md`。A queued abort removes that waiter immediately。
+
+### 8.2 Commit boundary
+
+`StreamResponseWriter` tracks `responseCommitted` at the first downstream byte：
+
+| Path | Before first byte | After first byte |
+| --- | --- | --- |
+| OpenAI Chat | protocol HTTP error | close；no synthetic `[DONE]` |
+| Ollama | Ollama HTTP error | exactly one safe NDJSON error for non-abort；no `done:true` |
+| Anthropic | Anthropic HTTP error | close；no synthetic `event:error`/`message_stop` |
+| Responses Chat bridge | Responses HTTP error | close；no synthetic `response.failed` |
+| Responses native | Responses HTTP error | close；never switch to Chat events |
+
+Client abort emits zero additional bytes in every phase, aborts the same upstream request, invokes iterator `return()`,
+releases decoder/state/timers/permit, and suppresses error/success terminal。
+
+Chat-bridge nonstream history commits after complete conversion and before sending the success body。Chat-bridge stream
+commits each `Semantic Checkpoint` synchronously before its `response.output_item.done` bytes, and completes the final
+transaction before `response.completed`。Commit failure suppresses that checkpoint/terminal；earlier bytes remain sent，
+live fragments are not recovered。Native Responses never reads or writes local history。
+
+Usage Buckets、Operational Events and JSONL logs are noncritical：short batches may be lost on hard crash；graceful
+shutdown flushes within its bounded grace period。Config、account activation、secret replace and Semantic Checkpoint
+are critical and synchronously report failure。
+
+## 9. Security, daemon 与 Admin contract
+
+### 9.1 Listener and files
+
+- The only accepted bind host is literal `127.0.0.1`，with default port `31400`；`0.0.0.0`、`::`、`::1`、
+  LAN addresses and hostname binds are rejected before listen。
+- Default data directory is `~/.ghc-gateway`。It contains `state.db`、WAL/SHM、`credentials.json`、
+  protected `daemon.json` and `logs/*.jsonl`。
+- Unix data directory mode is `0700`；Windows directory ACL is current-user-only。Credential/daemon paths and
+  same-directory temp paths must be regular files under the resolved data directory；symlink/reparse-point or ownership
+  mismatch fails closed。
+- Secret/daemon files use same-directory temporary file、flush、atomic replace；Unix final mode is `0600`。
+  Windows ACL grants file access only to the current user, removes inherited broad ACEs, and is verified after replace。
+  Permission/ACL failure is fatal；the app never continues with a weaker file。
+- Request/response content、tool arguments、Authorization、OAuth/Copilot/admin/control tokens and complete upstream
+  error bodies never enter logs、SQLite telemetry、Admin responses or exception messages。
+
+### 9.2 Self-managed daemon
+
+Both foreground `serve` and detached `start` hold an exclusive identity-file creation lock and publish protected
+`daemon.json` while running；the file includes `managed:false` for foreground and `managed:true` for detached mode。
+This makes all management CLI commands thin authenticated clients of the one running gateway；they never open SQLite or
+the secret file in a second process。If no gateway is running, auth/accounts/models/config/admin commands return exit 5
+and instruct the user to run `start` or `serve`。
+
+`ghcg start` spawns one detached Node.js child running the same package's
+`serve` implementation, waits at most 30 seconds for an authenticated ready handshake, then `unref()`s。An already
+verified running gateway is idempotent success，whether foreground or managed。Failed readiness terminates the verified
+child and removes its identity file。
+
+`daemon.json` is versioned and contains `managed`、`pid`、`processStartIdentity`、`instanceNonce`、`controlToken`、
+`port` and `createdAt`。Control routes share the main `127.0.0.1:<port>` listener；there is no second listener。
+Canonical routes：
+
+- `GET /__ghcg/control/v1/status`
+- `POST /__ghcg/control/v1/stop`
+- `POST /__ghcg/control/v1/admin-bootstrap`
+- `POST /__ghcg/control/v1/command`
+
+Each requires exact `X-GHCG-Control-Token` and `X-GHCG-Instance-Nonce` headers from the protected identity file。
+Success identifies the same `{pid, processStartIdentity, instanceNonce}`；status returns
+`{data:{state:"running",instance:{...}}}`，stop returns HTTP 202 with the same instance，and admin-bootstrap returns
+`{data:{token,expiresAt}}`。Missing/wrong token is 401，nonce/identity mismatch is 409，not-ready is 503，all using
+`{error:{code,message}}` with respectively `unauthorized`/`unauthorized`、
+`instance_mismatch`/`instance mismatch` and `not_ready`/`not ready`。Malformed command is 400
+`invalid_command`/`invalid command`；application command failures retain the canonical CLI error code category without
+adding sensitive details。These routes reject browser credential modes and are excluded
+from inference/Admin middleware and static fallback。
+All control responses use `Content-Type: application/json; charset=utf-8` and `Cache-Control: no-store`。
+
+Control command body is `{operation,arguments}`，validated without coercion。Operation is exactly one of：
+
+```text
+auth.login.start
+auth.login.poll
+auth.logout
+auth.status
+accounts.list
+accounts.use
+accounts.remove
+models.list
+models.current
+models.set
+config.get
+config.set
+```
+
+Interactive `ghcg auth login` calls start，prints the user code/verification URL，then polls by opaque `flowId` until
+terminal or interrupt；JSON mode returns after start as specified in section 9.4。Other arguments match public CLI
+grammar。The route returns `{data:<command-result>}` and uses the same application modules/revision rules as Admin；it
+never shells out to another `ghcg` process。
+
+Process identity is platform-specific and serialized canonically：
+
+- Linux：kernel boot ID + `/proc/<pid>/stat` start ticks；
+- Windows：process creation FILETIME；
+- macOS：`LC_ALL=C ps -o lstart= -p <pid>` canonicalized to UTC seconds，with nonce handshake as the second factor。
+
+`stop/restart` require `managed:true`；they refuse to terminate a foreground `serve` process。`stop` never kills based
+only on PID。After authenticated identity verification it requests graceful close and waits
+10 seconds；only if the same OS process identity still exists may it force terminate。Without verification it returns
+`conflict` or `unreachable` and never kills。`status` distinguishes `running`、`stopped`、`stale`、`conflict` and
+`unreachable`；it removes an identity file only after proving the recorded process no longer exists。There is no watchdog
+or automatic restart。`restart` is verified stop followed by start and receives a new nonce/start identity。
+
+JSONL logs rotate at 10 MiB, retain at most 5 files and delete files older than 7 days；both count and age limits apply。
+
+### 9.3 Admin authentication
+
+- First initialization generates a long random admin secret in the protected secret file。
+- `ghcg admin open` authenticates to local control and requests a 60-second single-use bootstrap token。
+- The browser URL carries the token in a fragment；the SPA exchanges it once through
+  `POST /admin/api/v1/auth/bootstrap`，so normal HTTP logs/referrers do not receive it。
+- Exchange creates an in-memory Admin Session cookie：`HttpOnly`、`SameSite=Strict`、`Path=/admin`；
+  idle timeout 30 minutes、absolute timeout 12 hours。Daemon restart invalidates every session/bootstrap token。
+- Bootstrap exchange is the sole mutation exempt from an existing Admin Session and CSRF token；it still requires exact
+  `Origin` plus a valid unexpired single-use bootstrap token。
+- Every other Admin mutation validates session、`X-GHCG-CSRF` and exact `Origin` derived from the active loopback listener。
+  Missing/null/alternate Origin fails closed。GET responses are `Cache-Control: no-store` where state is sensitive。
+- Admin/config DTOs use TypeBox with coercion disabled。Inference WireJson decoders are not reused for Admin。
+- `/admin/*` static fallback cannot catch `/v1/*`、`/api/*`、`/healthz`、`/readyz` or control routes。
+- `/admin/api/v1/events/stream` is authenticated SSE with bounded subscribers/queues；a slow subscriber is disconnected rather
+  than accumulating unbounded events。
+
+Every Admin JSON success is `{data:<value>}`。Every Admin failure is
+`{error:{code:string,message:string,requestId:string}}` with fixed low-information text。Validation is 400，
+unauthenticated is 401，CSRF/Origin failure is 403，missing resource is 404，revision/state conflict is 409，
+capacity is 503 and internal failure is 500。All Admin JSON/SSE responses are `Cache-Control: no-store`。
+Canonical codes are respectively `validation_failed`、`unauthenticated`、`forbidden`、`not_found`、
+`revision_conflict`、`capacity_exceeded` and `internal_error`；the matching messages are fixed lower-case versions
+with spaces。HTTP 204 responses have no body。
+
+Canonical Admin route matrix：
+
+| Method/path | Input | Success |
+| --- | --- | --- |
+| `POST /admin/api/v1/auth/bootstrap` | `{token}` | 200 `{csrfToken,idleExpiresAt,absoluteExpiresAt}` + session cookie |
+| `GET /admin/api/v1/auth/session` | none | 200 session expiry/CSRF metadata |
+| `POST /admin/api/v1/auth/logout` | CSRF + Origin | 204 and invalidate current session |
+| `GET /admin/api/v1/status` | none | version/uptime/health/degraded/admission/storage/daemon summary |
+| `GET /admin/api/v1/usage` | filters + cursor | page of Usage Buckets and aggregate totals |
+| `GET /admin/api/v1/accounts` | none | stable account summaries、default ID and revision |
+| `POST /admin/api/v1/device-flows` | `{host}` | 201 `{flowId,userCode,verificationUri,expiresAt,pollIntervalSeconds}` |
+| `GET /admin/api/v1/device-flows/:flowId` | none | `{state:"pending"|"complete"|"expired"|"failed",account?}` |
+| `DELETE /admin/api/v1/accounts/:accountId` | `{expectedRevision}` | final removed account summary |
+| `PUT /admin/api/v1/accounts/default` | `{accountId,expectedRevision}` | default account + new revision |
+| `GET /admin/api/v1/models?accountId=` | account or current default | catalog + preferred model validity |
+| `POST /admin/api/v1/models/refresh` | `{accountId}` | refreshed catalog + generation |
+| `PUT /admin/api/v1/models/preferred` | `{accountId,modelId,expectedRevision}` | preference + new revision |
+| `GET /admin/api/v1/config` | none | complete runtime config + revision + hard ranges |
+| `PUT /admin/api/v1/config` | `{expectedRevision,config}` | complete updated config + new revision |
+| `GET /admin/api/v1/history` | none | `{revision,count,oldestAt,newestAt,ttlDays,maxResponses}` |
+| `DELETE /admin/api/v1/history` | `{expectedRevision}` | cleared summary + new revision |
+| `GET /admin/api/v1/events` | filters + cursor | page of persisted Operational Events |
+| `GET /admin/api/v1/events/stream` | none | live Operational Event/performance SSE |
+
+Canonical response DTOs：
+
+```ts
+interface AdminStatus {
+  version: string;
+  uptimeMs: number;
+  health: "ok";
+  performance: "healthy" | "degraded";
+  degradedSince?: string;
+  performanceMetrics: Array<{
+    metric: "buffered_p95_ms" | "stream_event_p95_ms" | "checkpoint_p95_ms" | "event_loop_p95_ms";
+    state: "healthy" | "degraded" | "insufficient_data";
+    actual: number | null;
+    threshold: number;
+    samples: number;
+    startedAt: string | null;
+  }>;
+  admission: {
+    activeRequests: number;
+    activeStreams: number;
+    queuedRequests: number;
+    activeMax: number;
+    queueMax: number;
+  };
+  storage: { historyCount: number; usageBucketCount: number; eventCount: number };
+  telemetry: {
+    pendingMutations: number;
+    droppedUsageUpdates: number;
+    droppedOperationalEvents: number;
+  };
+  daemon: { managed: boolean; pid?: number; startedAt?: string };
+}
+
+interface AdminAccount {
+  accountId: string;
+  host: string;
+  numericUserId: string;
+  login: string | null;
+  displayName: string | null;
+  state: "active" | "removing" | "removed";
+  revision: number;
+  authenticatedAt: string | null;
+  preferredModel: {
+    revision: number;
+    modelId: string;
+    validity: "valid" | "invalid";
+  } | null;
+}
+
+interface AdminAccounts {
+  defaultRevision: number;
+  defaultAccountId: string | null;
+  items: AdminAccount[];
+}
+
+interface AdminModels {
+  accountId: string;
+  catalogGeneration: number;
+  fetchedAt: string;
+  preferredModel: {
+    revision: number;
+    modelId: string;
+    validity: "valid" | "invalid";
+  } | null;
+  items: Array<{
+    id: string;
+    name: string;
+    vendor: string;
+    maxInputTokens: number | null;
+    maxOutputTokens: number | null;
+  }>;
+}
+
+interface AdminUsageBucket {
+  utcHour: string;
+  accountId: string;
+  protocol: string;
+  resolvedModel: string;
+  outcome: string;
+  requestCount: number;
+  errorCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheTokens: number;
+  latencySumMs: number;
+  latencyMaxMs: number;
+}
+
+interface AdminUsageTotals {
+  requestCount: number;
+  errorCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheTokens: number;
+  latencySumMs: number;
+  latencyMaxMs: number;
+}
+
+interface AdminUsagePage {
+  items: AdminUsageBucket[];
+  nextCursor: string | null;
+  totals: AdminUsageTotals;
+}
+
+interface AdminOperationalEvent {
+  eventId: string;
+  occurredAt: string;
+  kind: string;
+  severity: "info" | "warning" | "error";
+  metadata: Record<string, string | number | boolean | null>;
+}
+
+interface AdminPage<T> {
+  items: T[];
+  nextCursor: string | null;
+}
+
+interface AdminRuntimeConfig {
+  revision: number;
+  config: {
+    limits: {
+      requestBodyBytes: number;
+      sseEventBytes: number;
+      nonstreamBodyBytes: number;
+      accumulatorBytes: number;
+    };
+    admission: { activeMax: number; queueMax: number };
+    timeouts: {
+      queueMs: number;
+      connectMs: number;
+      firstByteMs: number;
+      streamIdleMs: number;
+      totalMs: number;
+    };
+    accounts: { maxAuthenticated: number };
+    history: { ttlDays: number };
+    usage: { retentionDays: number };
+    events: { retentionDays: number };
+  };
+  ranges: Record<string, { min: number; max: number; unit: string }>;
+}
+```
+
+`AdminOperationalEvent.metadata` uses an allowlist per event kind and can never contain arbitrary nested JSON。History
+summary fields are exactly those in the route table。`GET /usage` returns `AdminUsagePage`；`totals` covers the complete
+filtered range, not only the current page。`GET /config` and successful `PUT /config` return `AdminRuntimeConfig`；
+PUT body `config` has exactly the same nested shape and every key is required，while `ranges` is response-only。
+
+Usage `protocol` is one of `openai_chat|openai_responses_native|openai_responses_bridge|anthropic|ollama`；`outcome` is
+one of `success|client_error|authentication_error|overloaded|upstream_error|timeout|aborted|internal_error`。These fixed
+values are also the only metric labels。
+
+Operational Event `kind` is one of `gateway_started|gateway_stopped|request_failed|account_authenticated|
+account_removed|default_account_changed|preferred_model_changed|runtime_config_changed|catalog_refreshed|
+performance_degraded|performance_recovered|telemetry_dropped|metadata_rejected|daemon_start_failed`。Metadata allowlists use only
+request/account IDs、protocol/status/category、revisions/counts、
+fixed metric names and numeric actual/threshold values；login/display names、paths、arbitrary messages and exception
+text are excluded。
+
+List endpoints use opaque cursor pagination。`limit` defaults to 100 and is an integer `1..500`；Events additionally
+cannot return more than its 512-row store。Usage defaults to the last 24 hours，accepts UTC `from`/`to` within the
+90-day retained range and optional exact `accountId`、`protocol`、`resolvedModel`、`outcome` filters。Event filters
+are exact `kind`、`severity` and UTC range。Unknown query/body fields are validation errors；no endpoint performs
+implicit coercion。
+
+Device-flow state is memory-only except the resulting account/credential。At most 8 flows may exist；the upstream expiry
+is capped at 15 minutes locally，completed/expired/failed flows are removed after their terminal result is observed or
+after expiry。The browser receives `userCode` and `verificationUri` but never `deviceCode`。
+
+Admin monitoring SSE uses `Content-Type: text/event-stream; charset=utf-8` and `Cache-Control: no-store`。Wire：
+
+```text
+id: <event-id>\n
+event: operational\n
+data: {"kind":"operational","event":<AdminOperationalEvent>}\n\n
+
+event: performance\n
+data: {"kind":"performance","status":<complete AdminStatus>}\n\n
+
+event: reset\n
+data: {"kind":"reset","reason":"history_unavailable","latestEventId":<string-or-null>}\n\n
+```
+
+JSON is compact UTF-8 and field order follows the displayed shape。Operational events alone carry decimal `id`。
+On connect, absent `Last-Event-ID` starts with one performance snapshot and then live events。A valid retained decimal ID
+replays later persisted events in ascending ID order，then sends a performance snapshot and continues live。Malformed
+`Last-Event-ID` is 400；a valid but evicted/unknown ID sends one `reset` event, then snapshot/live。A
+`: keep-alive\n\n` comment may be sent every 15 seconds and is not queued as an event。Reconnect never duplicates a
+persisted event ID。The 128-event/1 MiB subscriber cap disconnects the slow subscriber without a synthetic terminal。
+
+The UI has exactly six primary views：`Overview`、`Accounts`、`Models`、`Configuration`、
+`Responses History`、`Events`。
+
+### 9.4 CLI contract
+
+All commands support global `--json`。Human mode writes successful results only to stdout and errors only to stderr。
+JSON mode writes exactly one compact object：`{ok:true,data:<value>}` or
+`{ok:false,error:{code,message}}`。Secrets、bootstrap token and complete upstream endpoint never appear in either
+mode。`ghcg admin open` passes a fragment URL directly to the OS browser launcher and prints only a token-free success
+message/result。
+
+Interactive `ghcg auth login` prints the user code/verification URL and polls until terminal。With `--json`, it starts
+the flow, emits one pending flow object and exits 0 without polling；automation uses
+`ghcg --json auth login poll <flow-id>`。A terminal poll response is returned exactly once and then removes that flow；
+pending polls do not consume it。`auth status` reports account authentication state, not an ambiguous set of flows。
+
+`serve`、`start`、`stop`、`restart` and `status` are lifecycle commands。Every auth/accounts/models/config command
+and `admin open` requires a running foreground or managed gateway and uses the protected control transport；none opens
+application storage directly。`stop/restart` reject `managed:false` foreground instances。
+
+Every command accepts global `--data-dir` solely to locate the protected runtime identity，using
+`--data-dir > GHC_GATEWAY_DATA_DIR > ~/.ghc-gateway`。No command scans ports or directories。Only `serve/start` accept
+`--port` and `--log-level`；all other commands read port/identity from that exact data directory。Choosing the wrong
+directory therefore reports stopped/not-found rather than controlling another instance。
+
+Exit codes：
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | success or idempotent desired state |
+| `1` | unclassified internal failure |
+| `2` | CLI usage/input/config validation |
+| `3` | requested state/resource not found；`status` stopped |
+| `4` | security/permission failure |
+| `5` | remote、timeout、unavailable、stale/conflict/unreachable daemon |
+| `130` | user interrupt |
+
+`start` when already verified running and `stop` when already stopped both return 0。`status` running returns 0，stopped
+returns 3，and stale/conflict/unreachable returns 5。`auth logout [--account]` and
+`accounts remove <account-id>` call the same idempotent async account-removal operation；without `--account`, logout
+targets the current default account。They remove active credentials/preferences/caches but retain stable identity and
+Usage Buckets。
+
+Canonical command surface is exactly：
+
+```text
+ghcg serve | start | stop | restart | status
+ghcg auth login [--host <domain>] | login poll <flow-id> | logout [--account <account-id>] | status
+ghcg accounts list | use <account-id> | remove <account-id>
+ghcg models list [--account <account-id>] | current | set <model-id>
+ghcg config get [key] | set <key> <value>
+ghcg admin open
+```
+
+Lifecycle/admin-open JSON results：
+
+```ts
+interface CliLifecycleResult {
+  state: "running" | "stopped" | "stale" | "conflict" | "unreachable";
+  managed: boolean | null;
+  pid: number | null;
+  startedAt: string | null;
+  port: number | null;
+  dataDir: string;
+}
+
+interface CliAdminOpenResult {
+  opened: true;
+}
+```
+
+`serve` reports `running, managed:false` after readiness；in JSON mode it emits that one object and then remains in the
+foreground without further stdout until exit。`start`/`restart` return running managed state，`stop` returns stopped，
+and `status` returns the observed lifecycle state。`admin open` returns `{opened:true}` without its bootstrap URL/token。
+
+Canonical CLI error codes：
+
+| `error.code` | Exit | Category |
+| --- | ---: | --- |
+| `internal_error` | 1 | unclassified bug/failure |
+| `usage_error` | 2 | command grammar |
+| `validation_error` | 2 | argument/config validation |
+| `not_found` | 3 | requested non-daemon resource/state missing |
+| `revision_conflict` | 3 | application CAS conflict |
+| `permission_denied` | 4 | filesystem/OS permission |
+| `security_error` | 4 | ACL/identity/control security rejection |
+| `remote_error` | 5 | GitHub/Copilot/device-flow remote failure |
+| `timeout` | 5 | remote/control timeout |
+| `unavailable` | 5 | required running gateway unavailable |
+| `daemon_stale` | 5 | stale identity file |
+| `daemon_conflict` | 5 | PID/start/nonce or foreground-management conflict |
+| `daemon_unreachable` | 5 | verified process cannot answer control |
+| `interrupted` | 130 | user interrupt |
+
+Messages are fixed safe lower-case phrases derived from the code (`revision conflict`, `gateway unavailable`, etc.) and
+never include arbitrary exception text。Lifecycle stopped is successful state data for `stop` but `status` returns the
+same data with exit 3 as previously specified。
+
+Control command DTOs：
+
+| Operation | Arguments | `data` result |
+| --- | --- | --- |
+| `auth.login.start` | `{host?:string}` | device-flow start DTO from section 9.3 |
+| `auth.login.poll` | `{flowId:string}` | device-flow state DTO |
+| `auth.logout` | `{accountId?:string}` | final `AdminAccount` |
+| `auth.status` | `{}` | `{defaultAccountId,accounts:AdminAccount[]}` |
+| `accounts.list` | `{}` | `AdminAccounts` |
+| `accounts.use` | `{accountId:string}` | updated `AdminAccounts` |
+| `accounts.remove` | `{accountId:string}` | final `AdminAccount` |
+| `models.list` | `{accountId?:string}` | `AdminModels` |
+| `models.current` | `{}` | `{accountId,preferredModel}` |
+| `models.set` | `{modelId:string}` | updated preferred-model object |
+| `config.get` | `{key?:string}` | `AdminRuntimeConfig` or `{key,value,range}` |
+| `config.set` | `{key:string,value:string}` | updated `AdminRuntimeConfig` |
+
+For CLI commands without user-supplied revision，the running `CommandDispatcher` reads the current revision and performs
+one CAS attempt；a concurrent change returns exit 3/state conflict and is not silently retried。All non-interactive human
+success output is the `data` value encoded as two-space JSON plus one LF；human error is exactly
+`error: <safe message>\n` on stderr。Interactive login is the only progress UI and prints exactly `Code: <userCode>`，
+`Open: <verificationUri>` and terminal `Authenticated: <accountId>` lines。Root help begins
+`Usage: ghcg [--data-dir <path>] [--json] <command>` and lists command groups in the canonical order shown above；
+subcommand help is generated from the same immutable command registry。
+
+## 10. Performance, CI 与 release-wide gates
+
+### 10.1 Benchmarks
+
+Scripted local upstream、fixed clock/UUID and isolated data directory measure gateway overhead, not network/model time：
+
+| Metric | Gate |
+| --- | ---: |
+| Idle RSS | `<= 64 MiB` |
+| RSS after 1,000 completed/aborted streams and stabilization | `<= warmed baseline + 16 MiB` |
+| Buffered request overhead p95 | `<= 5 ms` |
+| Stream event conversion/forwarding overhead p95 | `<= 2 ms` |
+| Semantic Checkpoint SQLite commit p95 | `<= 5 ms` |
+| Event-loop delay p95 | `<= 10 ms` |
+
+每项 scripted benchmark 连续三次都必须通过。Memory 使用 Windows Private Bytes、Linux RSS/PSS、macOS
+RSS 等 process-resident 指标；不得用 V8 `heapUsed`、browser memory 或 package size 替代。
+All p95 values use nearest-rank `sorted[ceil(0.95 * n) - 1]` over the documented sample set；benchmark artifacts
+record warm-up、sample count、individual values and environment。
+
+Runtime 用 5-minute rolling windows 计算可在线测量的 buffered/event/checkpoint/event-loop p95。连续三个
+窗口超过任一 threshold 时只发生一次 `healthy -> degraded` transition；连续三个全部恢复窗口只发生
+一次 clear transition。Admin 显示 actual、threshold、startedAt；每次 transition 写一个 Operational
+Event。
+
+Buffered/event/checkpoint metrics require at least 20 observations in a window；otherwise that metric is
+`insufficient_data` and the window neither advances nor clears its consecutive counter。Event-loop delay is sampled
+continuously。A degraded metric clears only after three subsequently evaluated healthy windows。
+
+### 10.2 CI
+
+- Full required matrix：Windows x64、Linux x64、macOS arm64，均使用 Node.js 24。
+- Additional artifact smoke：Linux arm64、macOS x64，至少执行 `npm pack`、clean install、`ghcg --help`
+  和 foreground health probe。
+- CI has one explicit dependency-provision phase：`npm ci` may access only the configured npm registry and Playwright
+  browser artifact source, using the committed lockfile and an OS/arch/Node/npm/lockfile-keyed cache。It records
+  dependency/cache provenance。After provisioning, build、tests、fixtures、Playwright、benchmarks and package smoke
+  run with outbound network blocked；no test may contact GitHub、Copilot、OpenAI or Anthropic。
+- OAuth、GitHub REST、CAPI、Copilot Chat/Responses 全部 scripted；CI 不读取 developer credentials。
+- `better-sqlite3` install/load and a WAL transaction are part of every platform smoke。
+- Vitest is the unit/contract/integration runner。Playwright has 7 fixed flows in `RM-21`；不扩大为 brittle
+  pixel snapshot suite。
+
+## 11. Dependency DAG
+
+### 11.1 Mermaid
+
+```mermaid
+flowchart TD
+  RM00["RM-00 virtual spec merge gate"] --> RM01["RM-01 Node 24 toolchain and RSS baseline"]
+  RM01 --> RM02["RM-02 WireJson and deterministic serialization"]
+  RM02 --> RM03["RM-03 Gateway Foundation and HTTP host"]
+  RM03 --> RM04["RM-04 SQLite persistence and runtime config"]
+  RM04 --> RM05["RM-05 Telemetry and performance state"]
+  RM04 --> RM06["RM-06 Accounts, secrets, and GHES"]
+  RM06 --> RM07["RM-07 Copilot transport and SSE"]
+  RM03 --> RM07
+  RM02 --> RM07
+  RM07 --> RM08["RM-08 Model catalog and listing routes"]
+  RM06 --> RM08
+  RM04 --> RM08
+  RM08 --> RM09["RM-09 OpenAI Chat endpoint"]
+  RM07 --> RM09
+  RM03 --> RM09
+  RM07 --> RM10["RM-10 Ollama endpoint"]
+  RM03 --> RM10
+  RM07 --> RM11["RM-11 Anthropic endpoint"]
+  RM08 --> RM11
+  RM03 --> RM11
+  RM02 --> RM12["RM-12 Responses core DTO and History"]
+  RM04 --> RM12
+  RM12 --> RM13["RM-13 Responses planner and native execution"]
+  RM08 --> RM13
+  RM07 --> RM13
+  RM12 --> RM14["RM-14 Responses bridge request conversion"]
+  RM13 --> RM14
+  RM07 --> RM14
+  RM14 --> RM15["RM-15 Responses bridge non-stream conversion"]
+  RM14 --> RM16["RM-16 Responses bridge stream conversion"]
+  RM07 --> RM16
+  RM12 --> RM17["RM-17 Responses endpoint integration"]
+  RM13 --> RM17
+  RM15 --> RM17
+  RM16 --> RM17
+  RM17 --> RM18["RM-18 CLI core/control client and foreground runtime"]
+  RM09 --> RM18
+  RM10 --> RM18
+  RM11 --> RM18
+  RM17 --> RM20["RM-20 Admin auth and management API"]
+  RM06 --> RM18
+  RM08 --> RM18
+  RM04 --> RM18
+  RM05 --> RM20
+  RM06 --> RM20
+  RM08 --> RM20
+  RM12 --> RM20
+  RM18 --> RM19["RM-19 Self-managed daemon and local control"]
+  RM20 --> RM19
+  RM05 --> RM19
+  RM20 --> RM21["RM-21 Svelte Admin UI"]
+  RM19 --> RM21
+  RM19 --> RM22["RM-22 Cutover, legacy removal, and release handoff"]
+  RM21 --> RM22
+  RM17 --> RM22
+  RM05 --> RM22
+```
+
+### 11.2 Edge table
+
+“Parallel with” 表示 dependencies 已满足后可并行、且 owned files 无预期冲突；不是跳过 dependency。
+
+| ID | Title | Depends on | Consumed artifact | Parallel with |
+| --- | --- | --- | --- | --- |
+| `RM-00` | Virtual spec and fixture closure gate; no issue | none | merged normative baseline | none |
+| `RM-01` | Node 24 toolchain and RSS baseline | `RM-00` merge commit; no native issue edge | exact spec commit | none |
+| `RM-02` | WireJson and deterministic serialization | `RM-01` | strict toolchain/test harness | none |
+| `RM-03` | Gateway Foundation and HTTP host | `RM-02` | WireJson parser/serializer | none |
+| `RM-04` | SQLite persistence and runtime config | `RM-03` | config registry/snapshot types | none |
+| `RM-05` | Telemetry and performance state | `RM-04` | migration runner/database/config | `RM-06` |
+| `RM-06` | Accounts, secrets, and GHES | `RM-04` | migration runner/database/config | `RM-05` |
+| `RM-07` | Copilot transport and SSE | `RM-02`, `RM-03`, `RM-06` | WireJson、request cancellation/timers、Bound Account/secret | late `RM-05` |
+| `RM-08` | Model catalog and listing routes | `RM-04`, `RM-06`, `RM-07` | persistence、account identity、remote transport | `RM-05` |
+| `RM-09` | OpenAI Chat endpoint | `RM-03`, `RM-07`, `RM-08` | route seam、Chat transport、model resolver | `RM-05`, `RM-10`, `RM-11`, `RM-12` |
+| `RM-10` | Ollama endpoint | `RM-03`, `RM-07` | route seam、typed Chat DTO/frame | `RM-05`, `RM-08`, `RM-09`, `RM-11`, `RM-12` |
+| `RM-11` | Anthropic endpoint | `RM-03`, `RM-07`, `RM-08` | route seam、typed Chat DTO/frame、model resolver | `RM-05`, `RM-09`, `RM-10`, `RM-12` |
+| `RM-12` | Responses core DTO and History | `RM-02`, `RM-04` | WireJson、migration runner/database | `RM-05`, `RM-10`, `RM-11` |
+| `RM-13` | Responses planner and native execution | `RM-07`, `RM-08`, `RM-12` | native transport、routing metadata、Responses DTO | none |
+| `RM-14` | Responses bridge request conversion | `RM-07`, `RM-12`, `RM-13` | Chat DTO、history、immutable execution plan | none |
+| `RM-15` | Responses bridge non-stream conversion | `RM-14` | ToolContext/response context | `RM-16` |
+| `RM-16` | Responses bridge stream conversion | `RM-07`, `RM-14` | typed Chat frames、ToolContext/stream context | `RM-15` |
+| `RM-17` | Responses endpoint integration | `RM-12`, `RM-13`, `RM-15`, `RM-16` | history、native plan、both bridge converters | none |
+| `RM-18` | CLI core/control client and foreground runtime | `RM-04`, `RM-06`, `RM-08`, `RM-09`, `RM-10`, `RM-11`, `RM-17` | config/accounts/models/all public endpoint registrations | `RM-20` |
+| `RM-19` | Self-managed daemon and local control | `RM-05`, `RM-18`, `RM-20` | logging、CLI lifecycle hook、bootstrap mint interface | none |
+| `RM-20` | Admin auth and management API | `RM-05`, `RM-06`, `RM-08`, `RM-12`, `RM-17` | telemetry/accounts/models/history/gateway operations | `RM-18` |
+| `RM-21` | Svelte Admin UI | `RM-19`, `RM-20` | daemon bootstrap and complete Admin API | none |
+| `RM-22` | Cutover, legacy removal, and release handoff | `RM-05`, `RM-17`, `RM-19`, `RM-21` | telemetry、all routes、daemon、Admin UI | none |
+
+Critical tracer is：
+
+```text
+Spec closure
+-> Node 24/RSS/toolchain
+-> WireJson/Gateway Foundation
+-> persistence/accounts/Copilot/model catalog
+-> OpenAI Chat
+-> Ollama
+-> Anthropic
+-> Responses
+-> CLI/Admin
+-> cutover
+```
+
+## 12. Common issue template 与 PR quality gate
+
+### 12.1 Issue template
+
+Implementation issues are created only after virtual gate `RM-00` merges。Copy the slice contract verbatim rather than summarizing it：
+
+```markdown
+## Slice
+ID: RM-XX
+Master spec: docs/specs/refactor_master_spec.md#...
+Base branch: refactor
+Spec baseline: <RM-00 merge commit>
+
+## Goal
+<observable outcome>
+
+## Dependencies
+Blocked by: <native issue links matching the DAG>
+Parallel with: <issue links, or none>
+
+## Must read
+<exact context pointers>
+
+## Owned scope
+<paths this PR may change>
+
+## Interface and deliverables
+<small interface plus state/failure ownership>
+
+## Fixtures and test commands
+<case categories, exact files, exact commands>
+
+## Acceptance
+<binary, exhaustive done conditions>
+
+## Non-goals
+<positive scope boundary and hard guardrails>
+
+## PR handoff
+<evidence the next owner needs>
+```
+
+Create native dependency edges matching the table for `RM-01`–`RM-22`；`Blocked by:` text is a human-readable mirror,
+not a replacement。`RM-01` has no native blocker and instead pins the `Spec baseline` commit。
+Issue title is `[RM-XX] <English title>`。One issue maps to one coherent PR；a split requires a master-spec DAG update first。
+
+### 12.2 Gate for every implementation PR
+
+Every PR description records all commands and artifact paths. It is mergeable only when：
+
+1. every dependency issue is merged into `refactor` and the branch is rebased/merged from latest `refactor`；
+2. changes stay inside owned scope or document an approved cross-owner edit；
+3. `npm run typecheck:refactor` and `npm run lint:refactor` pass；
+4. the slice's targeted `npm run test:refactor -- <paths>` passes；
+5. `npm run build:refactor` and `npm run fixtures:verify` pass offline；
+6. legacy `npm run test:unit` and `npm run smoke:legacy` remain green through `RM-21`；default
+   `npm start`/bins remain legacy until `RM-22`；
+7. deterministic fixtures assert exact objects/bytes where required；golden changes name explicit `caseId`s and reason；
+8. abort、timeout、cleanup and post-commit branches added by the slice have tests；
+9. logs/errors/fixtures contain no credential or real request/response content；
+10. production/default paths contain no stub、TODO、legacy fallback or disabled failing test；
+11. hot-path/resource changes include the applicable benchmark delta, not an unmeasured performance claim；
+12. `git diff --check` passes and generated outputs/data directories are absent from the worktree。
+
+`RM-01` establishes these scripts；for that slice only, equivalent direct tool commands named in its PR are accepted。
+
+## 13. Slice contracts
+
+### RM-00 — Spec and fixture closure
+
+- **Goal**：冻结一个可执行 master contract、HTTP contract、canonical vocabulary、ADRs 与 fixture ownership；
+  merge 后不存在需要 implementation agent 自行决定的 normative gap。
+- **Depends on**：none。**Parallel with**：none；这是 issue creation 的 gate。
+- **Must read**：[AGENTS](../../AGENTS.md)、[CONTEXT](../../CONTEXT.md)、[Architecture](../architecture.md)、
+  六份 protocol/model specs、全部四份 ADR，以及 `docs/gateway_http_contracts.md`。
+- **Owned scope/files**：`docs/specs/refactor_master_spec.md`、`docs/architecture.md`、
+  `docs/gateway_http_contracts.md`、`docs/openai_chat_completions.md`、existing production-spec pointers/
+  retention closure、`CONTEXT.md`、`docs/adr/*.md`。本 PR 可由多个独立 doc agents 分工，但由 spec owner
+  统一检查。
+- **Deliverables/interface**：第 3.3 节 fixture matrix、route closure、source priority、DAG、issue template；
+  architecture 中使用相同 `Gateway Foundation`、`Protocol Endpoint Module`、`Bound Account`、
+  `Responses Execution Plan`、`Responses History`、`Stream Execution`、`Admin Session`、
+  `Semantic Checkpoint`、`Usage Bucket`、`Operational Event` identifiers。
+- **Tests**：Markdown local-link scan（对尚在同 PR 的 `docs/gateway_http_contracts.md` 以 merge tree 验证）、
+  balanced fences、unique `RM-*` IDs、DAG cycle check、`git diff --check -- '*.md'`。
+- **Acceptance/done**：所有 context pointers 存在；Mermaid/table edges 等价且 acyclic；每个后续 slice
+  有唯一 owner、tests、done/non-goal/handoff；HTTP/OpenAI Chat/`/api/version` gaps 已关闭。
+- **Non-goals/guardrails**：不创建 implementation issue、不改 production code、不提交 generated golden。
+- **PR handoff**：列出最终 spec commit、source commit pins、fixture family owners、DAG edge count，以及确认
+  “issues not yet created”。
+
+### RM-01 — Node 24 toolchain and RSS baseline
+
+- **Goal**：证明选定 stack 在五个平台可安装/build，并在实现前建立可重复 RSS/latency baseline；新 app
+  保持 non-default。
+- **Depends on**：virtual `RM-00` merge commit；record it as `Spec baseline`, with no native issue edge。
+  **Parallel with**：none。
+- **Must read**：本文第 4、5、10、12 节，[Architecture](../architecture.md) runtime/testing/resource sections。
+- **Owned scope/files**：`package.json`、`package-lock.json`、`tsconfig.refactor.json`、
+  TypeScript-aware ESLint config、`vitest.refactor.config.ts`、`playwright.config.ts`、
+  `src/version.ts`、`scripts/refactor/fixtures.ts`、`bench.ts`、`pack.ts`、`ci_network_guard.ts`、
+  `tests/refactor/performance/baseline.test.ts`、
+  `.github/workflows/refactor-ci.yml`。
+- **Deliverables/interface**：Node `>=24` refactor scripts：
+  `build:refactor`、`typecheck:refactor`、`lint:refactor`、`test:refactor`、
+  `test:e2e:refactor`、`fixtures:verify`、`fixtures:generate`、`bench:refactor`、
+  `pack:refactor`、`smoke:legacy`；lock Hono、TypeBox、Undici、`better-sqlite3`、Svelte 5、Vite、Vitest、
+  Playwright。
+  TypeScript 至少启用 `strict`、`noUncheckedIndexedAccess`、`exactOptionalPropertyTypes`、
+  `useUnknownInCatchVariables`、`noImplicitOverride`、`verbatimModuleSyntax`。
+  `src/version.ts` is the non-default target build's single `0.1.0` source through `RM-21`；`RM-22` sets
+  `package.json.version` to the same value and adds an equality gate before removing the temporary separation。
+- **Tests**：provision dependencies once from the locked sources，then repeat `npm ci --offline` from the produced
+  cache；`npm run typecheck:refactor`；`npm run build:refactor`；
+  `npm run bench:refactor -- baseline --repeat 3`；`npm run test:unit`；`npm run smoke:legacy`；platform smoke loads
+  `better-sqlite3` and commits a WAL transaction。
+- **Acceptance/done**：full CI matrix and extra smoke artifacts exist；empty selected runtime stack idle RSS
+  `<=64 MiB` three runs；network denial is enforced；default `start/main/bin` values still invoke legacy JavaScript。
+- **Non-goals/guardrails**：不实现 Gateway/routes，不 change published package identity，不 weaken strict flags；
+  test execution has no network fallback，and provisioning cannot contact arbitrary hosts。
+- **PR handoff**：附各 platform Node/npm/native-addon versions、three-run raw baseline files、script names 和
+  cache key；后续 slice 以同一 harness 比较。
+
+### RM-02 — WireJson and deterministic serialization
+
+- **Goal**：提供有界、保留 member order/number lexeme 的 `WireJson` deep module 与 deterministic
+  canonical/ordered serializers。
+- **Depends on**：`RM-01`。**Parallel with**：none。
+- **Must read**：[Architecture](../architecture.md) JSON/TypeScript/serializer locality sections，以及所有
+  protocol specs 中 canonical JSON、ordered arguments、exact bytes 段落。
+- **Owned scope/files**：`src/serialization/**`、`tests/refactor/unit/wire_json.test.ts`、
+  `tests/refactor/fixtures/wire-json/**`。
+- **Deliverables/interface**：`parseWireJson(bytes, limits): WireJson`、
+  `serializeWireJson(value): Uint8Array`、`canonicalizeWireJson(value): Uint8Array`，以及显式 protocol
+  decoder helpers；preserve duplicate members until a protocol decoder decides validity。
+- **Tests**：`npm run test:refactor -- tests/refactor/unit/wire_json.test.ts`；fixtures cover
+  missing/null/false/0/empty、`-0`/exponent/large lexemes、integer-like keys、duplicate keys、surrogates、
+  Unicode code-point sort、depth/byte limit、invalid UTF-8/JSON and compact output。
+- **Acceptance/done**：all round-trips and golden bytes exact；no JavaScript `number` conversion before decoder；
+  parsing/serialization failures are typed and preserve cause；32 MiB input fails before unbounded allocation。
+- **Non-goals/guardrails**：不建立 protocol canonical model、不 import Hono/SQLite、不把 Go/Python protocol
+  encoder 合并进通用 serializer。
+- **PR handoff**：记录 public exports、allocation benchmark、duplicate-member policy and fixture case IDs。
+
+### RM-03 — Gateway Foundation and HTTP host
+
+- **Goal**：实现可注入 endpoint 的 Hono `Gateway`，统一 request scope、admission、limits、timeouts、
+  stream pump、health/readiness 与 graceful close。
+- **Depends on**：`RM-02`。**Parallel with**：none。
+- **Must read**：`docs/gateway_http_contracts.md`、[Architecture](../architecture.md) Gateway/stream/error/resource
+  sections。
+- **Owned scope/files**：`src/gateway/**`、`src/config/schema.ts`、`src/config/startup_config.ts`、initial
+  `src/main.ts` composition shell、
+  `tests/refactor/contract/gateway_http_contracts.test.ts`、
+  `tests/refactor/integration/gateway_stream_lifecycle.test.ts`、
+  `tests/refactor/fixtures/gateway-http/**`。
+- **Deliverables/interface**：
+  `createGateway(config, routes, dependencies): Promise<Gateway>` matching Architecture、
+  `RouteRegistration`、`ProtocolEndpoint`、`RequestScope`、config registry/default snapshot、
+  startup parser with `CLI > env > default`、`AdmissionController`、pull-based `StreamResponseWriter`；loopback
+  validation before listen。A fake endpoint/presenter test adapter proves host failure routing without implementing any
+  protocol presenter。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/gateway_http_contracts.test.ts
+  tests/refactor/integration/gateway_stream_lifecycle.test.ts`；body/nonstream/accumulator host limits；4+16 admission
+  and 30s wait；connect/first-byte/idle/total timers；backpressure；duplicate-header merge/rejection；fake presenter
+  invocation；startup CLI/env/default precedence/ranges；abort before/after commit；static-route isolation；probe contracts；health/readiness unaffected by
+  synthetic degraded state。SSE grammar/event-size byte splits belong `RM-07`。
+- **Acceptance/done**：zero leaked permits/listeners/timers after repeated abort；one-item pull-ahead maximum；
+  `close()` idempotent；unimplemented inference routes are absent/404；no legacy import or fallback。
+- **Non-goals/guardrails**：不实现 production protocol DTO/presenter、account/Copilot logic 或 generic Hono wrapper；
+  不 register stub routes。
+- **PR handoff**：提供 route-registration interface、failure union、resource counters and benchmark deltas，
+  供 protocol owners直接通过 Fetch surface 测试。
+
+### RM-04 — SQLite persistence and runtime config
+
+- **Goal**：建立 single-connection SQLite/migration implementation 与 revisioned immutable runtime config。
+- **Depends on**：`RM-03`。**Parallel with**：none。
+- **Must read**：本文第 7 节、[Architecture](../architecture.md) persistence/config sections。
+- **Owned scope/files**：`src/persistence/database.ts`、`src/persistence/migrations.ts`、
+  `src/persistence/migrations/001_runtime_config.ts`、`scripts/refactor/generate_migrations.ts`、
+  `src/config/runtime_config.ts`、
+  `tests/refactor/unit/persistence_migrations.test.ts`、
+  `tests/refactor/unit/runtime_config.test.ts`。
+- **Deliverables/interface**：`openDatabase()`、forward-only checksummed migrations、
+  `RuntimeConfigStore.readSnapshot()`、`update(candidate, expectedRevision)` and one-time runtime seed。
+- **Tests**：`npm run test:refactor -- tests/refactor/unit/persistence_migrations.test.ts
+  tests/refactor/unit/runtime_config.test.ts`；empty/current/older/newer/checksum-drift DB；migration rollback；
+  build-time discovery、filename/export/duplicate mismatch、generated static manifest、WAL/FULL/FK；
+  concurrent revision conflict；TypeBox no-coercion；runtime seed-once；immutable in-flight snapshot；failed swap keeps old。
+- **Acceptance/done**：network/large transform absent from transactions；prepared statements finalized on close；
+  one main-thread connection；migration fixtures upgrade to exact current schema。
+- **Non-goals/guardrails**：不创建 ORM/`DatabasePort`、worker、polling cleanup timer；不 store secrets。
+- **PR handoff**：列出 schema version、PRAGMAs、busy timeout、transaction boundaries and measured commit/event-loop
+  baseline。
+
+### RM-05 — Telemetry and performance state
+
+- **Goal**：实现 content-free Usage Buckets、sanitized Operational Events、bounded JSONL logs 与 runtime
+  degraded transitions。
+- **Depends on**：`RM-04`。**Parallel with**：`RM-06`。
+- **Must read**：本文第 6.1、7.1、8、10 节，[CONTEXT](../../CONTEXT.md)，[Architecture](../architecture.md)
+  usage/resource/Admin monitoring sections。
+- **Owned scope/files**：`src/persistence/migrations/020_telemetry.ts`、`src/telemetry/**`、
+  `tests/refactor/unit/telemetry_retention.test.ts`、
+  `tests/refactor/unit/performance_windows.test.ts`、
+  `tests/refactor/integration/log_rotation.test.ts`、
+  `tests/refactor/performance/telemetry_bench.test.ts`、
+  `tests/refactor/performance/runtime_latency.test.ts`。
+- **Deliverables/interface**：nonblocking `TelemetryRecorder` for Usage Bucket/Operational Event；bounded
+  `flush(signal)`；`PerformanceSnapshot` and exact three-window state reducer；10 MiB × 5/7d logger。
+- **Tests**：`npm run test:refactor -- tests/refactor/unit/telemetry_retention.test.ts
+  tests/refactor/unit/performance_windows.test.ts tests/refactor/integration/log_rotation.test.ts`；
+  hour key dimensions、90d/100,000 cleanup、7d/512 cleanup、stable identity after
+  removal、1024 mixed/usage-only/event-only queue coalesce/eviction and persisted drop counters、16KiB
+  metadata/64KiB log line、sanitization denylist、rotation
+  boundary、hard-crash loss model、2/3/restore window transitions。
+- **Acceptance/done**：no prompts/bodies/request IDs/arbitrary labels；one event per enter/clear；health/readiness stay
+  green；writer queues bounded and graceful flush timed。
+- **Non-goals/guardrails**：不 build tracing warehouse、raw audit log、watchdog 或 auto-tuner；不 move SQLite to
+  worker without failed measured gate。
+- **PR handoff**：交付 metric definitions、queue bounds、retention evidence、three-run perf files and Admin DTO
+  shape needed by `RM-20`。
+
+### RM-06 — Accounts, secrets, and GHES
+
+- **Goal**：实现 GitHub.com/GHES device login、stable account identity、protected credentials、default/model
+  preferences and remove/relogin semantics。
+- **Depends on**：`RM-04`。**Parallel with**：`RM-05`。
+- **Must read**：[Model listing](../github_copilot_model_listing_apis.md) credential sections、
+  [Architecture](../architecture.md) GitHub environments/account lifecycle/security、
+  [ADR-0002](../adr/0002-file-backed-secret-store.md)。
+- **Owned scope/files**：`src/accounts/**`、`src/persistence/migrations/010_accounts.ts`、
+  `tests/refactor/unit/account_identity.test.ts`、
+  `tests/refactor/integration/credential_store_permissions.test.ts`、
+  `tests/refactor/integration/device_flow.test.ts`、
+  `tests/refactor/fixtures/accounts/**`。
+- **Deliverables/interface**：`GitHubEnvironmentResolver`、`AccountDirectory`、production/memory
+  `CredentialStore`、SQLite `AccountModelPreferences`、scriptable `DeviceFlow`。`AccountId` canonical text is
+  `<normalized-host>/<canonical-decimal-user-id>`。`normalized-host` is the lowercase ASCII/IDNA hostname with
+  one trailing dot removed, default `:443` omitted and an explicit non-443 decimal port preserved；
+  `canonical-decimal-user-id` is a positive integer rendered without leading zeroes。
+- **Tests**：`npm run test:refactor -- tests/refactor/unit/account_identity.test.ts
+  tests/refactor/integration/credential_store_permissions.test.ts tests/refactor/integration/device_flow.test.ts`；
+  host lowercase/IDNA/default-port/path/credential rejection；numeric ID canonicalization；8 default/32
+  hard cap；default fallback `authenticated_at DESC, accountId ASC`；atomic replace/SQLite-commit failure；Unix `0600`；
+  directory `0700`、symlink/owner rejection、Windows current-user ACL；revision CAS；
+  active→removing→removed crash/retry points；same identity relogin rejoins usage。
+- **Acceptance/done**：GitHub.com/GHES URLs/client IDs match architecture；secret never reaches DB/log/error；
+  default bind returns immutable `BoundAccount`；remove clears credentials/caches/preference but retains identity/usage；
+  invalid preferred model requires explicit reselection。
+- **Non-goals/guardrails**：不 add OS vault、old data importer、old env aliases、global refresh timer or model-name
+  inference。
+- **PR handoff**：提供 account ID examples、file format version、ACL evidence、reconciliation state machine and
+  scripted device-flow interface for CLI/Admin。
+
+### RM-07 — Copilot transport and SSE
+
+- **Goal**：实现 request-bound Copilot transport、token refresh、endpoint discovery、fixed client identity、
+  raw Chat SSE framing and cancellation。
+- **Depends on**：`RM-02`, `RM-03`, `RM-06`。**Parallel with**：late `RM-05`。
+- **Must read**：[Architecture](../architecture.md) Copilot/stream sections、
+  [Model listing](../github_copilot_model_listing_apis.md) token/endpoint/transport sections、
+  [Responses routing](../openai_responses_routing.md) native headers/URL、
+  [OpenAI Chat](../openai_chat_completions.md) shared Chat DTO/SSE parser sections。
+- **Owned scope/files**：`src/copilot/backend.ts`、`transport.ts`、`token_refresh.ts`、
+  `endpoint_discovery.ts`、`chat_sse.ts`、`src/protocols/chat_completions/**`、
+  `tests/refactor/unit/chat_sse.test.ts`、
+  `tests/refactor/integration/copilot_transport.test.ts`、
+  `tests/refactor/fixtures/copilot-transport/**`。
+- **Deliverables/interface**：production/scripted `CopilotBackend`、immutable `BoundCopilot`、
+  typed `ChatRequest/ChatResponse/ChatChunk` decoders、transport-only `NativeResponsesUpstreamRequest`、
+  `ChatStreamFrame = chunk | error | done`；
+  account-scoped refresh/discovery mutex with lock recheck。
+- **Tests**：`npm run test:refactor -- tests/refactor/unit/chat_sse.test.ts
+  tests/refactor/integration/copilot_transport.test.ts`；refresh `<60s` versus exactly 60s；GHES OAuth direct use；
+  complete discovery DTO；cached/noncached
+  fallbacks；fixed headers；redirect limit and five secret headers stripping；connect/total/cancel；BOM/LF/CRLF/CR、
+  multi-data、error、`[DONE]`、truncated EOF at every byte split。
+- **Acceptance/done**：one request retains account/target；pull-based stream has no unbounded queue；abort closes
+  socket/body/timers；credentials cannot be overridden by inbound headers；no same-provider protocol retry。
+- **Non-goals/guardrails**：不 convert downstream protocols、不 own Responses item IDs、不 create universal HTTP
+  wrapper；model catalog's special retry/cache remains `RM-08`。
+- **PR handoff**：记录 fixed identity values、timeout ownership、redirect evidence、SSE frame semantics and scripted
+  backend controls。
+
+### RM-08 — Model catalog and listing routes
+
+- **Goal**：实现唯一 per-account CAPI catalog、generation-safe cache、preferred-model validation，以及
+  `/v1/models` OpenAI/Anthropic serializers 与 `/api/tags`。
+- **Depends on**：`RM-04`, `RM-06`, `RM-07`。**Parallel with**：`RM-05`。
+- **Must read**：[Model listing](../github_copilot_model_listing_apis.md) 全文、
+  [Responses routing](../openai_responses_routing.md) routing metadata sections、
+  `docs/gateway_http_contracts.md`。
+- **Owned scope/files**：`src/copilot/model_catalog.ts`、`src/protocols/model_catalog/**`、
+  `tests/refactor/contract/model_catalog.test.ts`、
+  `tests/refactor/integration/model_routes.test.ts`、
+  `tests/refactor/fixtures/model-catalog/**`。
+- **Deliverables/interface**：`CopilotModelCatalog.get/invalidate/clear` and internal
+  `CopilotModelsSource` production/scripted seam；`ModelResolver` implementing section 6.2；public DTO excludes
+  private routing metadata；`PreferredModelManager.setPreferred` validates/captures catalog generation before calling
+  RM-06 storage；`createModelCatalogRoutes(dependencies): readonly RouteRegistration[]` exports
+  `/v1/models` and `/api/tags` without editing shared composition。Catalog refresh calls
+  `AccountModelPreferences.markInvalidIfMissing`，never writes preference tables directly。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/model_catalog.test.ts
+  tests/refactor/integration/model_routes.test.ts`；strict four-field CAPI items；picker
+  filter/order/duplicates/empty；no TTL/no single-flight；
+  generation races；literal `endpoint + "/models"`；redirect/Retry-After/errors；OpenAI fields；any
+  `anthropic-version` presence including empty/wrong value selects Anthropic success shape；nullable limits/all models；
+  Ollama RFC3339Nano；missing/preferred/explicit/unknown model matrix；`/models` 404。
+- **Acceptance/done**：three serializers read the same snapshot；no static list/name inference；cache isolated by
+  account；catalog invalidation marks missing preferred model invalid without silent fallback；errors expose no upstream
+  body。
+- **Non-goals/guardrails**：不 implement inference、device UI、pagination、download/delete model routes or query
+  cache bypass。
+- **PR handoff**：提供 `CatalogSnapshot`/private routing shape、cache generation traces、route golden IDs and
+  model resolver contract used by protocol owners。
+
+### RM-09 — OpenAI Chat endpoint
+
+- **Goal**：完成 `/v1/chat/completions` native Chat path as the first end-to-end tracer through Gateway、
+  Bound Account、model resolver and Copilot transport。
+- **Depends on**：`RM-03`, `RM-07`, `RM-08`。**Parallel with**：`RM-05`。
+- **Must read**：[OpenAI Chat](../openai_chat_completions.md) 全文、`docs/gateway_http_contracts.md` OpenAI
+  presenter sections、[Architecture](../architecture.md) OpenAI Chat/stream/commit sections。
+- **Owned scope/files**：`src/protocols/openai_chat/**`、
+  `tests/refactor/contract/openai_chat_endpoint.test.ts`、
+  `tests/refactor/integration/openai_chat_stream.test.ts`、
+  `tests/refactor/fixtures/openai-chat/**`。
+- **Deliverables/interface**：`createOpenAiChatRoute(dependencies): RouteRegistration`；explicit Chat decoder、
+  one resolved model rewrite、buffered JSON path and normalized OpenAI SSE fast path。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/openai_chat_endpoint.test.ts
+  tests/refactor/integration/openai_chat_stream.test.ts`；required/missing model/default preference；unknown fields
+  and exact reserialization per HTTP contract；
+  upstream statuses/safe errors；usage-only/event/error/one successful `[DONE]`；all byte splits；first-byte/idle/total
+  timeout；queue `503`；abort before/after commit；no aliases。
+- **Acceptance/done**：one upstream call with bound account/model；raw fast path does not instantiate Ollama/Anthropic/
+  Responses state；success terminal exactly once；zero additional bytes on abort；Fetch-surface tests need no private
+  method access。
+- **Non-goals/guardrails**：不 add Chat-to-canonical adapter、不 normalize into another protocol、不 fallback to
+  legacy or Responses。
+- **PR handoff**：交付 final upstream request fixtures、SSE byte evidence、per-request allocation/latency delta and
+  OpenAI endpoint registration/presenter evidence。
+
+### RM-10 — Ollama endpoint
+
+- **Goal**：完成 `/api/chat` request/nonstream/stream/exact NDJSON 与 `/api/version` probe。
+- **Depends on**：`RM-03`, `RM-07`。**Parallel with**：`RM-05`, `RM-08`, `RM-09`, `RM-11`, `RM-12`。
+- **Must read**：[Ollama bridge](../ollama_chat_to_chat_completions.md) 全文、
+  `docs/gateway_http_contracts.md` Ollama/`/api/version` sections。
+- **Owned scope/files**：`src/protocols/ollama_chat/**`、
+  `tests/refactor/contract/ollama_request.test.ts`、
+  `ollama_nonstream.test.ts`、`ollama_stream.test.ts`、`ollama_wire.test.ts`、
+  `tests/refactor/fixtures/ollama/**`。
+- **Deliverables/interface**：`createOllamaChatRoutes(dependencies): readonly RouteRegistration[]` for `/api/chat`
+  and `/api/version`；protocol-local request bridge、nonstream mapper、`Done`-owned reducer and Go-compatible encoder。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/ollama_request.test.ts
+  tests/refactor/contract/ollama_nonstream.test.ts tests/refactor/contract/ollama_stream.test.ts
+  tests/refactor/contract/ollama_wire.test.ts`；all spec §10 categories：model/messages/options/format/think、
+  image magic、ordered tool args、choice 0、
+  usage/logprobs、reasoning tags、sparse tools、absorbing `[DONE]`、truncation/abort/error；Go reference byte cases
+  for order/omitempty/HTML/Unicode/control/final LF；queue `503`。
+- **Acceptance/done**：`stream` missing means true；source-valid unrepresentable semantics fail with zero upstream；
+  exactly one terminal or post-commit error；all fields/bytes match goldens；`/api/version` matches closed HTTP fixture。
+- **Non-goals/guardrails**：不 expose model pull/delete/copy/show、不 add model capability guesses、不 reuse
+  Responses/Anthropic serializer。
+- **PR handoff**：列出 Go encoder version、all golden case IDs、terminal transition table、token-counter seam and
+  benchmark delta。
+
+### RM-11 — Anthropic endpoint
+
+- **Goal**：完成 `/v1/messages` request/nonstream/stream/Python-compatible SSE text。
+- **Depends on**：`RM-03`, `RM-07`, `RM-08`。**Parallel with**：`RM-05`, `RM-09`, `RM-10`, `RM-12`。
+- **Must read**：[Anthropic bridge](../claude_messages_to_chat_completions.md) 全文、
+  `docs/gateway_http_contracts.md` Anthropic header/error/admission sections。
+- **Owned scope/files**：`src/protocols/anthropic_messages/**`、
+  `tests/refactor/contract/anthropic_request.test.ts`、
+  `anthropic_nonstream.test.ts`、`anthropic_stream.test.ts`、`anthropic_wire.test.ts`、
+  `tests/refactor/fixtures/anthropic/**`。
+- **Deliverables/interface**：`createAnthropicMessagesRoute(dependencies): RouteRegistration`；strict route
+  accepts exactly `anthropic-version: 2023-06-01` as specified by HTTP contract；protocol-local block lifecycle。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/anthropic_request.test.ts
+  tests/refactor/contract/anthropic_nonstream.test.ts tests/refactor/contract/anthropic_stream.test.ts
+  tests/refactor/contract/anthropic_wire.test.ts`；spec §9 matrix：headers、system billing lines、
+  message/media/tool history、schema cleanup、reasoning
+  families、multi-choice/thinking/tool argument repair、usage aliases、block switches/signed thinking、finish-first/
+  no-finish/exception；Python default `json.dumps` spaces/ASCII；queue `529`；abort。
+- **Acceptance/done**：request matches pinned cc-switch behavior；nonstream/events match pinned LiteLLM plus specified
+  terminal closure；`message_stop` exactly once only on success path；Messages version rule is not reused by models
+  route header-presence selection。
+- **Non-goals/guardrails**：不 add hosted tools/name truncation/structured-output/context management、legacy aliases
+  or synthetic stream errors。
+- **PR handoff**：提供 Python encoder command/version、golden IDs、header matrix、block-state diagram and benchmark
+  delta。
+
+### RM-12 — Responses core DTO and History
+
+- **Goal**：建立唯一 Responses request DTO/decoder，并实现只供 `ChatBridgePlan` 使用的 durable bounded
+  Responses History 与 independent Admin read/clear interface。
+- **Depends on**：`RM-02`, `RM-04`。**Parallel with**：`RM-05`, `RM-10`, `RM-11`。
+- **Must read**：[Responses bridge](../codex_response_to_chat_completions.md) history sections、
+  [Architecture](../architecture.md) Responses history/commit sections、[CONTEXT](../../CONTEXT.md)。
+- **Owned scope/files**：`src/persistence/migrations/030_responses_history.ts`、
+  `src/protocols/responses/dto.ts`、`decoder.ts`、`history.ts`、
+  `tests/refactor/unit/responses_decoder.test.ts`、
+  `tests/refactor/unit/responses_history.test.ts`、
+  `tests/refactor/integration/responses_history_sqlite.test.ts`、
+  `tests/refactor/fixtures/responses-history/**`。
+- **Deliverables/interface**：`decodeResponsesRequest(WireJson): ResponsesRequest`、
+  `ResponsesHistory.enrich/record`、`ResponsesHistoryAdmin.inspect/clear`；transactionally store response +
+  ordered calls + call index and persistent history revision。
+- **Tests**：`npm run test:refactor -- tests/refactor/unit/responses_history.test.ts
+  tests/refactor/unit/responses_decoder.test.ts tests/refactor/integration/responses_history_sqlite.test.ts`；
+  missing/null/scalar/duplicate control fields；previous response first；unique global call fallback；
+  ambiguous miss；field fill/request precedence；
+  object-to-array only when changed；512 insertion eviction；7d expiry at startup/lookup/record；restart recovery；
+  transaction rollback；Admin clear revision conflict；concurrent abort。
+- **Acceptance/done**：one DTO owner for native/planner/bridge slices；global insertion order/TTL/revision exact；no
+  read-through cache/timer；Semantic Checkpoint record can be synchronously committed under 5 ms p95 harness；native IDs
+  never resolve locally。
+- **Non-goals/guardrails**：不 store token/reasoning fragments/live streams、不 delete on account removal、不 expose
+  Admin clear through inference interface。
+- **PR handoff**：交付 schema/query plan、enrichment examples、checkpoint transaction call and 3-run commit metrics。
+
+### RM-13 — Responses planner and native execution
+
+- **Goal**：实现 immutable `Responses Execution Plan` 与 native Responses JSON/SSE path。
+- **Depends on**：`RM-07`, `RM-08`, `RM-12`。**Parallel with**：none。
+- **Must read**：[Responses routing](../openai_responses_routing.md) 全文、
+  [Architecture](../architecture.md) Responses planning/native sections、
+  `docs/gateway_http_contracts.md` Responses sections。
+- **Owned scope/files**：`src/protocols/responses/planner.ts`、`native.ts`、native wire helpers、
+  `tests/refactor/contract/responses_planner.test.ts`、
+  `responses_native.test.ts`、`responses_native_stream.test.ts`、
+  `tests/refactor/fixtures/responses-native/**`。
+- **Deliverables/interface**：`planResponsesExecution(...) -> NativeResponsesPlan | ChatBridgePlan` exactly as defined
+  by the routing spec。Plan carries the original decoded request、one
+  `ResolvedModel` and immutable target/routing metadata；it does not convert a bridge request。Native executor reuses
+  that model/URL，serializes `NativeResponsesUpstreamRequest` bytes and parses the raw upstream response，using a
+  stream-scoped
+  `Map<output_index, stable_item_id>`。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/responses_planner.test.ts
+  tests/refactor/contract/responses_native.test.ts tests/refactor/contract/responses_native_stream.test.ts`；
+  mode first-match matrix、catalog-resolved metadata missing/malformed/lookup error bridge、explicit catalog miss
+  404、no name/vendor guess、metadata mutation after plan、
+  exact normalized `/responses` URL/headers、Responses-only fields/encrypted content、nonstream IDs/usage preservation、
+  item-ID normalization/isolation、native usage observation/outcome、invalid 2xx、cancel、no same-provider fallback/no
+  local history；native SSE media/framing/type-match/terminal/EOF。
+- **Acceptance/done**：planning happens once before converter；native path never calls Chat converter/history；
+  only item IDs are normalized in native events；upstream failure remains native protocol。
+- **Non-goals/guardrails**：不 implement compact/aliases、handwritten allowlist、cross-protocol retry or bridge
+  request conversion。
+- **PR handoff**：提供 discriminated plan types、routing fixture matrix、native upstream captures and stream memory
+  benchmark。
+
+### RM-14 — Responses bridge request conversion
+
+- **Goal**：实现 `ChatBridgePlan` 的 history enrichment、ToolContext、Responses request → Chat request conversion。
+- **Depends on**：`RM-07`, `RM-12`, `RM-13`。**Parallel with**：none。
+- **Must read**：[Responses bridge](../codex_response_to_chat_completions.md) §§1–8、§12、§14.1，
+  [Responses routing](../openai_responses_routing.md) bridge ownership。
+- **Owned scope/files**：`src/protocols/responses/bridge_request.ts`、`tool_context.ts`、
+  `tests/refactor/contract/responses_bridge_request.test.ts`、
+  `tests/refactor/fixtures/responses-bridge-request/**`。
+- **Deliverables/interface**：pure `convertResponsesRequest(request, context)` plus immutable
+  `RequestToolContext` builder；after planning has frozen `ResolvedModel`, bridge orchestration is exactly history
+  enrichment → apply the same resolved model → ToolContext → reasoning config → conversion → prompt cache。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/responses_bridge_request.test.ts`；
+  spec §14.1 categories：top-level/drop、instructions/system、input shapes/media、call batching、
+  canonical args、reasoning pending、depth-32/8KiB media、function/namespace hash/custom/tool-search/collision、
+  five effort modes、history 512/unique/ambiguous；cross-direction binding fixtures。
+- **Acceptance/done**：deep-equivalent pinned request fixtures；no catalog/default lookup inside converter；
+  request model equals context resolved model；collision ownership first-wins and immutable。
+- **Non-goals/guardrails**：不 implement response/stream、generic capabilities/behavior profile or raw HTTP/SSE。
+- **PR handoff**：交付 exported pure functions、ToolContext examples、loss matrix、fixture IDs and allocation benchmark。
+
+### RM-15 — Responses bridge non-stream conversion
+
+- **Goal**：实现 Chat response → Responses response object、managed IDs、tools/images/usage and history record
+  materialization。
+- **Depends on**：`RM-14`。**Parallel with**：`RM-16`。
+- **Must read**：[Responses bridge](../codex_response_to_chat_completions.md) §§9–10、§12–14。
+- **Owned scope/files**：`src/protocols/responses/bridge_nonstream.ts`、nonstream wire helper、
+  `tests/refactor/contract/responses_bridge_nonstream.test.ts`、
+  `tests/refactor/fixtures/responses-bridge-nonstream/**`。
+- **Deliverables/interface**：pure `convertChatResponse(response, context)` and
+  `buildResponsesHistoryRecord(response)`；deterministic clock/UUID inputs。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/responses_bridge_nonstream.test.ts`；
+  empty/all choices、first-choice status、envelope/defaults、reasoning blocks/encrypted content、message/
+  annotation/image IDs、function/custom/namespace/tool-search restoration、provider fields、usage detail aliases、
+  managed ID idempotence、argument failure；complete expected objects。
+- **Acceptance/done**：LiteLLM envelope/content/usage/IDs and cc-switch ToolContext restoration match pinned fixtures；
+  complete conversion precedes history commit；no partial success object on error。
+- **Non-goals/guardrails**：不 write SQLite、不 implement stream/native/error presenter、不 synthesize diagnostics or
+  stable bridge error DTO。
+- **PR handoff**：提供 output/history-record examples、UUID/clock sequence、all fixture IDs and conversion p95。
+
+### RM-16 — Responses bridge stream conversion
+
+- **Goal**：实现 typed Chat chunks → Responses events 的 independent item lifecycles、sequence numbers 与
+  `Semantic Checkpoint` emissions。
+- **Depends on**：`RM-07`, `RM-14`。**Parallel with**：`RM-15`。
+- **Must read**：[Responses bridge](../codex_response_to_chat_completions.md) §§11–14、
+  [Architecture](../architecture.md) stream/backpressure/checkpoint sections。
+- **Owned scope/files**：`src/protocols/responses/bridge_stream.ts`、stream wire helper、
+  `tests/refactor/contract/responses_bridge_stream.test.ts`、
+  `tests/refactor/fixtures/responses-bridge-stream/**`。
+- **Deliverables/interface**：pull-based
+  `convertChatStream(chunks, context): AsyncIterable<ResponsesStreamEmission>`；emission discriminates ordinary
+  event from checkpoint carrying minimal history, so endpoint can commit before encoding/writing done/completed bytes。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/responses_bridge_stream.test.ts`；
+  first chunk/empty iterator、created/in-progress fields、text/reasoning independent lifecycle、10-character
+  argument slices、sparse/ambiguous/late tools、custom input、annotations/provider fields、tool-only stream、completed
+  ownership、sequence starts 1 strictly increasing、exception/abort/no synthetic failed；every raw byte split remains
+  owned by upstream SSE parser。
+- **Acceptance/done**：added precedes delta/done；output index stable；only completed items enter snapshot/checkpoint；
+  iterator reads at most one unconsumed item；event overhead p95 `<=2 ms` three runs。
+- **Non-goals/guardrails**：不 read raw `data:`、write DB、reuse native state or merge lifecycles into generic
+  transformer。
+- **PR handoff**：交付 emission union、state transition table、checkpoint examples、fixture IDs、latency/RSS delta。
+
+### RM-17 — Responses endpoint integration
+
+- **Goal**：把 planner、native、history、bridge converters、commit boundaries and HTTP presenter 组合为完整
+  `POST /v1/responses`。
+- **Depends on**：`RM-12`, `RM-13`, `RM-15`, `RM-16`。**Parallel with**：none。
+- **Must read**：两份 Responses specs 全文、`docs/gateway_http_contracts.md`、[Architecture](../architecture.md)
+  Responses/history/failure sections。
+- **Owned scope/files**：`src/protocols/responses/endpoint.ts`、`wire.ts`、
+  `tests/refactor/contract/responses_endpoint.test.ts`、
+  `tests/refactor/integration/responses_endpoint_stream.test.ts`、
+  `tests/refactor/fixtures/responses-endpoint/**`。
+- **Deliverables/interface**：`createResponsesRoute(dependencies): RouteRegistration`；single planning and
+  model binding；nonstream/checkpoint commit orchestration；protocol-local presenter。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/responses_endpoint.test.ts
+  tests/refactor/integration/responses_endpoint_stream.test.ts`；native/bridge matrix end-to-end；captured upstream
+  body；history enrich/record/restart；checkpoint commit
+  failure before bytes；failure after earlier events；native no-history/no-fallback；queue `503`；all timeouts/limits；
+  exact shared Responses SSE encoder/no `[DONE]`；abort zero additional bytes；`/responses`、
+  `/openai/v1/responses`、compact aliases 404。
+- **Acceptance/done**：all Responses fixture families pass through Fetch surface；plan cannot change mid-request；
+  native and bridge ID namespaces/history remain separate；checkpoint p95 `<=5 ms` three runs。
+- **Non-goals/guardrails**：不 add compact/cross-account retry/live-stream recovery、legacy fallback or implementation
+  profile。
+- **PR handoff**：提供 route matrix、commit timeline traces、history before/after fixtures、failure evidence and
+  benchmark results to CLI/Admin owners。
+
+### RM-18 — CLI core, control client, and foreground runtime
+
+- **Goal**：实现 non-default `ghcg` parser、scripted/production control client、application command dispatcher and
+  foreground `serve`；real local control wiring remains RM-19。
+- **Depends on**：`RM-04`, `RM-06`, `RM-08`, `RM-09`, `RM-10`, `RM-11`, `RM-17`。
+  **Parallel with**：`RM-20`。
+- **Must read**：本文 CLI/config/security sections、[Architecture](../architecture.md) project identity/composition、
+  [ADR-0003](../adr/0003-clean-break-rename.md)。
+- **Owned scope/files**：`src/cli/main.ts`、`src/cli/commands/**`、finalized `src/main.ts` foreground wiring、
+  `tests/refactor/unit/cli_parser.test.ts`、`tests/refactor/integration/cli_commands.test.ts`。
+- **Deliverables/interface**：`ghcg serve`；all section 9.4 command parsers/output/exit codes；production/scripted
+  `ControlClient`；server-side `CommandDispatcher`；non-default composition registers model、OpenAI、Ollama、
+  Anthropic and Responses `RouteRegistration`s without editing their modules。
+- **Tests**：`npm run test:refactor -- tests/refactor/unit/cli_parser.test.ts
+  tests/refactor/integration/cli_commands.test.ts`；exact `--help` snapshots；unknown/missing args；exit codes；
+  human/`--json` stdout-stderr separation；
+  global data-dir CLI/env/default locator and wrong-directory isolation；
+  exact control request/result union；scripted-control GitHub.com/GHES login start/poll/consume/interrupt；account cap/
+  default/remove；model invalid/reselect；runtime config CAS/no coercion；startup-only key rejection；foreground
+  SIGINT/SIGTERM graceful close；no secret stdout/stderr。
+- **Acceptance/done**：all management commands pass exact tests against scripted `ControlClient`；foreground gateway
+  runs all completed routes；no `chat` command；`serve` rejects non-loopback；default published bin remains legacy。
+- **Non-goals/guardrails**：real identity file、control routes and `start/stop/restart/status/admin open` belong
+  `RM-19`；CLI never opens SQLite/secret files；不 add old executable/env/data aliases or duplicate domain logic。
+- **PR handoff**：提供 command tree/help/exit-code evidence、scripted transcript、foreground shutdown timing and daemon
+  composition hook。
+
+### RM-19 — Self-managed daemon and local control
+
+- **Goal**：完成 `start/stop/restart/status/admin open`、authenticated local control、safe process identity and
+  rotating daemon logs，并把全部 management CLI commands 接到唯一 running gateway。
+- **Depends on**：`RM-05`, `RM-18`, `RM-20`。**Parallel with**：none。
+- **Must read**：本文第 9 节、[Architecture](../architecture.md) CLI/security sections、
+  [ADR-0004](../adr/0004-self-managed-daemon.md)。
+- **Owned scope/files**：`src/daemon/**`、daemon CLI command files、
+  serialized non-default composition update in `src/main.ts`、
+  `tests/refactor/unit/daemon_identity.test.ts`、
+  `tests/refactor/integration/daemon_lifecycle.test.ts`、
+  `tests/refactor/integration/daemon_stale_pid.test.ts`。
+- **Deliverables/interface**：`DaemonController.start/stop/restart/status` and protected `DaemonIdentityFile`；
+  foreground/managed identity publication；control operations `status`、`stop`、`admin-bootstrap`、`command`
+  require token + PID/start/nonce verification。
+- **Tests**：`npm run test:refactor -- tests/refactor/unit/daemon_identity.test.ts
+  tests/refactor/integration/daemon_lifecycle.test.ts tests/refactor/integration/daemon_stale_pid.test.ts`；
+  start readiness/failed start cleanup；idempotent status/stop；restart changes nonce/start identity；PID reuse/
+  forged/stale/corrupt/weak-permission files；unreachable live process never killed；concurrent start lock；crash leaves
+  no watchdog；foreground management but stop/restart rejection；every management command requires running gateway and
+  never opens local stores；log 10 MiB×5/7d；`admin open` one-time 60s URL fragment。
+- **Acceptance/done**：one detached process only；verified lifecycle on required CI OSes；no PID-only termination；
+  daemon restart invalidates Admin state；all files/tokens redacted and protected。
+- **Non-goals/guardrails**：不 install system service、watchdog、auto-restart、file watcher or second server process。
+- **PR handoff**：提供 OS-specific process identity method、lifecycle transcripts、stale-PID safety evidence、log files
+  and bootstrap integration evidence。
+
+### RM-20 — Admin auth and management API
+
+- **Goal**：实现 bootstrap/session/CSRF/Origin security、management routes、bounded monitoring SSE and sanitized DTOs。
+- **Depends on**：`RM-05`, `RM-06`, `RM-08`, `RM-12`, `RM-17`。**Parallel with**：`RM-18`。
+- **Must read**：本文第 6.1、9.3 节、[Architecture](../architecture.md) Admin/security/routes sections、
+  `docs/gateway_http_contracts.md` Admin isolation rules。
+- **Owned scope/files**：`src/admin/auth.ts`、`api.ts`、`events.ts`、`routes.ts`、
+  `tests/refactor/contract/admin_auth.test.ts`、
+  `tests/refactor/contract/admin_api.test.ts`、
+  `tests/refactor/integration/admin_events.test.ts`。
+- **Deliverables/interface**：60s one-use bootstrap exchange、in-memory `AdminSession`、logout/session introspection；
+  `createAdminRoutes(dependencies): readonly RouteRegistration[]` covering all section 9.3
+  routes/DTOs/pagination/error envelope；control-facing bootstrap mint interface。
+- **Tests**：`npm run test:refactor -- tests/refactor/contract/admin_auth.test.ts
+  tests/refactor/contract/admin_api.test.ts tests/refactor/integration/admin_events.test.ts`；
+  token expiry/reuse/race；bootstrap no-session/CSRF exception with exact Origin；cookie flags；30m idle/12h
+  absolute/restart invalidation；CSRF and exact Origin on
+  every mutation；TypeBox no coercion/unknown handling；revision conflicts；no secret fields；history clear；degraded
+  transitions；device-flow polling/cap/expiry；usage/event cursor bounds；8 sessions/tokens/subscribers；
+  operational/performance/reset SSE exact bytes、Last-Event-ID replay/eviction/malformed、heartbeat；
+  active request versus active stream counters；bounded subscriber/slow disconnect；static catch-all isolation。
+- **Acceptance/done**：Admin can perform all six views' operations only through module interfaces；mutations fail closed；
+  inference middleware/envelopes are not reused；state responses are no-store and sanitized。
+- **Non-goals/guardrails**：不 implement UI、WebSocket、persistent browser session、remote bind or expose long-term
+  admin/control secret。
+- **PR handoff**：提供 route/DTO fixture index、cookie/CSRF bootstrap flow、scripted Admin backend and
+  event contract for UI/daemon owners。
+
+### RM-21 — Svelte Admin UI
+
+- **Goal**：交付 Svelte 5/Vite static SPA 的六个 views 与 7 个 offline Playwright flows。
+- **Depends on**：`RM-19`, `RM-20`。**Parallel with**：none。
+- **Must read**：本文 Admin/security sections、[Architecture](../architecture.md) Admin UI sections，以及
+  `RM-20` route/DTO fixtures。
+- **Owned scope/files**：`web/**`、`src/admin/static.ts`、serialized non-default composition update in
+  `src/main.ts`、
+  `tests/refactor/e2e/admin.spec.ts`、`tests/refactor/e2e/fixtures/**`。
+- **Deliverables/interface**：`Overview`、`Accounts`、`Models`、`Configuration`、`ResponsesHistory`、`Events`；
+  fragment bootstrap exchange、CSRF client、SSE reconnect with bounded UI state；no SvelteKit server。
+- **Tests**：`npm run test:e2e:refactor -- tests/refactor/e2e/admin.spec.ts`，exact 7 flows：
+  `bootstrap-and-session-expiry`、`github-and-ghes-account-lifecycle`、
+  `model-refresh-invalidates-preference`、`config-revision-and-security-rejection`、
+  `responses-history-inspect-and-clear`、`events-and-degraded-recovery`、
+  `daemon-restart-invalidates-session`。Run Chromium on all full CI jobs；one additional browser may run on Linux。
+- **Acceptance/done**：keyboard navigation/labels/focus/error states work；six views expose all required operations；
+  no secret rendered/stored；built assets served only under `/admin/*`；5–8 requirement is met with exactly 7 stable
+  behavior flows。
+- **Non-goals/guardrails**：不 add SvelteKit、SSR、WebSocket、client-side protocol console/chat、pixel-only golden or
+  extra primary view。
+- **PR handoff**：提供 asset manifest、Playwright traces only on failure、accessibility check output、flow-to-route
+  matrix and package size/RSS proof（browser excluded from daemon RSS）。
+
+### RM-22 — Cutover, legacy removal, and release handoff
+
+- **Goal**：一次性把 verified TypeScript app 切为 default，删除 legacy，完成 package/readme/release candidate；
+  不提前 rename GitHub repository。
+- **Depends on**：`RM-05`, `RM-17`, `RM-19`, `RM-21`（其余为 transitive）。**Parallel with**：none。
+- **Must read**：本文全文、[AGENTS](../../AGENTS.md)、[Architecture](../architecture.md) 全文、
+  [ADR-0003](../adr/0003-clean-break-rename.md)，所有 production specs。
+- **Owned scope/files**：`package.json`、`package-lock.json`、default build/test/release configs、`README.md`、
+  `src/**/*.js` legacy deletion、legacy tests/fixtures deletion or replacement、release workflows and package smoke。
+- **Deliverables/interface**：package becomes `@ljie-pi/ghc-gateway@0.1.0`；only bin `ghcg`；Node `>=24`；
+  default `start/build/test/lint` target TypeScript；`prepack` builds server + Admin assets；repository metadata targets
+  `ljie-PI/ghc-gateway`；data/env are only `~/.ghc-gateway`/`GHC_GATEWAY_`。
+- **Tests**：full offline `npm run typecheck`；`npm run lint`；`npm run build`；`npm test`；
+  `npm run fixtures:verify`；`npm pack`；all protocol/model/HTTP contracts；then
+  clean install on required/additional platforms；foreground and daemon lifecycle；all 7 Admin E2E flows；route/alias
+  closure；three-run RSS/latency/checkpoint/event-loop suite；fresh and migrated-within-new-v1 DB；clean tree after
+  pack/install。
+- **Acceptance/done**：every target route complete；no legacy files/imports/names/aliases/default scripts；pack contains
+  only intended dist/assets/docs/license；idle RSS `<=64 MiB` and 1,000-stream stable delta `<=16 MiB`；all latency
+  gates pass three times；README is the final user-facing update and matches actual CLI/security/config behavior。
+- **Non-goals/guardrails**：coding agent不运行 npm publish、不 target `main`、不运行 `gh repo rename`、不 retain
+  compatibility launcher/data migration or fallback。
+- **PR handoff**：附 package tarball manifest/SHA、five-platform smoke evidence、full route matrix、daemon/Admin traces、
+  benchmark raw files、clean `git status` and operator checklist from第 15 节。
+
+## 14. Final cutover checklist
+
+`RM-22` PR 在 `refactor` 上必须逐项为 green：
+
+- OpenAI Chat、Ollama、Anthropic、Responses native/bridge、OpenAI/Anthropic models、Ollama tags/version 全部
+  contract/golden fixtures。
+- Body/event/accumulator/admission/timeout/abort/post-commit tests；queue statuses OpenAI 503、Anthropic 529、
+  Ollama 503。
+- `npm pack` + clean install + `ghcg --help` + foreground health + full daemon lifecycle。
+- `ghcg admin open` bootstrap、Admin auth/CSRF/Origin、六 views、7 Playwright flows。
+- fresh login、GHES、multi-account cap/default/remove/relogin、preferred-model invalidation。
+- SQLite migration/checksum/WAL/FULL、history restart/TTL/512、usage 90d/100k、events 7d/512。
+- JSONL 10 MiB×5/7d、secrets Unix `0600`/Windows current-user ACL、redaction scans。
+- idle/stable-stream RSS and four latency/event-loop gates，each three consecutive runs。
+- default entrypoints contain no TODO/stub/legacy fallback；old executable/env/data names absent。
+- README updated last；tarball manifest exact；`git diff --check` and clean working tree after every generated/smoke step。
+
+Any failed item keeps `refactor` unreleased；the gate is never waived by documenting a follow-up issue。
+
+## 15. Post-merge release and repository rename
+
+After `RM-22` merges to `refactor`, a maintainer—not a coding agent—performs：
+
+1. rerun the signed/recorded release gate from a clean checkout；
+2. review and merge the single promotion from `refactor` to `main` under repository policy；
+3. manually or with authenticated GitHub CLI rename `ljie-PI/ghcp-ollama` to `ljie-PI/ghc-gateway`；
+4. verify redirects、default branch、remote URL、package metadata and README links；
+5. publish `@ljie-pi/ghc-gateway@0.1.0` from the verified main commit and verify clean install/release assets；
+6. announce the clean break：users reauthenticate/reconfigure；there are no old aliases or state import。
+
+Repository rename occurs only after the final main merge and pre-publish verification。No implementation PR may rename
+the remote early or make tests depend on the rename having occurred。

--- a/docs/specs/refactor_master_spec.md
+++ b/docs/specs/refactor_master_spec.md
@@ -309,8 +309,11 @@ tests/refactor/
   unit/
   contract/
   integration/
+  sdk/
   e2e/
   performance/
+tests/live/
+  sdk/
 scripts/refactor/
 dist-refactor/                 # generated, never committed
 dist/                          # final package output, never committed
@@ -1340,6 +1343,55 @@ continuously。A degraded metric clears only after three subsequently evaluated 
 - Vitest is the unit/contract/integration runner。Playwright has 7 fixed flows in `RM-21`；不扩大为 brittle
   pixel snapshot suite。
 
+### 10.3 Official SDK integration
+
+SDK integration has two separate tiers。
+
+#### Offline SDK compatibility
+
+CI installs exact lockfile-pinned official npm clients as dev dependencies：
+
+- `openai`
+- `@anthropic-ai/sdk`
+- `ollama`
+
+Tests start the real Node listener on loopback with an isolated data directory and scripted GitHub/Copilot remotes。
+Official SDKs send actual TCP HTTP requests to that listener；tests do not call `app.request()` and do not mock the SDK。
+Outbound network is blocked except loopback。
+
+| Client | Required local-gateway calls |
+| --- | --- |
+| OpenAI SDK | `models.list`；Chat Completions non-stream/stream；Responses non-stream/stream |
+| Anthropic SDK | `models.list`；Messages non-stream/stream |
+| Ollama SDK | list models；chat non-stream/stream |
+
+The suite validates SDK request construction、response deserialization、async stream iteration、terminal behavior、
+errors/request IDs and cancellation。Scripted upstream captures still prove the exact GitHub Copilot request。SDK tests
+complement rather than replace protocol byte goldens：SDK acceptance alone cannot prove member order or exact wire。
+
+Canonical command：
+
+```text
+npm run test:sdk:refactor
+```
+
+#### Manual live GitHub Copilot smoke
+
+`npm run test:live:sdk` is opt-in and immediately refuses unless `GHC_GATEWAY_LIVE_TESTS=1`。It connects all three
+official SDKs to an already running local `ghc-gateway` at
+`GHC_GATEWAY_LIVE_BASE_URL`（default `http://127.0.0.1:31400`），which then uses the current real Bound Account and
+GitHub Copilot endpoints。It is never part of CI、`npm test`、fixture generation or ordinary implementation PR gates。
+
+The live suite performs the same model-list and non-stream/stream calls with minimal token budgets。It validates only
+HTTP/SDK structure、event ordering、non-empty terminal result and cancellation；model prose is nondeterministic and is
+never a golden。It queries the current catalog and accepts optional explicit model overrides，but does not log prompt、
+response、tool content、credentials or complete endpoints。Native-Responses-specific live coverage may be recorded as
+`not_available` only when the account catalog has no native-capable model；offline routing fixtures remain mandatory。
+
+Before RM-22 promotion, a maintainer runs the live suite manually and records only timestamp、sanitized GitHub host、
+SDK versions、selected model IDs and pass/`not_available` status。A failure of a route that has an available model blocks
+release；transient remote failure is rerun and never converted into a changed golden。
+
 ## 11. Dependency DAG
 
 ### 11.1 Mermaid
@@ -1503,15 +1555,16 @@ Every PR description records all commands and artifact paths. It is mergeable on
 2. changes stay inside owned scope or document an approved cross-owner edit；
 3. `npm run typecheck:refactor` and `npm run lint:refactor` pass；
 4. the slice's targeted `npm run test:refactor -- <paths>` passes；
-5. `npm run build:refactor` and `npm run fixtures:verify` pass offline；
-6. legacy `npm run test:unit` and `npm run smoke:legacy` remain green through `RM-21`；default
+5. all SDK compatibility tests currently present pass through `npm run test:sdk:refactor` against loopback/scripted remotes；
+6. `npm run build:refactor` and `npm run fixtures:verify` pass offline；
+7. legacy `npm run test:unit` and `npm run smoke:legacy` remain green through `RM-21`；default
    `npm start`/bins remain legacy until `RM-22`；
-7. deterministic fixtures assert exact objects/bytes where required；golden changes name explicit `caseId`s and reason；
-8. abort、timeout、cleanup and post-commit branches added by the slice have tests；
-9. logs/errors/fixtures contain no credential or real request/response content；
-10. production/default paths contain no stub、TODO、legacy fallback or disabled failing test；
-11. hot-path/resource changes include the applicable benchmark delta, not an unmeasured performance claim；
-12. `git diff --check` passes and generated outputs/data directories are absent from the worktree。
+8. deterministic fixtures assert exact objects/bytes where required；golden changes name explicit `caseId`s and reason；
+9. abort、timeout、cleanup and post-commit branches added by the slice have tests；
+10. logs/errors/fixtures contain no credential or real request/response content；
+11. production/default paths contain no stub、TODO、legacy fallback or disabled failing test；
+12. hot-path/resource changes include the applicable benchmark delta, not an unmeasured performance claim；
+13. `git diff --check` passes and generated outputs/data directories are absent from the worktree。
 
 `RM-01` establishes these scripts；for that slice only, equivalent direct tool commands named in its PR are accepted。
 
@@ -1550,13 +1603,13 @@ Every PR description records all commands and artifact paths. It is mergeable on
 - **Owned scope/files**：`package.json`、`package-lock.json`、`tsconfig.refactor.json`、
   TypeScript-aware ESLint config、`vitest.refactor.config.ts`、`playwright.config.ts`、
   `src/version.ts`、`scripts/refactor/fixtures.ts`、`bench.ts`、`pack.ts`、`ci_network_guard.ts`、
-  `tests/refactor/performance/baseline.test.ts`、
+  `tests/refactor/performance/baseline.test.ts`、`tests/refactor/sdk/harness.ts`、`tests/live/sdk/harness.ts`、
   `.github/workflows/refactor-ci.yml`。
 - **Deliverables/interface**：Node `>=24` refactor scripts：
   `build:refactor`、`typecheck:refactor`、`lint:refactor`、`test:refactor`、
-  `test:e2e:refactor`、`fixtures:verify`、`fixtures:generate`、`bench:refactor`、
+  `test:sdk:refactor`、`test:live:sdk`、`test:e2e:refactor`、`fixtures:verify`、`fixtures:generate`、`bench:refactor`、
   `pack:refactor`、`smoke:legacy`；lock Hono、TypeBox、Undici、`better-sqlite3`、Svelte 5、Vite、Vitest、
-  Playwright。
+  Playwright and exact versions of the official OpenAI、Anthropic and Ollama SDK dev dependencies。
   TypeScript 至少启用 `strict`、`noUncheckedIndexedAccess`、`exactOptionalPropertyTypes`、
   `useUnknownInCatchVariables`、`noImplicitOverride`、`verbatimModuleSyntax`。
   `src/version.ts` is the non-default target build's single `0.1.0` source through `RM-21`；`RM-22` sets
@@ -1566,7 +1619,8 @@ Every PR description records all commands and artifact paths. It is mergeable on
   `npm run bench:refactor -- baseline --repeat 3`；`npm run test:unit`；`npm run smoke:legacy`；platform smoke loads
   `better-sqlite3` and commits a WAL transaction。
 - **Acceptance/done**：full CI matrix and extra smoke artifacts exist；empty selected runtime stack idle RSS
-  `<=64 MiB` three runs；network denial is enforced；default `start/main/bin` values still invoke legacy JavaScript。
+  `<=64 MiB` three runs；network denial is enforced；SDK harness can start a loopback listener with scripted remotes；
+  live command refuses without its opt-in flag；default `start/main/bin` values still invoke legacy JavaScript。
 - **Non-goals/guardrails**：不实现 Gateway/routes，不 change published package identity，不 weaken strict flags；
   test execution has no network fallback，and provisioning cannot contact arbitrary hosts。
 - **PR handoff**：附各 platform Node/npm/native-addon versions、three-run raw baseline files、script names 和
@@ -1746,6 +1800,7 @@ Every PR description records all commands and artifact paths. It is mergeable on
 - **Owned scope/files**：`src/copilot/model_catalog.ts`、`src/protocols/model_catalog/**`、
   `tests/refactor/contract/model_catalog.test.ts`、
   `tests/refactor/integration/model_routes.test.ts`、
+  `tests/refactor/sdk/model_listing.sdk.test.ts`、
   `tests/refactor/fixtures/model-catalog/**`。
 - **Deliverables/interface**：`CopilotModelCatalog.get/invalidate/clear` and internal
   `CopilotModelsSource` production/scripted seam；`ModelResolver` implementing section 6.2；public DTO excludes
@@ -1759,6 +1814,8 @@ Every PR description records all commands and artifact paths. It is mergeable on
   generation races；literal `endpoint + "/models"`；redirect/Retry-After/errors；OpenAI fields；any
   `anthropic-version` presence including empty/wrong value selects Anthropic success shape；nullable limits/all models；
   Ollama RFC3339Nano；missing/preferred/explicit/unknown model matrix；`/models` 404。
+  `npm run test:sdk:refactor -- tests/refactor/sdk/model_listing.sdk.test.ts` uses OpenAI `models.list`、
+  Anthropic `models.list` and Ollama list against the loopback gateway。
 - **Acceptance/done**：three serializers read the same snapshot；no static list/name inference；cache isolated by
   account；catalog invalidation marks missing preferred model invalid without silent fallback；errors expose no upstream
   body。
@@ -1777,6 +1834,7 @@ Every PR description records all commands and artifact paths. It is mergeable on
 - **Owned scope/files**：`src/protocols/openai_chat/**`、
   `tests/refactor/contract/openai_chat_endpoint.test.ts`、
   `tests/refactor/integration/openai_chat_stream.test.ts`、
+  `tests/refactor/sdk/openai_chat.sdk.test.ts`、
   `tests/refactor/fixtures/openai-chat/**`。
 - **Deliverables/interface**：`createOpenAiChatRoute(dependencies): RouteRegistration`；explicit Chat decoder、
   one resolved model rewrite、buffered JSON path and normalized OpenAI SSE fast path。
@@ -1785,6 +1843,8 @@ Every PR description records all commands and artifact paths. It is mergeable on
   and exact reserialization per HTTP contract；
   upstream statuses/safe errors；usage-only/event/error/one successful `[DONE]`；all byte splits；first-byte/idle/total
   timeout；queue `503`；abort before/after commit；no aliases。
+  `npm run test:sdk:refactor -- tests/refactor/sdk/openai_chat.sdk.test.ts` covers official SDK non-stream/stream、
+  error class/request ID and cancellation。
 - **Acceptance/done**：one upstream call with bound account/model；raw fast path does not instantiate Ollama/Anthropic/
   Responses state；success terminal exactly once；zero additional bytes on abort；Fetch-surface tests need no private
   method access。
@@ -1802,6 +1862,7 @@ Every PR description records all commands and artifact paths. It is mergeable on
 - **Owned scope/files**：`src/protocols/ollama_chat/**`、
   `tests/refactor/contract/ollama_request.test.ts`、
   `ollama_nonstream.test.ts`、`ollama_stream.test.ts`、`ollama_wire.test.ts`、
+  `tests/refactor/sdk/ollama.sdk.test.ts`、
   `tests/refactor/fixtures/ollama/**`。
 - **Deliverables/interface**：`createOllamaChatRoutes(dependencies): readonly RouteRegistration[]` for `/api/chat`
   and `/api/version`；protocol-local request bridge、nonstream mapper、`Done`-owned reducer and Go-compatible encoder。
@@ -1811,6 +1872,8 @@ Every PR description records all commands and artifact paths. It is mergeable on
   image magic、ordered tool args、choice 0、
   usage/logprobs、reasoning tags、sparse tools、absorbing `[DONE]`、truncation/abort/error；Go reference byte cases
   for order/omitempty/HTML/Unicode/control/final LF；queue `503`。
+  `npm run test:sdk:refactor -- tests/refactor/sdk/ollama.sdk.test.ts` covers official SDK list/chat
+  non-stream/stream and cancellation。
 - **Acceptance/done**：`stream` missing means true；source-valid unrepresentable semantics fail with zero upstream；
   exactly one terminal or post-commit error；all fields/bytes match goldens；`/api/version` matches closed HTTP fixture。
 - **Non-goals/guardrails**：不 expose model pull/delete/copy/show、不 add model capability guesses、不 reuse
@@ -1827,6 +1890,7 @@ Every PR description records all commands and artifact paths. It is mergeable on
 - **Owned scope/files**：`src/protocols/anthropic_messages/**`、
   `tests/refactor/contract/anthropic_request.test.ts`、
   `anthropic_nonstream.test.ts`、`anthropic_stream.test.ts`、`anthropic_wire.test.ts`、
+  `tests/refactor/sdk/anthropic.sdk.test.ts`、
   `tests/refactor/fixtures/anthropic/**`。
 - **Deliverables/interface**：`createAnthropicMessagesRoute(dependencies): RouteRegistration`；strict route
   accepts exactly `anthropic-version: 2023-06-01` as specified by HTTP contract；protocol-local block lifecycle。
@@ -1836,6 +1900,8 @@ Every PR description records all commands and artifact paths. It is mergeable on
   message/media/tool history、schema cleanup、reasoning
   families、multi-choice/thinking/tool argument repair、usage aliases、block switches/signed thinking、finish-first/
   no-finish/exception；Python default `json.dumps` spaces/ASCII；queue `529`；abort。
+  `npm run test:sdk:refactor -- tests/refactor/sdk/anthropic.sdk.test.ts` covers official SDK models/messages
+  non-stream/stream、native error/request ID and cancellation。
 - **Acceptance/done**：request matches pinned cc-switch behavior；nonstream/events match pinned LiteLLM plus specified
   terminal closure；`message_stop` exactly once only on success path；Messages version rule is not reused by models
   route header-presence selection。
@@ -1980,6 +2046,7 @@ Every PR description records all commands and artifact paths. It is mergeable on
 - **Owned scope/files**：`src/protocols/responses/endpoint.ts`、`wire.ts`、
   `tests/refactor/contract/responses_endpoint.test.ts`、
   `tests/refactor/integration/responses_endpoint_stream.test.ts`、
+  `tests/refactor/sdk/openai_responses.sdk.test.ts`、
   `tests/refactor/fixtures/responses-endpoint/**`。
 - **Deliverables/interface**：`createResponsesRoute(dependencies): RouteRegistration`；single planning and
   model binding；nonstream/checkpoint commit orchestration；protocol-local presenter。
@@ -1989,6 +2056,8 @@ Every PR description records all commands and artifact paths. It is mergeable on
   failure before bytes；failure after earlier events；native no-history/no-fallback；queue `503`；all timeouts/limits；
   exact shared Responses SSE encoder/no `[DONE]`；abort zero additional bytes；`/responses`、
   `/openai/v1/responses`、compact aliases 404。
+  `npm run test:sdk:refactor -- tests/refactor/sdk/openai_responses.sdk.test.ts` covers official OpenAI SDK
+  Responses non-stream/stream、native/bridge scripted plans、errors and cancellation。
 - **Acceptance/done**：all Responses fixture families pass through Fetch surface；plan cannot change mid-request；
   native and bridge ID namespaces/history remain separate；checkpoint p95 `<=5 ms` three runs。
 - **Non-goals/guardrails**：不 add compact/cross-account retry/live-stream recovery、legacy fallback or implementation
@@ -2110,26 +2179,28 @@ Every PR description records all commands and artifact paths. It is mergeable on
 - **Must read**：本文全文、[AGENTS](../../AGENTS.md)、[Architecture](../architecture.md) 全文、
   [ADR-0003](../adr/0003-clean-break-rename.md)，所有 production specs。
 - **Owned scope/files**：`package.json`、`package-lock.json`、default build/test/release configs、`README.md`、
-  `src/**/*.js` legacy deletion、legacy tests/fixtures deletion or replacement、release workflows and package smoke。
+  `src/**/*.js` legacy deletion、legacy tests/fixtures deletion or replacement、`tests/live/sdk/**`、release workflows
+  and package smoke。
 - **Deliverables/interface**：package becomes `@ljie-pi/ghc-gateway@0.1.0`；only bin `ghcg`；Node `>=24`；
   default `start/build/test/lint` target TypeScript；`prepack` builds server + Admin assets；repository metadata targets
   `ljie-PI/ghc-gateway`；data/env are only `~/.ghc-gateway`/`GHC_GATEWAY_`。
 - **Tests**：full offline `npm run typecheck`；`npm run lint`；`npm run build`；`npm test`；
-  `npm run fixtures:verify`；`npm pack`；all protocol/model/HTTP contracts；then
+  `npm run test:sdk:refactor`；`npm run fixtures:verify`；`npm pack`；all protocol/model/HTTP contracts；then
   clean install on required/additional platforms；foreground and daemon lifecycle；all 7 Admin E2E flows；route/alias
   closure；three-run RSS/latency/checkpoint/event-loop suite；fresh and migrated-within-new-v1 DB；clean tree after
   pack/install。
 - **Acceptance/done**：every target route complete；no legacy files/imports/names/aliases/default scripts；pack contains
   only intended dist/assets/docs/license；idle RSS `<=64 MiB` and 1,000-stream stable delta `<=16 MiB`；all latency
-  gates pass three times；README is the final user-facing update and matches actual CLI/security/config behavior。
+  gates pass three times；guarded live SDK suite exists but cannot run in CI without explicit opt-in；README is the final
+  user-facing update and matches actual CLI/security/config behavior。
 - **Non-goals/guardrails**：coding agent不运行 npm publish、不 target `main`、不运行 `gh repo rename`、不 retain
   compatibility launcher/data migration or fallback。
 - **PR handoff**：附 package tarball manifest/SHA、five-platform smoke evidence、full route matrix、daemon/Admin traces、
   benchmark raw files、clean `git status` and operator checklist from第 15 节。
 
-## 14. Final cutover checklist
+## 14. Final promotion checklist
 
-`RM-22` PR 在 `refactor` 上必须逐项为 green：
+After `RM-22` merges and before `refactor -> main` promotion，a maintainer verifies：
 
 - OpenAI Chat、Ollama、Anthropic、Responses native/bridge、OpenAI/Anthropic models、Ollama tags/version 全部
   contract/golden fixtures。
@@ -2142,6 +2213,8 @@ Every PR description records all commands and artifact paths. It is mergeable on
 - JSONL 10 MiB×5/7d、secrets Unix `0600`/Windows current-user ACL、redaction scans。
 - idle/stable-stream RSS and four latency/event-loop gates，each three consecutive runs。
 - default entrypoints contain no TODO/stub/legacy fallback；old executable/env/data names absent。
+- all three official SDK offline suites pass；the guarded manual live SDK suite has a sanitized passing/
+  `not_available` result under section 10.3 rules。
 - README updated last；tarball manifest exact；`git diff --check` and clean working tree after every generated/smoke step。
 
 Any failed item keeps `refactor` unreleased；the gate is never waived by documenting a follow-up issue。
@@ -2151,11 +2224,12 @@ Any failed item keeps `refactor` unreleased；the gate is never waived by docume
 After `RM-22` merges to `refactor`, a maintainer—not a coding agent—performs：
 
 1. rerun the signed/recorded release gate from a clean checkout；
-2. review and merge the single promotion from `refactor` to `main` under repository policy；
-3. manually or with authenticated GitHub CLI rename `ljie-PI/ghcp-ollama` to `ljie-PI/ghc-gateway`；
-4. verify redirects、default branch、remote URL、package metadata and README links；
-5. publish `@ljie-pi/ghc-gateway@0.1.0` from the verified main commit and verify clean install/release assets；
-6. announce the clean break：users reauthenticate/reconfigure；there are no old aliases or state import。
+2. run `GHC_GATEWAY_LIVE_TESTS=1 npm run test:live:sdk` against the real local gateway and attach the sanitized result；
+3. review and merge the single promotion from `refactor` to `main` under repository policy；
+4. manually or with authenticated GitHub CLI rename `ljie-PI/ghcp-ollama` to `ljie-PI/ghc-gateway`；
+5. verify redirects、default branch、remote URL、package metadata and README links；
+6. publish `@ljie-pi/ghc-gateway@0.1.0` from the verified main commit and verify clean install/release assets；
+7. announce the clean break：users reauthenticate/reconfigure；there are no old aliases or state import。
 
 Repository rename occurs only after the final main merge and pre-publish verification。No implementation PR may rename
 the remote early or make tests depend on the rename having occurred。

--- a/docs/specs/refactor_master_spec.md
+++ b/docs/specs/refactor_master_spec.md
@@ -1345,11 +1345,15 @@ continuously。A degraded metric clears only after three subsequently evaluated 
 
 ### 10.3 Official SDK integration
 
-SDK integration has two separate tiers。
+SDK integration has two separate **manual-only** tiers。Neither tier is part of CI、`npm test`、
+`npm run test:refactor`、implementation acceptance、PR review gates or the implement/code-review loop。Coding agents
+write and typecheck the owned SDK test files but do not execute official-client integration tests unless a human explicitly
+requests that run。Dedicated Vitest include patterns keep `tests/refactor/sdk/**` and `tests/live/sdk/**` out of every
+default test command。
 
 #### Offline SDK compatibility
 
-CI installs exact lockfile-pinned official npm clients as dev dependencies：
+The lockfile pins official npm clients as dev dependencies：
 
 - `openai`
 - `@anthropic-ai/sdk`
@@ -1372,8 +1376,10 @@ complement rather than replace protocol byte goldens：SDK acceptance alone cann
 Canonical command：
 
 ```text
-npm run test:sdk:refactor
+GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk:refactor
 ```
+
+The command refuses to start without `GHC_GATEWAY_SDK_TESTS=1`。No repository workflow sets that variable。
 
 #### Manual live GitHub Copilot smoke
 
@@ -1388,9 +1394,9 @@ never a golden。It queries the current catalog and accepts optional explicit mo
 response、tool content、credentials or complete endpoints。Native-Responses-specific live coverage may be recorded as
 `not_available` only when the account catalog has no native-capable model；offline routing fixtures remain mandatory。
 
-Before RM-22 promotion, a maintainer runs the live suite manually and records only timestamp、sanitized GitHub host、
-SDK versions、selected model IDs and pass/`not_available` status。A failure of a route that has an available model blocks
-release；transient remote failure is rerun and never converted into a changed golden。
+Before final promotion, a maintainer manually runs both official-client tiers and records only timestamp、sanitized
+GitHub host for the live tier、SDK versions、selected model IDs and pass/`not_available` status。A failure of a route
+that has an available model blocks release；transient remote failure is rerun and never converted into a changed golden。
 
 ## 11. Dependency DAG
 
@@ -1555,16 +1561,18 @@ Every PR description records all commands and artifact paths. It is mergeable on
 2. changes stay inside owned scope or document an approved cross-owner edit；
 3. `npm run typecheck:refactor` and `npm run lint:refactor` pass；
 4. the slice's targeted `npm run test:refactor -- <paths>` passes；
-5. all SDK compatibility tests currently present pass through `npm run test:sdk:refactor` against loopback/scripted remotes；
-6. `npm run build:refactor` and `npm run fixtures:verify` pass offline；
-7. legacy `npm run test:unit` and `npm run smoke:legacy` remain green through `RM-21`；default
+5. `npm run build:refactor` and `npm run fixtures:verify` pass offline；
+6. legacy `npm run test:unit` and `npm run smoke:legacy` remain green through `RM-21`；default
    `npm start`/bins remain legacy until `RM-22`；
-8. deterministic fixtures assert exact objects/bytes where required；golden changes name explicit `caseId`s and reason；
-9. abort、timeout、cleanup and post-commit branches added by the slice have tests；
-10. logs/errors/fixtures contain no credential or real request/response content；
-11. production/default paths contain no stub、TODO、legacy fallback or disabled failing test；
-12. hot-path/resource changes include the applicable benchmark delta, not an unmeasured performance claim；
-13. `git diff --check` passes and generated outputs/data directories are absent from the worktree。
+7. deterministic fixtures assert exact objects/bytes where required；golden changes name explicit `caseId`s and reason；
+8. abort、timeout、cleanup and post-commit branches added by the slice have tests；
+9. logs/errors/fixtures contain no credential or real request/response content；
+10. production/default paths contain no stub、TODO、legacy fallback or disabled failing test；
+11. hot-path/resource changes include the applicable benchmark delta, not an unmeasured performance claim；
+12. `git diff --check` passes and generated outputs/data directories are absent from the worktree。
+
+Official-client SDK tests are explicitly excluded from this gate and from code-review reruns；section 10.3 is the only
+authority for invoking them。
 
 `RM-01` establishes these scripts；for that slice only, equivalent direct tool commands named in its PR are accepted。
 
@@ -1602,6 +1610,7 @@ Every PR description records all commands and artifact paths. It is mergeable on
 - **Must read**：本文第 4、5、10、12 节，[Architecture](../architecture.md) runtime/testing/resource sections。
 - **Owned scope/files**：`package.json`、`package-lock.json`、`tsconfig.refactor.json`、
   TypeScript-aware ESLint config、`vitest.refactor.config.ts`、`playwright.config.ts`、
+  `vitest.sdk.config.ts`、
   `src/version.ts`、`scripts/refactor/fixtures.ts`、`bench.ts`、`pack.ts`、`ci_network_guard.ts`、
   `tests/refactor/performance/baseline.test.ts`、`tests/refactor/sdk/harness.ts`、`tests/live/sdk/harness.ts`、
   `.github/workflows/refactor-ci.yml`。
@@ -1619,8 +1628,9 @@ Every PR description records all commands and artifact paths. It is mergeable on
   `npm run bench:refactor -- baseline --repeat 3`；`npm run test:unit`；`npm run smoke:legacy`；platform smoke loads
   `better-sqlite3` and commits a WAL transaction。
 - **Acceptance/done**：full CI matrix and extra smoke artifacts exist；empty selected runtime stack idle RSS
-  `<=64 MiB` three runs；network denial is enforced；SDK harness can start a loopback listener with scripted remotes；
-  live command refuses without its opt-in flag；default `start/main/bin` values still invoke legacy JavaScript。
+  `<=64 MiB` three runs；network denial is enforced；dedicated SDK configs are excluded from default include patterns；
+  guard behavior is unit-tested without launching official clients；default `start/main/bin` values still invoke legacy
+  JavaScript。
 - **Non-goals/guardrails**：不实现 Gateway/routes，不 change published package identity，不 weaken strict flags；
   test execution has no network fallback，and provisioning cannot contact arbitrary hosts。
 - **PR handoff**：附各 platform Node/npm/native-addon versions、three-run raw baseline files、script names 和
@@ -1814,8 +1824,9 @@ Every PR description records all commands and artifact paths. It is mergeable on
   generation races；literal `endpoint + "/models"`；redirect/Retry-After/errors；OpenAI fields；any
   `anthropic-version` presence including empty/wrong value selects Anthropic success shape；nullable limits/all models；
   Ollama RFC3339Nano；missing/preferred/explicit/unknown model matrix；`/models` 404。
-  `npm run test:sdk:refactor -- tests/refactor/sdk/model_listing.sdk.test.ts` uses OpenAI `models.list`、
-  Anthropic `models.list` and Ollama list against the loopback gateway。
+- **Manual SDK checkpoint**（excluded from implementation/review gates）：
+  `GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk:refactor -- tests/refactor/sdk/model_listing.sdk.test.ts` uses OpenAI
+  `models.list`、Anthropic `models.list` and Ollama list against the loopback gateway。
 - **Acceptance/done**：three serializers read the same snapshot；no static list/name inference；cache isolated by
   account；catalog invalidation marks missing preferred model invalid without silent fallback；errors expose no upstream
   body。
@@ -1843,8 +1854,9 @@ Every PR description records all commands and artifact paths. It is mergeable on
   and exact reserialization per HTTP contract；
   upstream statuses/safe errors；usage-only/event/error/one successful `[DONE]`；all byte splits；first-byte/idle/total
   timeout；queue `503`；abort before/after commit；no aliases。
-  `npm run test:sdk:refactor -- tests/refactor/sdk/openai_chat.sdk.test.ts` covers official SDK non-stream/stream、
-  error class/request ID and cancellation。
+- **Manual SDK checkpoint**（excluded from implementation/review gates）：
+  `GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk:refactor -- tests/refactor/sdk/openai_chat.sdk.test.ts` covers official
+  SDK non-stream/stream、error class/request ID and cancellation。
 - **Acceptance/done**：one upstream call with bound account/model；raw fast path does not instantiate Ollama/Anthropic/
   Responses state；success terminal exactly once；zero additional bytes on abort；Fetch-surface tests need no private
   method access。
@@ -1872,8 +1884,9 @@ Every PR description records all commands and artifact paths. It is mergeable on
   image magic、ordered tool args、choice 0、
   usage/logprobs、reasoning tags、sparse tools、absorbing `[DONE]`、truncation/abort/error；Go reference byte cases
   for order/omitempty/HTML/Unicode/control/final LF；queue `503`。
-  `npm run test:sdk:refactor -- tests/refactor/sdk/ollama.sdk.test.ts` covers official SDK list/chat
-  non-stream/stream and cancellation。
+- **Manual SDK checkpoint**（excluded from implementation/review gates）：
+  `GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk:refactor -- tests/refactor/sdk/ollama.sdk.test.ts` covers official SDK
+  list/chat non-stream/stream and cancellation。
 - **Acceptance/done**：`stream` missing means true；source-valid unrepresentable semantics fail with zero upstream；
   exactly one terminal or post-commit error；all fields/bytes match goldens；`/api/version` matches closed HTTP fixture。
 - **Non-goals/guardrails**：不 expose model pull/delete/copy/show、不 add model capability guesses、不 reuse
@@ -1900,8 +1913,9 @@ Every PR description records all commands and artifact paths. It is mergeable on
   message/media/tool history、schema cleanup、reasoning
   families、multi-choice/thinking/tool argument repair、usage aliases、block switches/signed thinking、finish-first/
   no-finish/exception；Python default `json.dumps` spaces/ASCII；queue `529`；abort。
-  `npm run test:sdk:refactor -- tests/refactor/sdk/anthropic.sdk.test.ts` covers official SDK models/messages
-  non-stream/stream、native error/request ID and cancellation。
+- **Manual SDK checkpoint**（excluded from implementation/review gates）：
+  `GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk:refactor -- tests/refactor/sdk/anthropic.sdk.test.ts` covers official
+  SDK models/messages non-stream/stream、native error/request ID and cancellation。
 - **Acceptance/done**：request matches pinned cc-switch behavior；nonstream/events match pinned LiteLLM plus specified
   terminal closure；`message_stop` exactly once only on success path；Messages version rule is not reused by models
   route header-presence selection。
@@ -2056,8 +2070,9 @@ Every PR description records all commands and artifact paths. It is mergeable on
   failure before bytes；failure after earlier events；native no-history/no-fallback；queue `503`；all timeouts/limits；
   exact shared Responses SSE encoder/no `[DONE]`；abort zero additional bytes；`/responses`、
   `/openai/v1/responses`、compact aliases 404。
-  `npm run test:sdk:refactor -- tests/refactor/sdk/openai_responses.sdk.test.ts` covers official OpenAI SDK
-  Responses non-stream/stream、native/bridge scripted plans、errors and cancellation。
+- **Manual SDK checkpoint**（excluded from implementation/review gates）：
+  `GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk:refactor -- tests/refactor/sdk/openai_responses.sdk.test.ts` covers
+  official OpenAI SDK Responses non-stream/stream、native/bridge scripted plans、errors and cancellation。
 - **Acceptance/done**：all Responses fixture families pass through Fetch surface；plan cannot change mid-request；
   native and bridge ID namespaces/history remain separate；checkpoint p95 `<=5 ms` three runs。
 - **Non-goals/guardrails**：不 add compact/cross-account retry/live-stream recovery、legacy fallback or implementation
@@ -2185,14 +2200,14 @@ Every PR description records all commands and artifact paths. It is mergeable on
   default `start/build/test/lint` target TypeScript；`prepack` builds server + Admin assets；repository metadata targets
   `ljie-PI/ghc-gateway`；data/env are only `~/.ghc-gateway`/`GHC_GATEWAY_`。
 - **Tests**：full offline `npm run typecheck`；`npm run lint`；`npm run build`；`npm test`；
-  `npm run test:sdk:refactor`；`npm run fixtures:verify`；`npm pack`；all protocol/model/HTTP contracts；then
+  `npm run fixtures:verify`；`npm pack`；all protocol/model/HTTP contracts；then
   clean install on required/additional platforms；foreground and daemon lifecycle；all 7 Admin E2E flows；route/alias
   closure；three-run RSS/latency/checkpoint/event-loop suite；fresh and migrated-within-new-v1 DB；clean tree after
   pack/install。
 - **Acceptance/done**：every target route complete；no legacy files/imports/names/aliases/default scripts；pack contains
   only intended dist/assets/docs/license；idle RSS `<=64 MiB` and 1,000-stream stable delta `<=16 MiB`；all latency
-  gates pass three times；guarded live SDK suite exists but cannot run in CI without explicit opt-in；README is the final
-  user-facing update and matches actual CLI/security/config behavior。
+  gates pass three times；both guarded SDK suites exist、are excluded from automated gates and cannot run without explicit
+  opt-in；README is the final user-facing update and matches actual CLI/security/config behavior。
 - **Non-goals/guardrails**：coding agent不运行 npm publish、不 target `main`、不运行 `gh repo rename`、不 retain
   compatibility launcher/data migration or fallback。
 - **PR handoff**：附 package tarball manifest/SHA、five-platform smoke evidence、full route matrix、daemon/Admin traces、
@@ -2213,7 +2228,7 @@ After `RM-22` merges and before `refactor -> main` promotion，a maintainer veri
 - JSONL 10 MiB×5/7d、secrets Unix `0600`/Windows current-user ACL、redaction scans。
 - idle/stable-stream RSS and four latency/event-loop gates，each three consecutive runs。
 - default entrypoints contain no TODO/stub/legacy fallback；old executable/env/data names absent。
-- all three official SDK offline suites pass；the guarded manual live SDK suite has a sanitized passing/
+- the maintainer-triggered offline official SDK suite passes；the guarded manual live SDK suite has a sanitized passing/
   `not_available` result under section 10.3 rules。
 - README updated last；tarball manifest exact；`git diff --check` and clean working tree after every generated/smoke step。
 
@@ -2224,12 +2239,14 @@ Any failed item keeps `refactor` unreleased；the gate is never waived by docume
 After `RM-22` merges to `refactor`, a maintainer—not a coding agent—performs：
 
 1. rerun the signed/recorded release gate from a clean checkout；
-2. run `GHC_GATEWAY_LIVE_TESTS=1 npm run test:live:sdk` against the real local gateway and attach the sanitized result；
-3. review and merge the single promotion from `refactor` to `main` under repository policy；
-4. manually or with authenticated GitHub CLI rename `ljie-PI/ghcp-ollama` to `ljie-PI/ghc-gateway`；
-5. verify redirects、default branch、remote URL、package metadata and README links；
-6. publish `@ljie-pi/ghc-gateway@0.1.0` from the verified main commit and verify clean install/release assets；
-7. announce the clean break：users reauthenticate/reconfigure；there are no old aliases or state import。
+2. manually run `GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk:refactor` against scripted remotes and attach its result；
+3. manually run `GHC_GATEWAY_LIVE_TESTS=1 npm run test:live:sdk` against the real local gateway and attach the sanitized
+   result；
+4. review and merge the single promotion from `refactor` to `main` under repository policy；
+5. manually or with authenticated GitHub CLI rename `ljie-PI/ghcp-ollama` to `ljie-PI/ghc-gateway`；
+6. verify redirects、default branch、remote URL、package metadata and README links；
+7. publish `@ljie-pi/ghc-gateway@0.1.0` from the verified main commit and verify clean install/release assets；
+8. announce the clean break：users reauthenticate/reconfigure；there are no old aliases or state import。
 
 Repository rename occurs only after the final main merge and pre-publish verification。No implementation PR may rename
 the remote early or make tests depend on the rename having occurred。


### PR DESCRIPTION
## Summary
- define the executable ghc-gateway refactor master spec with 22 implementation slices after the virtual RM-00 spec gate
- add normative Gateway HTTP and OpenAI Chat contracts, and close Responses/Anthropic/Ollama/model-list host gaps
- add canonical domain vocabulary and four ADRs for protocol modules, protected secret files, clean-break rename, and self-managed daemonization
- synchronize the architecture with the `ghc-gateway` / `ghcg` identity, persistence, security, telemetry, Admin, and performance decisions
- specify official OpenAI, Anthropic, and Ollama SDK integration suites for loopback/scripted and live GitHub Copilot paths
- mark both official-client suites manual-only: excluded from CI, default tests, implementation acceptance, and implement/code-review loops

## Handoff model
- this PR is the virtual `RM-00` gate and creates no implementation code
- implementation issues `RM-01` through `RM-22` are created only after this PR merges
- issue dependencies, owned paths, required fixtures, exact test commands, acceptance criteria, and PR handoff evidence are defined in `docs/specs/refactor_master_spec.md`

## Validation
- 15 specification/context files checked for local links and balanced fences
- 23 ordered slice contracts (`RM-00`–`RM-22`)
- 56 Mermaid/table dependency edges verified equivalent and acyclic
- endpoint reachability to final cutover verified
- repeated blocker reviews completed with no remaining blocking findings

## Scope
Documentation only. No runtime code, package metadata, or README changes. Targets `refactor`; `main` is unchanged.