### PR TITLE
[RM-10] Ollama endpoint

### DIFF
--- a/src/protocols/ollama_chat/endpoint.ts
+++ b/src/protocols/ollama_chat/endpoint.ts
@@ -1,0 +1,202 @@
+import { VERSION } from "../../version.js";
+import type { CopilotBackend } from "../../copilot/backend.js";
+import type { AccountDirectory } from "../../accounts/account_directory.js";
+import { iterateChatFrames } from "../../copilot/backend.js";
+import { GatewayFailureError } from "../../gateway/failures.js";
+import type { FailurePresenter, RouteRegistration } from "../../gateway/hono_app.js";
+import { isWireJsonArray, isWireJsonObject, memberValues, type WireJson } from "../../serialization/wire_json.js";
+import { createStreamResponseWriter } from "../../gateway/stream_response.js";
+import { encodeNdjson, ollamaCreatedAt, ollamaErrorBody } from "./wire.js";
+
+export interface OllamaRouteDependencies {
+  readonly directory: AccountDirectory;
+  readonly copilot: CopilotBackend;
+  readonly now?: () => Date;
+}
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+} as const;
+
+export function createOllamaChatRoutes(dependencies: OllamaRouteDependencies): readonly RouteRegistration[] {
+  const presentFailure: FailurePresenter = (failure) => {
+    const status = failure.kind === "queue_full" || failure.kind === "queue_timeout"
+      ? 503
+      : failure.kind === "unsupported_semantics"
+        ? 422
+        : failure.kind === "upstream_timeout"
+          ? 504
+          : failure.kind === "internal"
+            ? 500
+            : 400;
+    const text = failure.kind === "queue_full" || failure.kind === "queue_timeout"
+      ? "server overloaded"
+      : failure.kind === "unsupported_semantics"
+        ? "unsupported semantics"
+        : failure.kind === "upstream_timeout"
+          ? "upstream timeout"
+          : failure.kind === "internal"
+            ? "internal error"
+            : "invalid request";
+    return new Response(ollamaErrorBody(text), { status, headers: JSON_HEADERS });
+  };
+
+  return [
+    {
+      method: "GET",
+      path: "/api/version",
+      admission: "none",
+      body: "none",
+      presentFailure,
+      endpoint: async () => new Response(JSON.stringify({ version: VERSION }), {
+        headers: JSON_HEADERS,
+      }),
+    },
+    {
+      method: "POST",
+      path: "/api/chat",
+      admission: "inference",
+      body: "wire-json-object",
+      presentFailure,
+      endpoint: async (request, scope) => {
+        if (request.body === undefined) {
+          throw new GatewayFailureError({ kind: "invalid_request" });
+        }
+        const model = asNonEmptyString(memberValues(request.body, "model")[0]);
+        const messages = memberValues(request.body, "messages")[0];
+        if (model === undefined || !isWireJsonArray(messages) || messages.items.length === 0) {
+          throw new GatewayFailureError({ kind: "invalid_request" });
+        }
+        const streamValue = memberValues(request.body, "stream")[0];
+        const stream = streamValue === undefined ? true : streamValue === true;
+        if (streamValue !== undefined && streamValue !== true && streamValue !== false) {
+          throw new GatewayFailureError({ kind: "invalid_request" });
+        }
+        const account = await dependencies.directory.bindDefault(scope.signal);
+        const copilot = await dependencies.copilot.bind(account, scope.signal);
+        const chatBody = new TextEncoder().encode(JSON.stringify({
+          model,
+          messages: messages.items.map(ollamaMessageToChat),
+          stream,
+          ...(stream ? { stream_options: { include_usage: true } } : {}),
+        }));
+        const createdAt = ollamaCreatedAt((dependencies.now ?? (() => new Date()))());
+        if (!stream) {
+          const response = await copilot.completeChat({
+            model,
+            body: chatBody,
+            stream: false,
+            hasVisionInput: false,
+            signal: scope.signal,
+          });
+          const content = extractContent(response.body);
+          return new Response(JSON.stringify({
+            model,
+            created_at: createdAt,
+            message: { role: "assistant", content },
+            done: true,
+            done_reason: "stop",
+          }), { headers: { "Content-Type": "application/json; charset=utf-8" } });
+        }
+        const writer = createStreamResponseWriter({
+          signal: scope.signal,
+          headers: { "Content-Type": "application/x-ndjson" },
+        });
+        const upstream = await copilot.openChatStream({
+          model,
+          body: chatBody,
+          stream: true,
+          hasVisionInput: false,
+          signal: scope.signal,
+        });
+        void (async () => {
+          try {
+            for await (const frame of iterateChatFrames(upstream)) {
+              if (scope.signal.aborted) {
+                writer.abort();
+                return;
+              }
+              if (frame.kind === "chunk") {
+                const content = textFromWire(frame.chunk.payload);
+                if (content.length > 0) {
+                  await writer.enqueue(encodeNdjson({
+                    model,
+                    created_at: createdAt,
+                    message: { role: "assistant", content },
+                    done: false,
+                  }));
+                }
+              }
+              if (frame.kind === "done") {
+                await writer.enqueue(encodeNdjson({
+                  model,
+                  created_at: createdAt,
+                  message: { role: "assistant", content: "" },
+                  done: true,
+                  done_reason: "stop",
+                }));
+                writer.close();
+                return;
+              }
+              if (frame.kind === "error") {
+                await writer.enqueue(encodeNdjson({ error: "upstream stream error" }));
+                writer.close();
+                return;
+              }
+            }
+            writer.close();
+          } catch (_error) {
+            if (writer.committed) {
+              await writer.enqueue(encodeNdjson({ error: "upstream stream error" }));
+            }
+            writer.close();
+          }
+        })();
+        return writer.response;
+      },
+    },
+  ];
+}
+
+function asNonEmptyString(value: WireJson | undefined): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function ollamaMessageToChat(value: WireJson): { role: string; content: string } {
+  if (!isWireJsonObject(value)) {
+    return { role: "user", content: "" };
+  }
+  const role = asNonEmptyString(memberValues(value, "role")[0]) ?? "user";
+  const content = typeof memberValues(value, "content")[0] === "string"
+    ? memberValues(value, "content")[0] as string
+    : "";
+  return { role: role.toLowerCase(), content };
+}
+
+function extractContent(body: Uint8Array): string {
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(body)) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    return parsed.choices?.[0]?.message?.content ?? "";
+  } catch (_error) {
+    return "";
+  }
+}
+
+function textFromWire(value: WireJson): string {
+  if (!isWireJsonObject(value)) {
+    return "";
+  }
+  const choices = memberValues(value, "choices")[0];
+  if (!isWireJsonArray(choices) || choices.items[0] === undefined || !isWireJsonObject(choices.items[0])) {
+    return "";
+  }
+  const delta = memberValues(choices.items[0], "delta")[0];
+  if (!isWireJsonObject(delta)) {
+    return "";
+  }
+  const content = memberValues(delta, "content")[0];
+  return typeof content === "string" ? content : "";
+}

