### PR TITLE
Fix abortable gateway request body lifecycle

### DIFF
--- a/src/gateway/body_reader.ts
+++ b/src/gateway/body_reader.ts
@@ -12,11 +12,12 @@ const UTF8 = "utf-8";
 export async function readWireJsonObjectBody(
   request: Request,
   maxBytes: number,
+  signal: AbortSignal,
 ): Promise<WireJsonObject> {
   assertJsonMediaType(request.headers);
   assertIdentityEncoding(request.headers);
 
-  const bytes = await readLimitedBytes(request, maxBytes);
+  const bytes = await readLimitedBytes(request, maxBytes, signal);
   if (bytes.byteLength === 0) {
     throw new GatewayFailureError({ kind: "invalid_request" });
   }
@@ -64,7 +65,7 @@ function assertIdentityEncoding(headers: Headers): void {
   }
 }
 
-async function readLimitedBytes(request: Request, maxBytes: number): Promise<Uint8Array> {
+async function readLimitedBytes(request: Request, maxBytes: number, signal: AbortSignal): Promise<Uint8Array> {
   const declared = request.headers.get("content-length");
   if (declared !== null && /^[0-9]+$/u.test(declared)) {
     const length = Number.parseInt(declared, 10);
@@ -75,7 +76,7 @@ async function readLimitedBytes(request: Request, maxBytes: number): Promise<Uin
 
   const body = request.body;
   if (body === null) {
-    const buffered = new Uint8Array(await request.arrayBuffer());
+    const buffered = new Uint8Array(await withAbort(request.arrayBuffer(), signal));
     if (buffered.byteLength > maxBytes) {
       throw new GatewayFailureError({ kind: "body_too_large" });
     }
@@ -87,7 +88,7 @@ async function readLimitedBytes(request: Request, maxBytes: number): Promise<Uin
   let total = 0;
   try {
     for (;;) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readNext(reader, signal);
       if (done) {
         break;
       }
@@ -96,12 +97,15 @@ async function readLimitedBytes(request: Request, maxBytes: number): Promise<Uin
       }
       total += value.byteLength;
       if (total > maxBytes) {
-        await reader.cancel();
+        void reader.cancel().catch(() => undefined);
         throw new GatewayFailureError({ kind: "body_too_large" });
       }
       chunks.push(value);
     }
   } finally {
+    if (signal.aborted) {
+      void reader.cancel().catch(() => undefined);
+    }
     reader.releaseLock();
   }
 
@@ -110,6 +114,39 @@ async function readLimitedBytes(request: Request, maxBytes: number): Promise<Uin
   for (const chunk of chunks) {
     bytes.set(chunk, offset);
     offset += chunk.byteLength;
+  }
+
+  function readNext(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    signal: AbortSignal,
+  ): Promise<ReadableStreamReadResult<Uint8Array>> {
+    return withAbort(reader.read(), signal, () => {
+      void reader.cancel().catch(() => undefined);
+    });
+  }
+
+  function withAbort<T>(work: Promise<T>, signal: AbortSignal, onAbort?: () => void): Promise<T> {
+    if (signal.aborted) {
+      onAbort?.();
+      return Promise.reject(new GatewayFailureError({ kind: "aborted" }));
+    }
+    return new Promise<T>((resolve, reject) => {
+      const abort = (): void => {
+        onAbort?.();
+        reject(new GatewayFailureError({ kind: "aborted" }));
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      work.then(
+        (value) => {
+          signal.removeEventListener("abort", abort);
+          resolve(value);
+        },
+        (error: unknown) => {
+          signal.removeEventListener("abort", abort);
+          reject(error);
+        },
+      );
+    });
   }
   return bytes;
 }

--- a/src/gateway/hono_app.ts
+++ b/src/gateway/hono_app.ts
@@ -110,7 +110,7 @@ async function handleRoute(
     const url = new URL(request.url);
     let decoded: DecodedHttpRequest = { url, headers: request.headers };
     if (route.body === "wire-json-object") {
-      const body = await readWireJsonObjectBody(request, snapshot.limits.requestBodyBytes);
+      const body = await readWireJsonObjectBody(request, snapshot.limits.requestBodyBytes, controller.signal);
       decoded = { url, headers: request.headers, body };
     }
 

--- a/tests/refactor/contract/gateway_http_contracts.test.ts
+++ b/tests/refactor/contract/gateway_http_contracts.test.ts
@@ -22,7 +22,9 @@ const fakePresenter: FailurePresenter = (failure, requestId) => {
       ? 413
       : failure.kind === "unsupported_media_type"
         ? 415
-        : 400;
+        : failure.kind === "upstream_timeout"
+          ? 504
+          : 400;
   return new Response(JSON.stringify({ kind: failure.kind, requestId }), {
     status,
     headers: {
@@ -88,6 +90,39 @@ function jsonRequest(pathName: string, body: string, headers: HeadersInit = {}):
     method: "POST",
     headers: { "content-type": "application/json", ...headers },
     body,
+  });
+}
+
+interface StreamingRequestInit extends RequestInit {
+  readonly duplex: "half";
+}
+
+function streamingJsonRequest(
+  pathName: string,
+  stream: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): Request {
+  const init: StreamingRequestInit = {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: stream,
+    ...(signal === undefined ? {} : { signal }),
+    duplex: "half",
+  };
+  return new Request(`http://127.0.0.1:31400${pathName}`, init);
+}
+
+function stalledJsonBody(onCancel: () => void): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller): void {
+      controller.enqueue(new TextEncoder().encode("{"));
+    },
+    pull: async (): Promise<void> => {
+      await new Promise<void>(() => undefined);
+    },
+    cancel(): void {
+      onCancel();
+    },
   });
 }
 
