### PR TITLE
[RM-08] Model catalog and listing routes

### DIFF
--- a/src/copilot/model_catalog.ts
+++ b/src/copilot/model_catalog.ts
@@ -1,0 +1,117 @@
+export const DEFAULT_MODEL_CREATED_AT_TIME = 1_677_610_602;
+
+export interface CopilotCatalogModel {
+  readonly id: string;
+  readonly name: string;
+  readonly vendor: string;
+  readonly modelPickerEnabled: boolean;
+  readonly routing?: {
+    readonly mode?: string;
+    readonly supportedEndpoints?: readonly string[];
+  };
+}
+
+export interface CatalogSnapshot {
+  readonly accountId: string;
+  readonly models: readonly CopilotCatalogModel[];
+  readonly fetchedAt: string;
+  readonly generation: number;
+}
+
+export interface CapiModelsResponse {
+  readonly data: readonly unknown[];
+}
+
+export interface CopilotModelsSource {
+  fetch(accountId: string, signal: AbortSignal): Promise<CapiModelsResponse>;
+}
+
+export interface ModelInfoLookup {
+  get(modelId: string): {
+    readonly mode?: unknown;
+    readonly max_input_tokens?: unknown;
+    readonly max_output_tokens?: unknown;
+    readonly supported_endpoints?: unknown;
+  } | null;
+}
+
+interface CacheEntry {
+  catalog: CatalogSnapshot;
+  generation: number;
+}
+
+export class CopilotModelCatalog {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly generations = new Map<string, number>();
+
+  constructor(
+    private readonly source: CopilotModelsSource,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async get(accountId: string, signal: AbortSignal): Promise<CatalogSnapshot> {
+    const hit = this.cache.get(accountId);
+    if (hit !== undefined) {
+      return hit.catalog;
+    }
+    const generation = this.generations.get(accountId) ?? 0;
+    const raw = await this.source.fetch(accountId, signal);
+    const models = parseCapiModels(raw);
+    const fetchedAt = toRfc3339Nano(this.now());
+    const catalog: CatalogSnapshot = { accountId, models, fetchedAt, generation };
+    if ((this.generations.get(accountId) ?? 0) === generation) {
+      this.cache.set(accountId, { catalog, generation });
+    }
+    return catalog;
+  }
+
+  invalidate(accountId: string): void {
+    this.cache.delete(accountId);
+    this.generations.set(accountId, (this.generations.get(accountId) ?? 0) + 1);
+  }
+
+  clear(): void {
+    for (const accountId of new Set([...this.cache.keys(), ...this.generations.keys()])) {
+      this.generations.set(accountId, (this.generations.get(accountId) ?? 0) + 1);
+    }
+    this.cache.clear();
+  }
+}
+
+export function parseCapiModels(raw: CapiModelsResponse | unknown): CopilotCatalogModel[] {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw) || !("data" in raw)) {
+    throw new Error("invalid CAPI models response");
+  }
+  const data = (raw as { data: unknown }).data;
+  if (!Array.isArray(data)) {
+    throw new Error("invalid CAPI models response");
+  }
+  const models: CopilotCatalogModel[] = [];
+  for (const item of data) {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error("invalid CAPI model item");
+    }
+    const record = item as Record<string, unknown>;
+    if (typeof record.id !== "string" || typeof record.name !== "string" || typeof record.vendor !== "string" || typeof record.model_picker_enabled !== "boolean") {
+      throw new Error("invalid CAPI model item");
+    }
+    if (record.model_picker_enabled !== true) {
+      continue;
+    }
+    models.push({
+      id: record.id,
+      name: record.name,
+      vendor: record.vendor,
+      modelPickerEnabled: true,
+    });
+  }
+  return models;
+}
+
+export function toRfc3339Nano(date: Date): string {
+  return date.toISOString().replace(/\.\d+Z$/u, "Z");
+}
+
+export function capiModelsUrl(endpoint: string): string {
+  return `${endpoint}/models`;
+}

