### PR TITLE
[RM-04] SQLite persistence and runtime config

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "test:golden": "node tests/integration/utils/golden_generator.js",
-    "build:refactor": "node scripts/refactor/bootstrap.mjs --check && tsc -p tsconfig.refactor.json",
+    "build:refactor": "node scripts/refactor/bootstrap.mjs --check && tsc -p tsconfig.refactor.json && node scripts/refactor/bootstrap.mjs scripts/refactor/generate_migrations.ts",
     "typecheck:refactor": "node scripts/refactor/bootstrap.mjs --check && tsc -p tsconfig.refactor.json --noEmit",
     "lint:refactor": "node scripts/refactor/bootstrap.mjs --check && eslint --no-error-on-unmatched-pattern --config eslint.config.js \"src/**/*.ts\" \"scripts/refactor/**/*.{ts,mjs}\" \"tests/refactor/unit/**/*.ts\" \"tests/refactor/contract/**/*.ts\" \"tests/refactor/integration/**/*.ts\" \"tests/refactor/performance/**/*.ts\" \"vitest.refactor.config.ts\" \"playwright.config.ts\"",
     "test:refactor": "node scripts/refactor/bootstrap.mjs --check && vitest run --config vitest.refactor.config.ts",

--- a/scripts/refactor/generate_migrations.ts
+++ b/scripts/refactor/generate_migrations.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { embedMigration, type EmbeddedMigration, type MigrationModule } from "../../src/persistence/migrations.js";
+import { assertNode24 } from "./node_version.js";
+
+export const RESERVED_MIGRATION_FILES: ReadonlyMap<number, string> = new Map([
+  [1, "001_runtime_config.ts"],
+  [10, "010_accounts.ts"],
+  [20, "020_telemetry.ts"],
+  [30, "030_responses_history.ts"],
+]);
+
+export const DEFAULT_MIGRATIONS_DIR = path.resolve("src/persistence/migrations");
+export const DEFAULT_MANIFEST_PATH = path.resolve("dist-refactor/migrations-manifest.json");
+
+export class MigrationGenerateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MigrationGenerateError";
+  }
+}
+
+export async function generateMigrationManifest(
+  migrationsDir = DEFAULT_MIGRATIONS_DIR,
+): Promise<readonly EmbeddedMigration[]> {
+  const entries = await readdir(migrationsDir);
+  const files = entries.filter((name) => /^\d{3}_.+\.ts$/u.test(name)).sort();
+  const seen = new Set<number>();
+  const migrations: EmbeddedMigration[] = [];
+
+  for (const file of files) {
+    const versionText = file.slice(0, 3);
+    const version = Number.parseInt(versionText, 10);
+    const reserved = RESERVED_MIGRATION_FILES.get(version);
+    if (reserved === undefined) {
+      throw new MigrationGenerateError(`migration version ${version} is not reserved`);
+    }
+    if (file !== reserved) {
+      throw new MigrationGenerateError(`reserved-owner violation: expected ${reserved}, found ${file}`);
+    }
+    if (seen.has(version)) {
+      throw new MigrationGenerateError(`duplicate migration version ${version}`);
+    }
+    seen.add(version);
+
+    const moduleUrl = pathToFileURL(path.join(migrationsDir, file)).href;
+    const loaded = await import(moduleUrl) as { migration?: MigrationModule };
+    if (loaded.migration === undefined) {
+      throw new MigrationGenerateError(`${file} must export migration`);
+    }
+    if (loaded.migration.version !== version) {
+      throw new MigrationGenerateError(`filename/export mismatch in ${file}`);
+    }
+    if (typeof loaded.migration.name !== "string" || loaded.migration.name.length === 0) {
+      throw new MigrationGenerateError(`${file} migration name must be a non-empty string`);
+    }
+    if (typeof loaded.migration.sql !== "string" || loaded.migration.sql.length === 0) {
+      throw new MigrationGenerateError(`${file} migration sql must be a non-empty string`);
+    }
+    migrations.push(embedMigration(loaded.migration));
+  }
+
+  return migrations.sort((left, right) => left.version - right.version);
+}
+
+export function readMigrationManifest(manifestPath = DEFAULT_MANIFEST_PATH): EmbeddedMigration[] {
+  const raw = JSON.parse(readFileSync(manifestPath, "utf8")) as { migrations?: unknown };
+  if (!Array.isArray(raw.migrations)) {
+    throw new MigrationGenerateError("migration manifest must contain a migrations array");
+  }
+  return raw.migrations as EmbeddedMigration[];
+}
+
+export async function writeMigrationManifest(
+  migrations: readonly EmbeddedMigration[],
+  manifestPath = DEFAULT_MANIFEST_PATH,
+): Promise<string> {
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  const payload = `${JSON.stringify({ migrations }, null, 2)}\n`;
+  await writeFile(manifestPath, payload, "utf8");
+  return manifestPath;
+}
+
+async function main(): Promise<void> {
+  assertNode24();
+  const migrations = await generateMigrationManifest();
+  const manifestPath = await writeMigrationManifest(migrations);
+  console.log(`Wrote ${migrations.length} migrations to ${manifestPath}`);
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/src/config/runtime_config.ts
+++ b/src/config/runtime_config.ts
@@ -1,0 +1,173 @@
+import type Database from "better-sqlite3";
+import {
+  defaultRuntimeConfigSnapshot,
+  parseRuntimeConfigSnapshot,
+  type RuntimeConfigSnapshot,
+} from "./schema.js";
+
+export class RuntimeConfigError extends Error {
+  readonly code: "revision_conflict" | "invalid_config";
+
+  constructor(code: RuntimeConfigError["code"], message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "RuntimeConfigError";
+    this.code = code;
+  }
+}
+
+export class RuntimeConfigStore {
+  private snapshot: RuntimeConfigSnapshot;
+  private revision: number;
+
+  constructor(
+    private readonly database: Database.Database,
+    private readonly nowMs: () => number = Date.now,
+  ) {
+    const row = this.readRow();
+    if (row === undefined) {
+      this.snapshot = freezeSnapshot(defaultRuntimeConfigSnapshot());
+      this.revision = 0;
+      return;
+    }
+    this.snapshot = freezeSnapshot(parseRuntimeConfigSnapshot(JSON.parse(row.config_json) as unknown));
+    this.revision = row.revision;
+  }
+
+  readSnapshot(): RuntimeConfigSnapshot {
+    return this.snapshot;
+  }
+
+  readRevision(): number {
+    return this.revision;
+  }
+
+  seedIfEmpty(env: NodeJS.ProcessEnv): RuntimeConfigSnapshot {
+    if (this.readRow() !== undefined) {
+      return this.snapshot;
+    }
+    const seeded = freezeSnapshot(parseRuntimeConfigSnapshot(overlayEnvironment(defaultRuntimeConfigSnapshot(), env)));
+    this.writeRow(1, seeded);
+    this.snapshot = seeded;
+    this.revision = 1;
+    return this.snapshot;
+  }
+
+  update(candidate: unknown, expectedRevision: number): RuntimeConfigSnapshot {
+    let next: RuntimeConfigSnapshot;
+    try {
+      next = freezeSnapshot(parseRuntimeConfigSnapshot(candidate));
+    } catch (error: unknown) {
+      throw new RuntimeConfigError("invalid_config", "invalid runtime config", { cause: error });
+    }
+
+    const swap = this.database.transaction(() => {
+      const row = this.readRow();
+      const currentRevision = row?.revision ?? 0;
+      if (currentRevision !== expectedRevision) {
+        throw new RuntimeConfigError("revision_conflict", "runtime config revision conflict");
+      }
+      this.writeRow(expectedRevision + 1, next);
+    });
+
+    try {
+      swap();
+    } catch (error: unknown) {
+      if (error instanceof RuntimeConfigError) {
+        throw error;
+      }
+      throw new RuntimeConfigError("invalid_config", "runtime config write failed", { cause: error });
+    }
+
+    this.snapshot = next;
+    this.revision = expectedRevision + 1;
+    return this.snapshot;
+  }
+
+  private readRow(): { revision: number; config_json: string } | undefined {
+    return this.database.prepare(
+      "SELECT revision, config_json FROM runtime_config WHERE singleton_id = 1",
+    ).get() as { revision: number; config_json: string } | undefined;
+  }
+
+  private writeRow(revision: number, snapshot: RuntimeConfigSnapshot): void {
+    this.database.prepare(
+      `INSERT INTO runtime_config (singleton_id, revision, config_json, updated_at_ms)
+       VALUES (1, ?, ?, ?)
+       ON CONFLICT(singleton_id) DO UPDATE SET
+         revision = excluded.revision,
+         config_json = excluded.config_json,
+         updated_at_ms = excluded.updated_at_ms`,
+    ).run(revision, JSON.stringify(snapshot), this.nowMs());
+  }
+}
+
+function overlayEnvironment(base: RuntimeConfigSnapshot, env: NodeJS.ProcessEnv): RuntimeConfigSnapshot {
+  const next = structuredClone(base);
+  assignInteger(env.GHC_GATEWAY_LIMITS_REQUEST_BODY_BYTES, (value) => {
+    next.limits.requestBodyBytes = value;
+  });
+  assignInteger(env.GHC_GATEWAY_LIMITS_SSE_EVENT_BYTES, (value) => {
+    next.limits.sseEventBytes = value;
+  });
+  assignInteger(env.GHC_GATEWAY_LIMITS_NONSTREAM_BODY_BYTES, (value) => {
+    next.limits.nonstreamBodyBytes = value;
+  });
+  assignInteger(env.GHC_GATEWAY_LIMITS_ACCUMULATOR_BYTES, (value) => {
+    next.limits.accumulatorBytes = value;
+  });
+  assignInteger(env.GHC_GATEWAY_ADMISSION_ACTIVE_MAX, (value) => {
+    next.admission.activeMax = value;
+  });
+  assignInteger(env.GHC_GATEWAY_ADMISSION_QUEUE_MAX, (value) => {
+    next.admission.queueMax = value;
+  });
+  assignInteger(env.GHC_GATEWAY_TIMEOUTS_QUEUE_MS, (value) => {
+    next.timeouts.queueMs = value;
+  });
+  assignInteger(env.GHC_GATEWAY_TIMEOUTS_CONNECT_MS, (value) => {
+    next.timeouts.connectMs = value;
+  });
+  assignInteger(env.GHC_GATEWAY_TIMEOUTS_FIRST_BYTE_MS, (value) => {
+    next.timeouts.firstByteMs = value;
+  });
+  assignInteger(env.GHC_GATEWAY_TIMEOUTS_STREAM_IDLE_MS, (value) => {
+    next.timeouts.streamIdleMs = value;
+  });
+  assignInteger(env.GHC_GATEWAY_TIMEOUTS_TOTAL_MS, (value) => {
+    next.timeouts.totalMs = value;
+  });
+  assignInteger(env.GHC_GATEWAY_ACCOUNTS_MAX_AUTHENTICATED, (value) => {
+    next.accounts.maxAuthenticated = value;
+  });
+  assignInteger(env.GHC_GATEWAY_HISTORY_TTL_DAYS, (value) => {
+    next.history.ttlDays = value;
+  });
+  assignInteger(env.GHC_GATEWAY_USAGE_RETENTION_DAYS, (value) => {
+    next.usage.retentionDays = value;
+  });
+  assignInteger(env.GHC_GATEWAY_EVENTS_RETENTION_DAYS, (value) => {
+    next.events.retentionDays = value;
+  });
+  return next;
+}
+
+function assignInteger(raw: string | undefined, assign: (value: number) => void): void {
+  if (raw === undefined || raw === "") {
+    return;
+  }
+  if (!/^-?[0-9]+$/u.test(raw)) {
+    throw new RuntimeConfigError("invalid_config", "invalid runtime config environment integer");
+  }
+  assign(Number.parseInt(raw, 10));
+}
+
+function freezeSnapshot(value: RuntimeConfigSnapshot): RuntimeConfigSnapshot {
+  Object.freeze(value.limits);
+  Object.freeze(value.admission);
+  Object.freeze(value.timeouts);
+  Object.freeze(value.accounts);
+  Object.freeze(value.history);
+  Object.freeze(value.usage);
+  Object.freeze(value.events);
+  return Object.freeze(value);
+}

--- a/src/persistence/database.ts
+++ b/src/persistence/database.ts
@@ -1,0 +1,28 @@
+import Database from "better-sqlite3";
+import { applyMigrations, type EmbeddedMigration } from "./migrations.js";
+
+export const SQLITE_BUSY_TIMEOUT_MS = 1000;
+export const SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
+export const SQLITE_JOURNAL_SIZE_LIMIT_BYTES = 67_108_864;
+
+export interface OpenDatabaseOptions {
+  readonly path: string;
+  readonly migrations: readonly EmbeddedMigration[];
+  readonly nowMs?: () => number;
+}
+
+export function openDatabase(options: OpenDatabaseOptions): Database.Database {
+  const database = new Database(options.path);
+  database.pragma("journal_mode = WAL");
+  database.pragma("synchronous = FULL");
+  database.pragma("foreign_keys = ON");
+  database.pragma("busy_timeout = 1000");
+  database.pragma("wal_autocheckpoint = 1000");
+  database.pragma("journal_size_limit = 67108864");
+  applyMigrations(database, options.migrations, options.nowMs ?? Date.now);
+  return database;
+}
+
+export function closeDatabase(database: Database.Database): void {
+  database.close();
+}

--- a/src/persistence/migrations.ts
+++ b/src/persistence/migrations.ts
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+import type Database from "better-sqlite3";
+
+export interface MigrationModule {
+  readonly version: number;
+  readonly name: string;
+  readonly sql: string;
+}
+
+export interface EmbeddedMigration extends MigrationModule {
+  readonly checksum: string;
+}
+
+export class MigrationError extends Error {
+  readonly code: "checksum_drift" | "unknown_version" | "apply_failed";
+
+  constructor(code: MigrationError["code"], message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "MigrationError";
+    this.code = code;
+  }
+}
+
+export function checksumSql(sql: string): string {
+  return createHash("sha256").update(sql, "utf8").digest("hex");
+}
+
+export function embedMigration(module: MigrationModule): EmbeddedMigration {
+  return {
+    version: module.version,
+    name: module.name,
+    sql: module.sql,
+    checksum: checksumSql(module.sql),
+  };
+}
+
+export function applyMigrations(
+  database: Database.Database,
+  migrations: readonly EmbeddedMigration[],
+  nowMs: () => number = Date.now,
+): void {
+  const ordered = [...migrations].sort((left, right) => left.version - right.version);
+  const byVersion = new Map(ordered.map((migration) => [migration.version, migration]));
+  const applied = readApplied(database);
+
+  for (const row of applied) {
+    const expected = byVersion.get(row.version);
+    if (expected === undefined) {
+      throw new MigrationError("unknown_version", `applied migration ${row.version} is unknown to this binary`);
+    }
+    if (expected.checksum !== row.checksum) {
+      throw new MigrationError("checksum_drift", `checksum drift for migration ${row.version}`);
+    }
+  }
+
+  const appliedVersions = new Set(applied.map((row) => row.version));
+  for (const migration of ordered) {
+    if (appliedVersions.has(migration.version)) {
+      continue;
+    }
+    const apply = database.transaction(() => {
+      database.exec(migration.sql);
+      database.prepare(
+        "INSERT INTO schema_migrations (version, name, checksum, applied_at_ms) VALUES (?, ?, ?, ?)",
+      ).run(migration.version, migration.name, migration.checksum, nowMs());
+    });
+    try {
+      apply();
+    } catch (error: unknown) {
+      throw new MigrationError("apply_failed", `failed to apply migration ${migration.version}`, { cause: error });
+    }
+  }
+}
+
+interface AppliedRow {
+  readonly version: number;
+  readonly checksum: string;
+}
+
+function readApplied(database: Database.Database): readonly AppliedRow[] {
+  const exists = database.prepare(
+    "SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'",
+  ).get() as { ok: number } | undefined;
+  if (exists === undefined) {
+    return [];
+  }
+  return database.prepare(
+    "SELECT version, checksum FROM schema_migrations ORDER BY version",
+  ).all() as AppliedRow[];
+}

--- a/src/persistence/migrations/001_runtime_config.ts
+++ b/src/persistence/migrations/001_runtime_config.ts
@@ -1,0 +1,18 @@
+export const migration = {
+  version: 1,
+  name: "runtime_config",
+  sql: [
+    "CREATE TABLE schema_migrations (",
+    "  version INTEGER PRIMARY KEY,",
+    "  name TEXT NOT NULL UNIQUE,",
+    "  checksum TEXT NOT NULL,",
+    "  applied_at_ms INTEGER NOT NULL",
+    ");",
+    "CREATE TABLE runtime_config (",
+    "  singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),",
+    "  revision INTEGER NOT NULL,",
+    "  config_json TEXT NOT NULL,",
+    "  updated_at_ms INTEGER NOT NULL",
+    ");",
+  ].join("\n"),
+} as const;

--- a/tests/refactor/unit/persistence_migrations.test.ts
+++ b/tests/refactor/unit/persistence_migrations.test.ts
@@ -1,0 +1,169 @@
+import Database from "better-sqlite3";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  generateMigrationManifest,
+  MigrationGenerateError,
+  readMigrationManifest,
+  writeMigrationManifest,
+} from "../../../scripts/refactor/generate_migrations.js";
+import { closeDatabase, openDatabase } from "../../../src/persistence/database.js";
+import { migration as runtimeConfigMigration } from "../../../src/persistence/migrations/001_runtime_config.js";
+import {
+  applyMigrations,
+  embedMigration,
+  MigrationError,
+} from "../../../src/persistence/migrations.js";
+
+const nowMs = (): number => 1_700_000_000_000;
+
+async function tempDbPath(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-db-"));
+  return path.join(dir, "state.db");
+}
+
+describe("RM-04 migrations", () => {
+  it("opens WAL/FULL/FK with documented busy timeout and journal limits", async () => {
+    const database = openDatabase({
+      path: await tempDbPath(),
+      migrations: [embedMigration(runtimeConfigMigration)],
+      nowMs,
+    });
+    try {
+      expect(String(database.pragma("journal_mode", { simple: true })).toLowerCase()).toBe("wal");
+      expect(Number(database.pragma("synchronous", { simple: true }))).toBe(2);
+      expect(Number(database.pragma("foreign_keys", { simple: true }))).toBe(1);
+      expect(Number(database.pragma("busy_timeout", { simple: true }))).toBe(1000);
+      expect(Number(database.pragma("wal_autocheckpoint", { simple: true }))).toBe(1000);
+      expect(Number(database.pragma("journal_size_limit", { simple: true }))).toBe(67_108_864);
+      const row = database.prepare("SELECT version, name FROM schema_migrations").get() as {
+        version: number;
+        name: string;
+      };
+      expect(row).toEqual({ version: 1, name: "runtime_config" });
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("is idempotent for a current database and upgrades an older one", async () => {
+    const dbPath = await tempDbPath();
+    const first = openDatabase({
+      path: dbPath,
+      migrations: [embedMigration(runtimeConfigMigration)],
+      nowMs,
+    });
+    closeDatabase(first);
+
+    const extra = embedMigration({
+      version: 10,
+      name: "accounts",
+      sql: "CREATE TABLE accounts_probe (id INTEGER PRIMARY KEY);",
+    });
+    const upgraded = openDatabase({
+      path: dbPath,
+      migrations: [embedMigration(runtimeConfigMigration), extra],
+      nowMs,
+    });
+    try {
+      const versions = upgraded.prepare("SELECT version FROM schema_migrations ORDER BY version").all() as Array<{
+        version: number;
+      }>;
+      expect(versions.map((row) => row.version)).toEqual([1, 10]);
+      expect(upgraded.prepare("SELECT 1 AS ok FROM sqlite_master WHERE name = 'accounts_probe'").get()).toEqual({
+        ok: 1,
+      });
+    } finally {
+      closeDatabase(upgraded);
+    }
+  });
+
+  it("applies a later lower reserved version after a higher version exists", () => {
+    const database = new Database(":memory:");
+    const first = embedMigration(runtimeConfigMigration);
+    const high = embedMigration({
+      version: 20,
+      name: "telemetry",
+      sql: "CREATE TABLE telemetry_probe (id INTEGER PRIMARY KEY);",
+    });
+    const low = embedMigration({
+      version: 10,
+      name: "accounts",
+      sql: "CREATE TABLE accounts_probe (id INTEGER PRIMARY KEY);",
+    });
+    applyMigrations(database, [first, high], nowMs);
+    applyMigrations(database, [first, low, high], nowMs);
+    const versions = database.prepare("SELECT version FROM schema_migrations ORDER BY version").all() as Array<{
+      version: number;
+    }>;
+    expect(versions.map((row) => row.version)).toEqual([1, 10, 20]);
+    database.close();
+  });
+
+  it("rejects checksum drift and unknown applied versions", () => {
+    const database = new Database(":memory:");
+    const first = embedMigration(runtimeConfigMigration);
+    applyMigrations(database, [first], nowMs);
+    database.prepare("UPDATE schema_migrations SET checksum = 'drift' WHERE version = 1").run();
+    expect(() => applyMigrations(database, [first], nowMs)).toThrow(MigrationError);
+    database.close();
+
+    const unknown = new Database(":memory:");
+    applyMigrations(unknown, [first], nowMs);
+    unknown.prepare(
+      "INSERT INTO schema_migrations (version, name, checksum, applied_at_ms) VALUES (99, 'future', 'abc', 1)",
+    ).run();
+    expect(() => applyMigrations(unknown, [first], nowMs)).toThrow(/unknown/u);
+    unknown.close();
+  });
+
+  it("rolls back a failed migration", () => {
+    const database = new Database(":memory:");
+    const first = embedMigration(runtimeConfigMigration);
+    applyMigrations(database, [first], nowMs);
+    const bad = embedMigration({
+      version: 10,
+      name: "bad",
+      sql: "CREATE TABLE ok_probe (id INTEGER PRIMARY KEY); CREATE TABLE",
+    });
+    expect(() => applyMigrations(database, [first, bad], nowMs)).toThrow(MigrationError);
+    const versions = database.prepare("SELECT version FROM schema_migrations").all() as Array<{ version: number }>;
+    expect(versions).toEqual([{ version: 1 }]);
+    expect(database.prepare("SELECT 1 AS ok FROM sqlite_master WHERE name = 'ok_probe'").get()).toBeUndefined();
+    database.close();
+  });
+});
+
+describe("RM-04 generate_migrations", () => {
+  it("embeds the reserved 001 module and writes a static manifest", async () => {
+    const migrations = await generateMigrationManifest();
+    expect(migrations).toEqual([embedMigration(runtimeConfigMigration)]);
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-manifest-"));
+    const manifestPath = path.join(dir, "migrations-manifest.json");
+    await writeMigrationManifest(migrations, manifestPath);
+    const written = JSON.parse(await (await import("node:fs/promises")).readFile(manifestPath, "utf8")) as {
+      migrations: unknown;
+    };
+    expect(written.migrations).toEqual(migrations);
+    expect(readMigrationManifest(manifestPath)).toEqual(migrations);
+  });
+
+  it("rejects filename/export mismatch, duplicates, and reserved-owner violations", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-mig-"));
+    await writeFile(path.join(dir, "001_wrong.ts"), "export const migration = { version: 1, name: 'x', sql: 'SELECT 1' };\n");
+    await expect(generateMigrationManifest(dir)).rejects.toBeInstanceOf(MigrationGenerateError);
+
+    const mismatch = await mkdtemp(path.join(tmpdir(), "ghc-gateway-mig-"));
+    await writeFile(
+      path.join(mismatch, "001_runtime_config.ts"),
+      "export const migration = { version: 2, name: 'runtime_config', sql: 'SELECT 1' };\n",
+    );
+    await expect(generateMigrationManifest(mismatch)).rejects.toThrow(/mismatch/u);
+
+    const unknown = await mkdtemp(path.join(tmpdir(), "ghc-gateway-mig-"));
+    await writeFile(path.join(unknown, "002_extra.ts"), "export const migration = { version: 2, name: 'extra', sql: 'SELECT 1' };\n");
+    await expect(generateMigrationManifest(unknown)).rejects.toThrow(/not reserved/u);
+  });
+});

--- a/tests/refactor/unit/runtime_config.test.ts
+++ b/tests/refactor/unit/runtime_config.test.ts
@@ -1,0 +1,119 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { describe, expect, it } from "vitest";
+import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
+import { RuntimeConfigError, RuntimeConfigStore } from "../../../src/config/runtime_config.js";
+import { closeDatabase, openDatabase } from "../../../src/persistence/database.js";
+import { embedMigration } from "../../../src/persistence/migrations.js";
+import { migration as runtimeConfigMigration } from "../../../src/persistence/migrations/001_runtime_config.js";
+
+const nowMs = (): number => 1_700_000_000_000;
+
+async function openStore(env: NodeJS.ProcessEnv = {}): Promise<{
+  store: RuntimeConfigStore;
+  close: () => void;
+}> {
+  const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-cfg-"));
+  const database = openDatabase({
+    path: path.join(dir, "state.db"),
+    migrations: [embedMigration(runtimeConfigMigration)],
+    nowMs,
+  });
+  const store = new RuntimeConfigStore(database, nowMs);
+  store.seedIfEmpty(env);
+  return {
+    store,
+    close: () => closeDatabase(database),
+  };
+}
+
+describe("RM-04 runtime config", () => {
+  it("seeds from environment only when no row exists", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-cfg-"));
+    const dbPath = path.join(dir, "state.db");
+    const firstDb = openDatabase({
+      path: dbPath,
+      migrations: [embedMigration(runtimeConfigMigration)],
+      nowMs,
+    });
+    const first = new RuntimeConfigStore(firstDb, nowMs);
+    first.seedIfEmpty({ GHC_GATEWAY_ADMISSION_ACTIVE_MAX: "2" });
+    expect(first.readSnapshot().admission.activeMax).toBe(2);
+    expect(first.readRevision()).toBe(1);
+    closeDatabase(firstDb);
+
+    const secondDb = openDatabase({
+      path: dbPath,
+      migrations: [embedMigration(runtimeConfigMigration)],
+      nowMs,
+    });
+    const second = new RuntimeConfigStore(secondDb, nowMs);
+    second.seedIfEmpty({ GHC_GATEWAY_ADMISSION_ACTIVE_MAX: "8" });
+    expect(second.readSnapshot().admission.activeMax).toBe(2);
+    expect(second.readRevision()).toBe(1);
+    closeDatabase(secondDb);
+  });
+
+  it("rejects TypeBox coercion and keeps the previous snapshot on failed update", async () => {
+    const { store, close } = await openStore();
+    try {
+      const before = store.readSnapshot();
+      expect(() => store.update({
+        ...defaultRuntimeConfigSnapshot(),
+        admission: { activeMax: "4", queueMax: 16 },
+      }, store.readRevision())).toThrow(RuntimeConfigError);
+      expect(store.readSnapshot()).toBe(before);
+      expect(store.readRevision()).toBe(1);
+    } finally {
+      close();
+    }
+  });
+
+  it("compare-and-swaps revisions and leaves in-flight snapshots unchanged", async () => {
+    const { store, close } = await openStore();
+    try {
+      const inFlight = store.readSnapshot();
+      const candidate = defaultRuntimeConfigSnapshot();
+      candidate.admission.activeMax = 3;
+      const updated = store.update(candidate, 1);
+      expect(updated.admission.activeMax).toBe(3);
+      expect(store.readRevision()).toBe(2);
+      expect(inFlight.admission.activeMax).toBe(4);
+      expect(() => {
+        inFlight.admission.activeMax = 9;
+      }).toThrow();
+      expect(() => store.update(candidate, 1)).toThrow(RuntimeConfigError);
+      expect(store.readSnapshot().admission.activeMax).toBe(3);
+    } finally {
+      close();
+    }
+  });
+
+  it("records commit timing evidence", async () => {
+    const { store, close } = await openStore();
+    try {
+      const samples: number[] = [];
+      for (let index = 0; index < 20; index += 1) {
+        const candidate = defaultRuntimeConfigSnapshot();
+        candidate.timeouts.queueMs = 30_000 + index;
+        const started = performance.now();
+        store.update(candidate, store.readRevision());
+        samples.push(performance.now() - started);
+      }
+      const artifactDir = path.resolve("dist-refactor", "bench");
+      await mkdir(artifactDir, { recursive: true });
+      const sorted = samples.slice().sort((left, right) => left - right);
+      const p95 = sorted[Math.ceil(0.95 * sorted.length) - 1];
+      await writeFile(path.join(artifactDir, "persistence.json"), `${JSON.stringify({
+        kind: "runtime_config_commit",
+        samples,
+        p95,
+      }, null, 2)}\n`);
+      expect(p95).toBeGreaterThanOrEqual(0);
+    } finally {
+      close();
+    }
+  });
+});


### PR DESCRIPTION
## Slice
ID: RM-04
Closes #11
Base: refactor

## Goal
Single-connection SQLite (WAL/FULL/FK), checksummed forward-only migrations with a build-time static manifest, and revisioned RuntimeConfigStore.

## Commands
- `npm run typecheck:refactor`
- `npm run lint:refactor`
- `npm run test:refactor -- tests/refactor/unit/persistence_migrations.test.ts tests/refactor/unit/runtime_config.test.ts`
- `npm run test:refactor`
- `npm run build:refactor` (writes `dist-refactor/migrations-manifest.json`)
- `npm run fixtures:verify`
- `npm run test:unit`
- `npm run smoke:legacy`

## Handoff
- PRAGMAs: WAL, synchronous=FULL, FK on, busy_timeout=1000, wal_autocheckpoint=1000, journal_size_limit=67108864
- Schema version 001 `runtime_config`
- `RuntimeConfigStore.seedIfEmpty` / `readSnapshot` / `update(candidate, expectedRevision)`
- Commit timing artifact: `dist-refactor/bench/persistence.json` (local)

## Code review
Standards: 0 important blockers. Spec: nits only (manifest wiring left to later composition; event-loop p95 not a separate file).