@@ -235,6 +270,72 @@ describe("RM-03 body reading and fake presenter", () => {
     }));
     expect(response.headers.get("x-request-id")).toBe("req_generated_1");
     await gw.close();
+  });
+
+  it("times out stalled uploads and releases the inference slot", async () => {
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.admission.activeMax = 1;
+    runtime.admission.queueMax = 0;
+    runtime.timeouts.totalMs = 1;
+    let canceled = false;
+    const gw = await gatewayWith([echoRoute()], { runtime });
+    try {
+      const timedOut = await gw.fetch(streamingJsonRequest("/v1/echo", stalledJsonBody(() => {
+        canceled = true;
+      })));
+      expect(timedOut.status).toBe(504);
+      expect(JSON.parse(await timedOut.text())).toMatchObject({ kind: "upstream_timeout" });
+      expect(canceled).toBe(true);
+
+      const after = await gw.fetch(jsonRequest("/v1/echo", "{}"));
+      expect(after.status).toBe(200);
+    } finally {
+      await gw.close();
+    }
+  });
+
+  it("cancels body reads on client abort without writing a response", async () => {
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.admission.activeMax = 1;
+    runtime.admission.queueMax = 0;
+    let canceled = false;
+    const controller = new AbortController();
+    const gw = await gatewayWith([echoRoute()], { runtime });
+    try {
+      const pending = gw.fetch(streamingJsonRequest("/v1/echo", stalledJsonBody(() => {
+        canceled = true;
+      }), controller.signal));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      controller.abort();
+      const response = await pending;
+      expect(response.body).toBeNull();
+      expect(canceled).toBe(true);
+
+      const after = await gw.fetch(jsonRequest("/v1/echo", "{}"));
+      expect(after.status).toBe(200);
+    } finally {
+      await gw.close();
+    }
+  });
+
+  it("cancels in-flight body reads when the gateway closes", async () => {
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.admission.activeMax = 1;
+    runtime.admission.queueMax = 0;
+    let canceled = false;
+    const gw = await gatewayWith([echoRoute()], { runtime });
+    try {
+      const pending = gw.fetch(streamingJsonRequest("/v1/echo", stalledJsonBody(() => {
+        canceled = true;
+      })));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      await gw.close();
+      const response = await pending;
+      expect(response.body).toBeNull();
+      expect(canceled).toBe(true);
+    } finally {
+      await gw.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Makes Gateway request body reads observe the route abort signal.
- Cancels stalled request body readers on total timeout, client abort, and gateway close.
- Adds Fetch-surface coverage for timeout, abort, close, and slot release.

Closes #44

## Validation
- `npm run typecheck:refactor`
- `npm run lint:refactor`
- `npm run test:refactor -- tests/refactor/contract/gateway_http_contracts.test.ts`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check origin/refactor...HEAD`

## Code review
- Standards review: no blocker/significant findings.
- Spec review: no significant issues found.