--- a/src/copilot/models_source.ts
+++ b/src/copilot/models_source.ts
@@ -1,0 +1,58 @@
+import { copilotHeaders } from "./identity.js";
+import { capiModelsUrl, type CapiModelsResponse, type CopilotModelsSource } from "./model_catalog.js";
+import { MAX_REDIRECTS, stripSecretsOnRedirect } from "./endpoint_discovery.js";
+
+export class CapiFetchError extends Error {
+  constructor(
+    readonly status: number,
+    readonly retryAfter?: string,
+  ) {
+    super("capi fetch failed");
+    this.name = "CapiFetchError";
+  }
+}
+
+export class HttpCopilotModelsSource implements CopilotModelsSource {
+  constructor(
+    private readonly resolve: (accountId: string, signal: AbortSignal) => Promise<{ token: string; endpoint: string }>,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async fetch(accountId: string, signal: AbortSignal): Promise<CapiModelsResponse> {
+    const { token, endpoint } = await this.resolve(accountId, signal);
+    const url = capiModelsUrl(endpoint);
+    const response = await getWithRedirects(this.fetchImpl, url, token, signal);
+    if (response.status < 200 || response.status >= 300) {
+      const retryAfter = response.status === 429 ? response.headers.get("retry-after") : null;
+      if (retryAfter === null || retryAfter === undefined) {
+        throw new CapiFetchError(response.status);
+      }
+      throw new CapiFetchError(response.status, retryAfter);
+    }
+    return await response.json() as CapiModelsResponse;
+  }
+}
+
+async function getWithRedirects(
+  fetchImpl: typeof fetch,
+  url: string,
+  token: string,
+  signal: AbortSignal,
+): Promise<Response> {
+  let current = url;
+  let headers = new Headers({ ...copilotHeaders(), authorization: `Bearer ${token}`, "content-type": "application/json" });
+  for (let attempt = 0; attempt <= MAX_REDIRECTS; attempt += 1) {
+    const response = await fetchImpl(current, { method: "GET", headers, signal, redirect: "manual" });
+    if (response.status < 300 || response.status >= 400) {
+      return response;
+    }
+    const location = response.headers.get("location");
+    if (location === null) {
+      return response;
+    }
+    const next = new URL(location, current).toString();
+    headers = stripSecretsOnRedirect(current, next, headers);
+    current = next;
+  }
+  throw new CapiFetchError(502);
+}

--- a/src/protocols/model_catalog/preferred.ts
+++ b/src/protocols/model_catalog/preferred.ts
@@ -1,0 +1,21 @@
+import type { AccountModelPreferences, ModelPreference } from "../../accounts/model_preferences.js";
+import type { CatalogSnapshot } from "../../copilot/model_catalog.js";
+
+export class PreferredModelManager {
+  constructor(private readonly preferences: AccountModelPreferences) {}
+
+  setPreferred(
+    accountId: string,
+    modelId: string,
+    expectedRevision: number,
+    catalog: CatalogSnapshot,
+  ): ModelPreference {
+    if (!catalog.models.some((model) => model.id === modelId)) {
+      throw new Error("model not in catalog");
+    }
+    return this.preferences.set(accountId, {
+      modelId,
+      catalogGeneration: catalog.generation,
+    }, expectedRevision);
+  }
+}

--- a/src/protocols/model_catalog/resolver.ts
+++ b/src/protocols/model_catalog/resolver.ts
@@ -1,0 +1,56 @@
+import type { CatalogSnapshot } from "../../copilot/model_catalog.js";
+
+export type ModelResolutionSource = "explicit" | "preferred";
+
+export interface ResolvedModel {
+  readonly requestedModel?: string;
+  readonly upstreamModel: string;
+  readonly source: ModelResolutionSource;
+  readonly routing: {
+    readonly mode?: string;
+    readonly supportedEndpoints?: readonly string[];
+  };
+}
+
+export type ModelResolveError =
+  | { readonly kind: "invalid_request" }
+  | { readonly kind: "model_not_found" };
+
+export function resolveModel(
+  catalog: CatalogSnapshot,
+  requested: string | undefined,
+  preferred: { readonly modelId: string; readonly validity: "valid" | "invalid" } | null,
+): ResolvedModel | ModelResolveError {
+  const ids = new Set(catalog.models.map((model) => model.id));
+  if (requested !== undefined) {
+    if (requested.length === 0) {
+      return { kind: "invalid_request" };
+    }
+    if (!ids.has(requested)) {
+      return { kind: "model_not_found" };
+    }
+    return resolved(catalog, requested, "explicit", requested);
+  }
+  if (preferred === null || preferred.validity !== "valid" || preferred.modelId.length === 0 || !ids.has(preferred.modelId)) {
+    return { kind: "invalid_request" };
+  }
+  return resolved(catalog, undefined, "preferred", preferred.modelId);
+}
+
+function resolved(
+  catalog: CatalogSnapshot,
+  requested: string | undefined,
+  source: ModelResolutionSource,
+  upstreamModel: string,
+): ResolvedModel {
+  const model = catalog.models.find((item) => item.id === upstreamModel);
+  return {
+    ...(requested === undefined ? {} : { requestedModel: requested }),
+    upstreamModel,
+    source,
+    routing: {
+      ...(model?.routing?.mode === undefined ? {} : { mode: model.routing.mode }),
+      ...(model?.routing?.supportedEndpoints === undefined ? {} : { supportedEndpoints: model.routing.supportedEndpoints }),
+    },
+  };
+}

--- a/src/protocols/model_catalog/routes.ts
+++ b/src/protocols/model_catalog/routes.ts
@@ -1,0 +1,123 @@
+import { AccountDirectoryError, type AccountDirectory } from "../../accounts/account_directory.js";
+import { GatewayFailureError, type GatewayFailure } from "../../gateway/failures.js";
+import { CapiFetchError } from "../../copilot/models_source.js";
+import type { AccountModelPreferences } from "../../accounts/model_preferences.js";
+import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
+import type { FailurePresenter, RouteRegistration } from "../../gateway/hono_app.js";
+import {
+  serializeAnthropicModels,
+  serializeOllamaTags,
+  serializeOllamaTagsError,
+  serializeOpenAiModels,
+  serializeOpenAiModelsError,
+  type ModelMetadata,
+} from "./wire.js";
+
+export interface ModelCatalogRouteDependencies {
+  readonly directory: AccountDirectory;
+  readonly catalog: CopilotModelCatalog;
+  readonly preferences: AccountModelPreferences;
+  readonly metadata?: ReadonlyMap<string, ModelMetadata>;
+}
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+} as const;
+
+export function createModelCatalogRoutes(dependencies: ModelCatalogRouteDependencies): readonly RouteRegistration[] {
+  const modelsPresenter: FailurePresenter = (failure, requestId) => {
+    const status = statusFor(failure.kind, failure);
+    const headers = new Headers({ ...JSON_HEADERS, "x-request-id": requestId });
+    if (failure.kind === "upstream_http" && failure.retryAfter !== undefined) {
+      headers.set("retry-after", failure.retryAfter);
+    }
+    return new Response(serializeOpenAiModelsError(status), { status, headers });
+  };
+  const tagsPresenter: FailurePresenter = (failure) => {
+    const status = statusFor(failure.kind, failure);
+    const headers = new Headers(JSON_HEADERS);
+    if (failure.kind === "upstream_http" && failure.retryAfter !== undefined) {
+      headers.set("retry-after", failure.retryAfter);
+    }
+    return new Response(serializeOllamaTagsError(), { status, headers });
+  };
+
+  return [
+    {
+      method: "GET",
+      path: "/v1/models",
+      admission: "none",
+      body: "none",
+      presentFailure: modelsPresenter,
+      endpoint: async (request, scope) => {
+        const catalog = await loadCatalog(dependencies, scope.signal);
+        const anthropic = request.headers.has("anthropic-version");
+        const metadata = dependencies.metadata ?? new Map<string, ModelMetadata>();
+        const body = anthropic
+          ? serializeAnthropicModels(catalog, metadata)
+          : serializeOpenAiModels(catalog, metadata);
+        return new Response(body, {
+          headers: { ...JSON_HEADERS, "x-request-id": scope.requestId },
+        });
+      },
+    },
+    {
+      method: "GET",
+      path: "/api/tags",
+      admission: "none",
+      body: "none",
+      presentFailure: tagsPresenter,
+      endpoint: async (_request, scope) => {
+        const catalog = await loadCatalog(dependencies, scope.signal);
+        return new Response(serializeOllamaTags(catalog), { headers: JSON_HEADERS });
+      },
+    },
+  ];
+}
+
+async function loadCatalog(
+  dependencies: ModelCatalogRouteDependencies,
+  signal: AbortSignal,
+) {
+  let account;
+  try {
+    account = await dependencies.directory.bindDefault(signal);
+  } catch (error: unknown) {
+    if (error instanceof AccountDirectoryError && (error.code === "no_default" || error.code === "not_found")) {
+      throw new GatewayFailureError({ kind: "authentication" });
+    }
+    throw error;
+  }
+  try {
+    const catalog = await dependencies.catalog.get(account.accountId, signal);
+    const visible = new Set(catalog.models.map((model) => model.id));
+    dependencies.preferences.markInvalidIfMissing(account.accountId, visible, catalog.generation);
+    return catalog;
+  } catch (error: unknown) {
+    if (error instanceof CapiFetchError) {
+      throw new GatewayFailureError({
+        kind: "upstream_http",
+        status: error.status,
+        ...(error.retryAfter === undefined ? {} : { retryAfter: error.retryAfter }),
+      });
+    }
+    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+  }
+}
+
+function statusFor(kind: GatewayFailure["kind"], failure?: GatewayFailure): number {
+  if (kind === "authentication") {
+    return 401;
+  }
+  if (kind === "permission") {
+    return 403;
+  }
+  if (kind === "upstream_http" && failure !== undefined && "status" in failure) {
+    return failure.status;
+  }
+  if (kind === "internal") {
+    return 500;
+  }
+  return 502;
+}

