### PR TITLE
ci: use macos-15-intel for x64 smoke

### DIFF
--- a/.github/workflows/refactor-ci.yml
+++ b/.github/workflows/refactor-ci.yml
@@ -110,7 +110,7 @@ jobs:
         include:
           - os: ubuntu-24.04-arm
             arch: linux-arm64
-          - os: macos-13
+          - os: macos-15-intel
             arch: macos-x64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Why

`smoke-macos-13-macos-x64` has been queued since RM-01. GitHub retired macos-13 hosted images, so that extra smoke never starts and the whole Refactor CI run stays queued.

Ubuntu, Windows, macos-14, and linux-arm64 jobs were already succeeding.

## Change

Use `macos-15-intel` for the macOS x64 extra-smoke matrix entry. Required matrix is unchanged (`ubuntu-latest`, `windows-latest`, `macos-14`).