--- a/src/protocols/ollama_chat/wire.ts
+++ b/src/protocols/ollama_chat/wire.ts
@@ -1,0 +1,11 @@
+export function ollamaErrorBody(text: string): string {
+  return JSON.stringify({ error: text });
+}
+
+export function ollamaCreatedAt(now: Date): string {
+  return now.toISOString().replace(/\.\d+Z$/u, "Z");
+}
+
+export function encodeNdjson(value: unknown): Uint8Array {
+  return new TextEncoder().encode(`${JSON.stringify(value)}\n`);
+}

--- a/tests/refactor/contract/ollama_nonstream.test.ts
+++ b/tests/refactor/contract/ollama_nonstream.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { AccountDirectory } from "../../../src/accounts/account_directory.js";
+import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
+import { ScriptedCopilotBackend } from "../../../src/copilot/backend.js";
+import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
+import { parseStartupConfig } from "../../../src/config/startup_config.js";
+import { createGateway } from "../../../src/gateway/create_gateway.js";
+import { closeDatabase, openDatabase } from "../../../src/persistence/database.js";
+import { embedMigration } from "../../../src/persistence/migrations.js";
+import { migration as runtimeConfigMigration } from "../../../src/persistence/migrations/001_runtime_config.js";
+import { migration as accountsMigration } from "../../../src/persistence/migrations/010_accounts.js";
+import { createOllamaChatRoutes } from "../../../src/protocols/ollama_chat/endpoint.js";
+
+const nowMs = (): number => 1_700_000_000_000;
+
+describe("RM-10 Ollama non-stream", () => {
+  it("maps chat JSON to an Ollama object with done true", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-ollama-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+    await accounts.upsertAuthenticated({
+      host: "github.com",
+      userId: "1",
+      secret: { generation: 0, githubToken: "t" },
+    });
+    const backend = new ScriptedCopilotBackend({
+      chat: {
+        status: 200,
+        headers: new Headers(),
+        body: new TextEncoder().encode(JSON.stringify({
+          choices: [{ message: { role: "assistant", content: "hello" } }],
+        })),
+      },
+    });
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: dir }),
+      runtime: defaultRuntimeConfigSnapshot(),
+    }, createOllamaChatRoutes({
+      directory: accounts,
+      copilot: backend,
+      now: () => new Date("2026-01-02T03:04:05.000Z"),
+    }));
+    try {
+      const response = await gw.fetch(new Request("http://127.0.0.1:31400/api/chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt",
+          stream: false,
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }));
+      expect(response.status).toBe(200);
+      const body = JSON.parse(await response.text()) as {
+        done: boolean;
+        done_reason: string;
+        message: { content: string };
+        created_at: string;
+      };
+      expect(body.done).toBe(true);
+      expect(body.done_reason).toBe("stop");
+      expect(body.message.content).toBe("hello");
+      expect(body.created_at).toBe("2026-01-02T03:04:05Z");
+    } finally {
+      await gw.close();
+      closeDatabase(database);
+    }
+  });
+});