--- a/src/protocols/model_catalog/wire.ts
+++ b/src/protocols/model_catalog/wire.ts
@@ -1,0 +1,119 @@
+import { DEFAULT_MODEL_CREATED_AT_TIME, type CatalogSnapshot, type CopilotCatalogModel } from "../../copilot/model_catalog.js";
+
+export interface ModelMetadata {
+  readonly mode?: string;
+  readonly maxInputTokens?: number;
+  readonly maxOutputTokens?: number;
+}
+
+export function coerceTokenLimit(value: unknown): number | undefined {
+  if (typeof value === "boolean" || value === null || typeof value === "object") {
+    return undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+export function serializeOpenAiModels(
+  catalog: CatalogSnapshot,
+  metadata: ReadonlyMap<string, ModelMetadata>,
+  created = DEFAULT_MODEL_CREATED_AT_TIME,
+): string {
+  const data = catalog.models.map((model) => {
+    const meta = metadata.get(model.id);
+    const item: Record<string, unknown> = {
+      id: model.id,
+      object: "model",
+      created,
+      owned_by: "openai",
+    };
+    if (meta?.mode !== undefined) {
+      item.mode = meta.mode;
+    }
+    if (meta?.maxInputTokens !== undefined) {
+      item.max_input_tokens = meta.maxInputTokens;
+    }
+    if (meta?.maxOutputTokens !== undefined) {
+      item.max_output_tokens = meta.maxOutputTokens;
+    }
+    return item;
+  });
+  return JSON.stringify({ data, object: "list" });
+}
+
+export function serializeAnthropicModels(
+  catalog: CatalogSnapshot,
+  metadata: ReadonlyMap<string, ModelMetadata>,
+  created = DEFAULT_MODEL_CREATED_AT_TIME,
+): string {
+  const createdAt = new Date(created * 1000).toISOString().replace(/\.\d+Z$/u, "Z");
+  const data = catalog.models.map((model) => {
+    const meta = metadata.get(model.id);
+    return {
+      type: "model",
+      id: model.id,
+      display_name: model.id,
+      created_at: createdAt,
+      max_input_tokens: meta?.maxInputTokens ?? null,
+      max_tokens: meta?.maxOutputTokens ?? null,
+    };
+  });
+  const first = catalog.models[0]?.id ?? null;
+  const last = catalog.models[catalog.models.length - 1]?.id ?? null;
+  return JSON.stringify({
+    data,
+    has_more: false,
+    first_id: first,
+    last_id: last,
+  });
+}
+
+export function serializeOllamaTags(catalog: CatalogSnapshot): string {
+  return JSON.stringify({
+    models: catalog.models.map((model) => serializeOllamaModel(model, catalog.fetchedAt)),
+  });
+}
+
+function serializeOllamaModel(model: CopilotCatalogModel, fetchedAt: string): unknown {
+  return {
+    name: model.id,
+    model: model.id,
+    modified_at: fetchedAt,
+    size: 0,
+    digest: `copilot-${model.id}`,
+    details: {
+      parent_model: "",
+      format: "Copilot API",
+      family: "GitHub Copilot",
+      families: ["GitHub Copilot"],
+      parameter_size: "unknown",
+      quantization_level: "unknown",
+    },
+  };
+}
+
+export function serializeOpenAiModelsError(status: number): string {
+  const type = status === 401 || status === 403
+    ? "authentication_error"
+    : status === 429
+      ? "rate_limit_error"
+      : "api_error";
+  return JSON.stringify({
+    error: {
+      message: "Failed to list GitHub Copilot models",
+      type,
+      param: null,
+      code: String(status),
+    },
+  });
+}
+
+export function serializeOllamaTagsError(): string {
+  return JSON.stringify({ error: "Failed to list GitHub Copilot models" });
+}

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -1,0 +1,168 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { AccountDirectory } from "../../../src/accounts/account_directory.js";
+import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
+import {
+  CopilotModelCatalog,
+  parseCapiModels,
+} from "../../../src/copilot/model_catalog.js";
+import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
+import { parseStartupConfig } from "../../../src/config/startup_config.js";
+import { createGateway } from "../../../src/gateway/create_gateway.js";
+import { closeDatabase, openDatabase } from "../../../src/persistence/database.js";
+import { embedMigration } from "../../../src/persistence/migrations.js";
+import { migration as runtimeConfigMigration } from "../../../src/persistence/migrations/001_runtime_config.js";
+import { migration as accountsMigration } from "../../../src/persistence/migrations/010_accounts.js";
+import { createModelCatalogRoutes } from "../../../src/protocols/model_catalog/routes.js";
+import { resolveModel } from "../../../src/protocols/model_catalog/resolver.js";
+import { serializeAnthropicModels, serializeOllamaTags, serializeOpenAiModels } from "../../../src/protocols/model_catalog/wire.js";
+
+const nowMs = (): number => 1_700_000_000_000;
+
+const CAPI = {
+  data: [
+    { id: "keep", name: "Keep", vendor: "x", model_picker_enabled: true, capabilities: { mode: "chat", supported_endpoints: ["/v1/chat/completions"] } },
+    { id: "hidden", name: "Hidden", vendor: "x", model_picker_enabled: false },
+    { id: "keep", name: "Dup", vendor: "x", model_picker_enabled: true },
+  ],
+};
+
+describe("RM-08 CAPI parse and cache", () => {
+  it("keeps picker-enabled models in upstream order including duplicates", () => {
+    const models = parseCapiModels(CAPI);
+    expect(models.map((model) => model.id)).toEqual(["keep", "keep"]);
+  });
+
+  it("rejects incomplete CAPI items", () => {
+    expect(() => parseCapiModels({ data: [{ id: "x" }] })).toThrow(/invalid/u);
+  });
+
+  it("does not write cache after invalidate generation change", async () => {
+    let fetches = 0;
+    const catalog = new CopilotModelCatalog({
+      async fetch() {
+        fetches += 1;
+        return CAPI;
+      },
+    }, () => new Date("2026-08-30T05:00:00.000Z"));
+    const first = catalog.get("github.com/1", new AbortController().signal);
+    catalog.invalidate("github.com/1");
+    const snapshot = await first;
+    expect(snapshot.models[0]?.id).toBe("keep");
+    await catalog.get("github.com/1", new AbortController().signal);
+    expect(fetches).toBe(2);
+  });
+
+  it("caches empty catalogs per account and does not share them", async () => {
+    const seen: string[] = [];
+    const catalog = new CopilotModelCatalog({
+      async fetch(accountId) {
+        seen.push(accountId);
+        return { data: [] };
+      },
+    });
+    const a = await catalog.get("github.com/1", new AbortController().signal);
+    const b = await catalog.get("github.com/1", new AbortController().signal);
+    const c = await catalog.get("github.com/2", new AbortController().signal);
+    expect(a.models).toEqual([]);
+    expect(b.models).toEqual([]);
+    expect(c.accountId).toBe("github.com/2");
+    expect(seen).toEqual(["github.com/1", "github.com/2"]);
+  });
+});
+
+describe("RM-08 model resolver", () => {
+  const catalog = {
+    accountId: "github.com/1",
+    fetchedAt: "t",
+    generation: 1,
+    models: [{ id: "gpt", name: "GPT", vendor: "x", modelPickerEnabled: true }],
+  };
+
+  it("uses valid visible preference only when model is missing", () => {
+    const resolved = resolveModel(catalog, undefined, { modelId: "gpt", validity: "valid" });
+    expect(resolved).toMatchObject({ source: "preferred", upstreamModel: "gpt" });
+    expect(resolveModel(catalog, undefined, { modelId: "gpt", validity: "invalid" })).toEqual({ kind: "invalid_request" });
+    expect(resolveModel(catalog, "nope", { modelId: "gpt", validity: "valid" })).toEqual({ kind: "model_not_found" });
+    expect(resolveModel(catalog, "", null)).toEqual({ kind: "invalid_request" });
+  });
+});
+
+describe("RM-08 listing routes", () => {
+  it("serializes one snapshot as OpenAI, Anthropic, and Ollama shapes", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-cat-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+    await accounts.upsertAuthenticated({
+      host: "github.com",
+      userId: "1",
+      secret: { generation: 0, githubToken: "t" },
+    });
+    const catalog = new CopilotModelCatalog({
+      async fetch() {
+        return CAPI;
+      },
+    }, () => new Date("2026-08-30T05:00:00.000Z"));
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: dir }),
+      runtime: defaultRuntimeConfigSnapshot(),
+    }, createModelCatalogRoutes({
+      directory: accounts,
+      catalog,
+      preferences: accounts.preferences,
+    }));
+    try {
+      const openai = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"));
+      expect(openai.status).toBe(200);
+      const openaiBody = JSON.parse(await openai.text()) as { object: string; data: Array<{ id: string; owned_by: string; created: number }> };
+      expect(openaiBody.object).toBe("list");
+      expect(openaiBody.data[0]).toMatchObject({ id: "keep", owned_by: "openai", created: 1_677_610_602 });
+      expect(openai.headers.get("cache-control")).toBe("no-store");
+
+      const anthropic = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models", {
+        headers: { "anthropic-version": "" },
+      }));
+      const anthropicBody = JSON.parse(await anthropic.text()) as { first_id: string; data: Array<{ type: string; max_tokens: null }> };
+      expect(anthropicBody.first_id).toBe("keep");
+      expect(anthropicBody.data[0]?.type).toBe("model");
+      expect(anthropicBody.data[0]?.max_tokens).toBeNull();
+
+      const tags = await gw.fetch(new Request("http://127.0.0.1:31400/api/tags"));
+      const tagsBody = JSON.parse(await tags.text()) as { models: Array<{ name: string; digest: string }> };
+      expect(tagsBody.models[0]?.name).toBe("keep");
+      expect(tagsBody.models[0]?.digest).toBe("copilot-keep");
+
+      expect((await gw.fetch(new Request("http://127.0.0.1:31400/models"))).status).toBe(404);
+    } finally {
+      await gw.close();
+      closeDatabase(database);
+    }
+  });
+});
+
+describe("RM-08 serializers", () => {
+  it("omits routing metadata from public OpenAI objects", () => {
+    const catalog = {
+      accountId: "a",
+      fetchedAt: "2026-08-30T05:00:00Z",
+      generation: 1,
+      models: [{
+        id: "m",
+        name: "M",
+        vendor: "v",
+        modelPickerEnabled: true,
+        routing: { mode: "responses", supportedEndpoints: ["/v1/responses"] },
+      }],
+    };
+    const openai = JSON.parse(serializeOpenAiModels(catalog, new Map())) as { data: Array<Record<string, unknown>> };
+    expect(openai.data[0]?.supported_endpoints).toBeUndefined();
+    expect(JSON.parse(serializeAnthropicModels(catalog, new Map())).data[0].display_name).toBe("m");
+    expect(JSON.parse(serializeOllamaTags(catalog)).models[0].modified_at).toBe("2026-08-30T05:00:00Z");
+  });
+});

--- a/tests/refactor/fixtures/model-catalog/manifest.json
+++ b/tests/refactor/fixtures/model-catalog/manifest.json
@@ -1,0 +1,10 @@
+[
+  {
+    "caseId": "model-catalog.openai.empty",
+    "owner": "RM-08",
+    "source": "docs/github_copilot_model_listing_apis.md#92-default-openai-success-response",
+    "input": "empty.input.json",
+    "expected": "empty.expected.json",
+    "encoder": "openai-models"
+  }
+]

--- a/tests/refactor/integration/model_routes.test.ts
+++ b/tests/refactor/integration/model_routes.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { AccountDirectory } from "../../../src/accounts/account_directory.js";
+import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
+import { CopilotModelCatalog } from "../../../src/copilot/model_catalog.js";
+import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
+import { parseStartupConfig } from "../../../src/config/startup_config.js";
+import { createGateway } from "../../../src/gateway/create_gateway.js";
+import { closeDatabase, openDatabase } from "../../../src/persistence/database.js";
+import { embedMigration } from "../../../src/persistence/migrations.js";
+import { migration as runtimeConfigMigration } from "../../../src/persistence/migrations/001_runtime_config.js";
+import { migration as accountsMigration } from "../../../src/persistence/migrations/010_accounts.js";
+import { PreferredModelManager } from "../../../src/protocols/model_catalog/preferred.js";
+import { createModelCatalogRoutes } from "../../../src/protocols/model_catalog/routes.js";
+
+const nowMs = (): number => 1_700_000_000_000;
+
+describe("RM-08 model routes errors and preferences", () => {
+  it("returns 401 without an account and invalidates missing preferences", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-cat-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+    const catalog = new CopilotModelCatalog({
+      async fetch() {
+        return { data: [{ id: "visible", name: "V", vendor: "x", model_picker_enabled: true }] };
+      },
+    });
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: dir }),
+      runtime: defaultRuntimeConfigSnapshot(),
+    }, createModelCatalogRoutes({
+      directory: accounts,
+      catalog,
+      preferences: accounts.preferences,
+    }));
+    try {
+      const missing = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"));
+      expect(missing.status).toBe(401);
+      await accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "t" },
+      });
+      const ok = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"));
+      expect(ok.status).toBe(200);
+      const snapshot = await catalog.get("github.com/1", new AbortController().signal);
+      const manager = new PreferredModelManager(accounts.preferences);
+      manager.setPreferred("github.com/1", "visible", 0, snapshot);
+      catalog.invalidate("github.com/1");
+      const empty = new CopilotModelCatalog({
+        async fetch() {
+          return { data: [] };
+        },
+      });
+      await empty.get("github.com/1", new AbortController().signal);
+      accounts.preferences.markInvalidIfMissing("github.com/1", new Set(), 2);
+      expect(accounts.preferences.get("github.com/1")?.validity).toBe("invalid");
+    } finally {
+      await gw.close();
+      closeDatabase(database);
+    }
+  });
+});

--- a/tests/refactor/sdk/model_listing.sdk.test.ts
+++ b/tests/refactor/sdk/model_listing.sdk.test.ts
@@ -1,0 +1,7 @@
+import { describe, it } from "vitest";
+
+describe("RM-08 official SDK model listing", () => {
+  it.skip("manual-only: OpenAI, Anthropic, and Ollama list against loopback", () => {
+    // GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk:refactor -- tests/refactor/sdk/model_listing.sdk.test.ts
+  });
+});


### PR DESCRIPTION
## Slice
ID: RM-08
Closes #17

Per-account Copilot catalog, strict CAPI parse, generation-safe cache, three serializers, model resolver, preferred-model manager, HttpCopilotModelsSource.

## Commands
- `npm run typecheck:refactor`
- `npm run lint:refactor`
- `npm run test:refactor -- tests/refactor/contract/model_catalog.test.ts tests/refactor/integration/model_routes.test.ts`

## Code review
Fixed production CAPI source, status/Retry-After mapping, RFC3339 without dummy nanos, public DTO without CAPI routing, empty-cache isolation.