--- a/tests/refactor/contract/ollama_request.test.ts
+++ b/tests/refactor/contract/ollama_request.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { AccountDirectory } from "../../../src/accounts/account_directory.js";
+import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
+import { ScriptedCopilotBackend } from "../../../src/copilot/backend.js";
+import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
+import { parseStartupConfig } from "../../../src/config/startup_config.js";
+import { createGateway } from "../../../src/gateway/create_gateway.js";
+import { closeDatabase, openDatabase } from "../../../src/persistence/database.js";
+import { embedMigration } from "../../../src/persistence/migrations.js";
+import { migration as runtimeConfigMigration } from "../../../src/persistence/migrations/001_runtime_config.js";
+import { migration as accountsMigration } from "../../../src/persistence/migrations/010_accounts.js";
+import { createOllamaChatRoutes } from "../../../src/protocols/ollama_chat/endpoint.js";
+
+const nowMs = (): number => 1_700_000_000_000;
+
+async function ollamaGateway(backend: ScriptedCopilotBackend) {
+  const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-ollama-"));
+  const database = openDatabase({
+    path: path.join(dir, "state.db"),
+    migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+    nowMs,
+  });
+  const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+  await accounts.upsertAuthenticated({
+    host: "github.com",
+    userId: "1",
+    secret: { generation: 0, githubToken: "t" },
+  });
+  const gw = await createGateway({
+    startup: parseStartupConfig([], {}, { homedir: dir }),
+    runtime: defaultRuntimeConfigSnapshot(),
+  }, createOllamaChatRoutes({
+    directory: accounts,
+    copilot: backend,
+    now: () => new Date("2026-01-02T03:04:05.000Z"),
+  }));
+  return { gw, close: async () => { await gw.close(); closeDatabase(database); } };
+}
+
+describe("RM-10 Ollama request", () => {
+  it("requires model and messages and defaults stream to true", async () => {
+    const backend = new ScriptedCopilotBackend({
+      chatStream: [new TextEncoder().encode("data: [DONE]\n\n")],
+    });
+    const { gw, close } = await ollamaGateway(backend);
+    try {
+      const missing = await gw.fetch(new Request("http://127.0.0.1:31400/api/chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }));
+      expect(missing.status).toBe(400);
+      expect(await missing.text()).toBe("{\"error\":\"invalid request\"}");
+
+      const ok = await gw.fetch(new Request("http://127.0.0.1:31400/api/chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt", messages: [{ role: "user", content: "hi" }] }),
+      }));
+      expect(ok.headers.get("content-type")).toBe("application/x-ndjson");
+      const text = await ok.text();
+      expect(text.endsWith("\n")).toBe(true);
+      expect(text).toContain("\"done\":true");
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/refactor/contract/ollama_stream.test.ts
+++ b/tests/refactor/contract/ollama_stream.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { encodeNdjson } from "../../../src/protocols/ollama_chat/wire.js";
+
+describe("RM-10 Ollama stream wire", () => {
+  it("encodes one compact JSON object and a trailing LF", () => {
+    const bytes = encodeNdjson({ done: true });
+    expect(new TextDecoder().decode(bytes)).toBe("{\"done\":true}\n");
+  });
+});

--- a/tests/refactor/contract/ollama_wire.test.ts
+++ b/tests/refactor/contract/ollama_wire.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { ollamaErrorBody } from "../../../src/protocols/ollama_chat/wire.js";
+import { VERSION } from "../../../src/version.js";
+
+describe("RM-10 Ollama wire helpers", () => {
+  it("uses the fixed error envelope and gateway version", () => {
+    expect(ollamaErrorBody("invalid request")).toBe("{\"error\":\"invalid request\"}");
+    expect(VERSION).toBe("0.1.0");
+  });
+});

--- a/tests/refactor/sdk/ollama.sdk.test.ts
+++ b/tests/refactor/sdk/ollama.sdk.test.ts
@@ -1,0 +1,7 @@
+import { describe, it } from "vitest";
+
+describe("RM-10 official Ollama SDK", () => {
+  it.skip("manual-only: list/chat non-stream/stream against loopback", () => {
+    // GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk:refactor -- tests/refactor/sdk/ollama.sdk.test.ts
+  });
+});


### PR DESCRIPTION
## Slice
ID: RM-10
Closes #16

Ollama `/api/chat` + `/api/version` registrations, stream default true, Chat backend, NDJSON with final LF, Ollama error envelope.

## Commands
- `npm run typecheck:refactor`
- `npm run lint:refactor`
- `npm run test:refactor -- tests/refactor/contract/ollama_request.test.ts tests/refactor/contract/ollama_nonstream.test.ts tests/refactor/contract/ollama_stream.test.ts tests/refactor/contract/ollama_wire.test.ts`