### PR TITLE
Make credential activation failure-safe

### DIFF
--- a/src/accounts/account_directory.ts
+++ b/src/accounts/account_directory.ts
@@ -169,7 +169,7 @@ export class AccountDirectory {
     if (row === undefined) {
       throw new AccountDirectoryError("not_found", "account not found");
     }
-    if (row.credential_state !== "removing" && row.revision !== expectedRevision) {
+    if (row.revision !== expectedRevision) {
       throw new AccountDirectoryError("revision_conflict", "account revision conflict");
     }
     if (row.credential_state === "removed") {

--- a/src/accounts/account_directory.ts
+++ b/src/accounts/account_directory.ts
@@ -41,6 +41,8 @@ export class AccountDirectoryError extends Error {
   }
 }
 
+const accountMutationLocks = new Map<AccountId, Promise<void>>();
+
 export class AccountDirectory {
   readonly preferences: AccountModelPreferences;
 
@@ -95,41 +97,41 @@ export class AccountDirectory {
     const environment = resolveGitHubEnvironment(input.host);
     const userId = canonicalUserId(input.userId);
     const accountId = formatAccountId(environment.host, userId);
-    const existing = this.readAccount(accountId);
-    const activating = existing === undefined || existing.credential_state !== "active";
-    if (activating && this.activeCount() >= this.maxAuthenticated) {
-      throw new AccountDirectoryError("capacity", "authenticated account capacity reached");
-    }
-    const previousCredentialReferences = this.activeCredentialReferences();
-    const generation = (existing?.credential_generation ?? 0) + 1;
-    const secret = { ...input.secret, generation };
-    await this.credentials.putGeneration(accountId, generation, secret);
+    return await withAccountMutationLock(accountId, async () => {
+      const existing = this.readAccount(accountId);
+      const activating = existing === undefined || existing.credential_state !== "active";
+      if (activating && this.activeCount() >= this.maxAuthenticated) {
+        throw new AccountDirectoryError("capacity", "authenticated account capacity reached");
+      }
+      const generation = (existing?.credential_generation ?? 0) + 1;
+      const secret = { ...input.secret, generation };
+      await this.credentials.putGeneration(accountId, generation, secret);
 
-    const now = this.nowMs();
-    try {
-      this.database.transaction(() => {
-        if (existing === undefined) {
-          this.database.prepare(
-            `INSERT INTO accounts (
+      const now = this.nowMs();
+      try {
+        this.database.transaction(() => {
+          if (existing === undefined) {
+            this.database.prepare(
+              `INSERT INTO accounts (
                account_id, revision, normalized_host, numeric_user_id, environment_kind,
                login, display_name, authenticated_at_ms, credential_generation, credential_state,
                created_at_ms, updated_at_ms
              ) VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)`,
-          ).run(
-            accountId,
-            environment.host,
-            userId,
-            environment.kind,
-            input.login ?? null,
-            input.displayName ?? null,
-            now,
-            generation,
-            now,
-            now,
-          );
-        } else {
-          this.database.prepare(
-            `UPDATE accounts SET
+            ).run(
+              accountId,
+              environment.host,
+              userId,
+              environment.kind,
+              input.login ?? null,
+              input.displayName ?? null,
+              now,
+              generation,
+              now,
+              now,
+            );
+          } else {
+            this.database.prepare(
+              `UPDATE accounts SET
                revision = revision + 1,
                login = ?,
                display_name = ?,
@@ -138,22 +140,23 @@ export class AccountDirectory {
                credential_state = 'active',
                updated_at_ms = ?
              WHERE account_id = ?`,
-          ).run(input.login ?? existing.login, input.displayName ?? existing.display_name, now, generation, now, accountId);
-        }
+            ).run(input.login ?? existing.login, input.displayName ?? existing.display_name, now, generation, now, accountId);
+          }
 
-        if (this.readPrefs().default_account_id === null) {
-          this.database.prepare(
-            "UPDATE gateway_preferences SET default_account_id = ?, revision = revision + 1, updated_at_ms = ? WHERE singleton_id = 1",
-          ).run(accountId, now);
-        }
-      })();
-    } catch (error: unknown) {
-      await this.credentials.prune(previousCredentialReferences);
-      throw error;
-    }
+          if (this.readPrefs().default_account_id === null) {
+            this.database.prepare(
+              "UPDATE gateway_preferences SET default_account_id = ?, revision = revision + 1, updated_at_ms = ? WHERE singleton_id = 1",
+            ).run(accountId, now);
+          }
+        })();
+      } catch (error: unknown) {
+        await this.credentials.prune(this.activeCredentialReferences());
+        throw error;
+      }
 
-    await this.credentials.prune(this.activeCredentialReferences());
-    return this.bind(accountId);
+      await this.credentials.prune(this.activeCredentialReferences());
+      return this.bind(accountId);
+    });
   }
 
   async remove(accountId: AccountId, expectedRevision: number): Promise<AccountSummary> {
@@ -259,6 +262,25 @@ export class AccountDirectory {
     return this.database.prepare(
       "SELECT account_id, revision, normalized_host, numeric_user_id, environment_kind, login, display_name, authenticated_at_ms, credential_generation, credential_state FROM accounts WHERE account_id = ?",
     ).get(accountId) as AccountRow | undefined;
+  }
+}
+
+async function withAccountMutationLock<T>(accountId: AccountId, work: () => Promise<T>): Promise<T> {
+  const previous = accountMutationLocks.get(accountId) ?? Promise.resolve();
+  let release: () => void = () => undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => current);
+  accountMutationLocks.set(accountId, queued);
+  await previous;
+  try {
+    return await work();
+  } finally {
+    release();
+    if (accountMutationLocks.get(accountId) === queued) {
+      accountMutationLocks.delete(accountId);
+    }
   }
 }
 

--- a/src/accounts/account_directory.ts
+++ b/src/accounts/account_directory.ts
@@ -41,7 +41,7 @@ export class AccountDirectoryError extends Error {
   }
 }
 
-const accountMutationLocks = new Map<AccountId, Promise<void>>();
+let accountLifecycleLock: Promise<void> = Promise.resolve();
 
 export class AccountDirectory {
   readonly preferences: AccountModelPreferences;
@@ -97,7 +97,7 @@ export class AccountDirectory {
     const environment = resolveGitHubEnvironment(input.host);
     const userId = canonicalUserId(input.userId);
     const accountId = formatAccountId(environment.host, userId);
-    return await withAccountMutationLock(accountId, async () => {
+    return await withAccountLifecycleLock(async () => {
       const existing = this.readAccount(accountId);
       const activating = existing === undefined || existing.credential_state !== "active";
       if (activating && this.activeCount() >= this.maxAuthenticated) {
@@ -160,6 +160,10 @@ export class AccountDirectory {
   }
 
   async remove(accountId: AccountId, expectedRevision: number): Promise<AccountSummary> {
+    return await withAccountLifecycleLock(() => this.removeUnlocked(accountId, expectedRevision));
+  }
+
+  private async removeUnlocked(accountId: AccountId, expectedRevision: number): Promise<AccountSummary> {
     const row = this.readAccount(accountId);
     if (row === undefined) {
       throw new AccountDirectoryError("not_found", "account not found");
@@ -195,17 +199,15 @@ export class AccountDirectory {
   }
 
   async reconcile(): Promise<void> {
-    const removing = this.database.prepare(
-      "SELECT account_id, revision FROM accounts WHERE credential_state = 'removing'",
-    ).all() as Array<{ account_id: string; revision: number }>;
-    for (const row of removing) {
-      await this.remove(row.account_id, row.revision);
-    }
-    const active = this.database.prepare(
-      "SELECT account_id, credential_generation FROM accounts WHERE credential_state = 'active' AND credential_generation IS NOT NULL",
-    ).all() as Array<{ account_id: string; credential_generation: number }>;
-    const references = new Map(active.map((row) => [row.account_id, row.credential_generation]));
-    await this.credentials.prune(references);
+    await withAccountLifecycleLock(async () => {
+      const removing = this.database.prepare(
+        "SELECT account_id, revision FROM accounts WHERE credential_state = 'removing'",
+      ).all() as Array<{ account_id: string; revision: number }>;
+      for (const row of removing) {
+        await this.removeUnlocked(row.account_id, row.revision);
+      }
+      await this.credentials.prune(this.activeCredentialReferences());
+    });
   }
 
   private bind(accountId: AccountId): BoundAccount {
@@ -265,21 +267,21 @@ export class AccountDirectory {
   }
 }
 
-async function withAccountMutationLock<T>(accountId: AccountId, work: () => Promise<T>): Promise<T> {
-  const previous = accountMutationLocks.get(accountId) ?? Promise.resolve();
+async function withAccountLifecycleLock<T>(work: () => Promise<T>): Promise<T> {
+  const previous = accountLifecycleLock;
   let release: () => void = () => undefined;
   const current = new Promise<void>((resolve) => {
     release = resolve;
   });
   const queued = previous.then(() => current);
-  accountMutationLocks.set(accountId, queued);
+  accountLifecycleLock = queued;
   await previous;
   try {
     return await work();
   } finally {
     release();
-    if (accountMutationLocks.get(accountId) === queued) {
-      accountMutationLocks.delete(accountId);
+    if (accountLifecycleLock === queued) {
+      accountLifecycleLock = Promise.resolve();
     }
   }
 }

--- a/src/accounts/account_directory.ts
+++ b/src/accounts/account_directory.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { withCredentialGenerationLock } from "./credential_generation_lock.js";
 import { AccountModelPreferences } from "./model_preferences.js";
 import type { CredentialStore, SecretCredential } from "./credential_store.js";
 import {
@@ -97,7 +98,7 @@ export class AccountDirectory {
     const environment = resolveGitHubEnvironment(input.host);
     const userId = canonicalUserId(input.userId);
     const accountId = formatAccountId(environment.host, userId);
-    return await withAccountLifecycleLock(async () => {
+    return await withAccountLifecycleLock(() => withCredentialGenerationLock(accountId, async () => {
       const existing = this.readAccount(accountId);
       const activating = existing === undefined || existing.credential_state !== "active";
       if (activating && this.activeCount() >= this.maxAuthenticated) {
@@ -156,11 +157,11 @@ export class AccountDirectory {
 
       await this.credentials.prune(this.activeCredentialReferences());
       return this.bind(accountId);
-    });
+    }));
   }
 
   async remove(accountId: AccountId, expectedRevision: number): Promise<AccountSummary> {
-    return await withAccountLifecycleLock(() => this.removeUnlocked(accountId, expectedRevision));
+    return await withAccountLifecycleLock(() => withCredentialGenerationLock(accountId, () => this.removeUnlocked(accountId, expectedRevision)));
   }
 
   private async removeUnlocked(accountId: AccountId, expectedRevision: number): Promise<AccountSummary> {
@@ -204,7 +205,7 @@ export class AccountDirectory {
         "SELECT account_id, revision FROM accounts WHERE credential_state = 'removing'",
       ).all() as Array<{ account_id: string; revision: number }>;
       for (const row of removing) {
-        await this.removeUnlocked(row.account_id, row.revision);
+        await withCredentialGenerationLock(row.account_id, () => this.removeUnlocked(row.account_id, row.revision));
       }
       await this.credentials.prune(this.activeCredentialReferences());
     });

--- a/src/accounts/account_directory.ts
+++ b/src/accounts/account_directory.ts
@@ -169,7 +169,7 @@ export class AccountDirectory {
     if (row === undefined) {
       throw new AccountDirectoryError("not_found", "account not found");
     }
-    if (row.revision !== expectedRevision) {
+    if (row.credential_state !== "removing" && row.revision !== expectedRevision) {
       throw new AccountDirectoryError("revision_conflict", "account revision conflict");
     }
     if (row.credential_state === "removed") {

--- a/src/accounts/account_directory.ts
+++ b/src/accounts/account_directory.ts
@@ -100,6 +100,9 @@ export class AccountDirectory {
     const accountId = formatAccountId(environment.host, userId);
     return await withAccountLifecycleLock(() => withCredentialGenerationLock(accountId, async () => {
       const existing = this.readAccount(accountId);
+      if (existing?.credential_state === "removing") {
+        throw new AccountDirectoryError("revision_conflict", "account removal is in progress");
+      }
       const activating = existing === undefined || existing.credential_state !== "active";
       if (activating && this.activeCount() >= this.maxAuthenticated) {
         throw new AccountDirectoryError("capacity", "authenticated account capacity reached");

--- a/src/accounts/account_directory.ts
+++ b/src/accounts/account_directory.ts
@@ -100,59 +100,59 @@ export class AccountDirectory {
     if (activating && this.activeCount() >= this.maxAuthenticated) {
       throw new AccountDirectoryError("capacity", "authenticated account capacity reached");
     }
+    const previousCredentialReferences = this.activeCredentialReferences();
     const generation = (existing?.credential_generation ?? 0) + 1;
     const secret = { ...input.secret, generation };
     await this.credentials.putGeneration(accountId, generation, secret);
 
     const now = this.nowMs();
-    if (existing === undefined) {
-      this.database.prepare(
-        `INSERT INTO accounts (
-           account_id, revision, normalized_host, numeric_user_id, environment_kind,
-           login, display_name, authenticated_at_ms, credential_generation, credential_state,
-           created_at_ms, updated_at_ms
-         ) VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)`,
-      ).run(
-        accountId,
-        environment.host,
-        userId,
-        environment.kind,
-        input.login ?? null,
-        input.displayName ?? null,
-        now,
-        generation,
-        now,
-        now,
-      );
-    } else {
-      this.database.prepare(
-        `UPDATE accounts SET
-           revision = revision + 1,
-           login = ?,
-           display_name = ?,
-           authenticated_at_ms = ?,
-           credential_generation = ?,
-           credential_state = 'active',
-           updated_at_ms = ?
-         WHERE account_id = ?`,
-      ).run(input.login ?? existing.login, input.displayName ?? existing.display_name, now, generation, now, accountId);
+    try {
+      this.database.transaction(() => {
+        if (existing === undefined) {
+          this.database.prepare(
+            `INSERT INTO accounts (
+               account_id, revision, normalized_host, numeric_user_id, environment_kind,
+               login, display_name, authenticated_at_ms, credential_generation, credential_state,
+               created_at_ms, updated_at_ms
+             ) VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)`,
+          ).run(
+            accountId,
+            environment.host,
+            userId,
+            environment.kind,
+            input.login ?? null,
+            input.displayName ?? null,
+            now,
+            generation,
+            now,
+            now,
+          );
+        } else {
+          this.database.prepare(
+            `UPDATE accounts SET
+               revision = revision + 1,
+               login = ?,
+               display_name = ?,
+               authenticated_at_ms = ?,
+               credential_generation = ?,
+               credential_state = 'active',
+               updated_at_ms = ?
+             WHERE account_id = ?`,
+          ).run(input.login ?? existing.login, input.displayName ?? existing.display_name, now, generation, now, accountId);
+        }
+
+        if (this.readPrefs().default_account_id === null) {
+          this.database.prepare(
+            "UPDATE gateway_preferences SET default_account_id = ?, revision = revision + 1, updated_at_ms = ? WHERE singleton_id = 1",
+          ).run(accountId, now);
+        }
+      })();
+    } catch (error: unknown) {
+      await this.credentials.prune(previousCredentialReferences);
+      throw error;
     }
 
-    if (this.readPrefs().default_account_id === null) {
-      this.database.prepare(
-        "UPDATE gateway_preferences SET default_account_id = ?, revision = revision + 1, updated_at_ms = ? WHERE singleton_id = 1",
-      ).run(accountId, now);
-    }
-
-    const references = new Map<AccountId, number>();
-    const active = this.database.prepare(
-      "SELECT account_id, credential_generation FROM accounts WHERE credential_state = 'active' AND credential_generation IS NOT NULL",
-    ).all() as Array<{ account_id: string; credential_generation: number }>;
-    for (const row of active) {
-      references.set(row.account_id, row.credential_generation);
-    }
-    references.set(accountId, generation);
-    await this.credentials.prune(references);
+    await this.credentials.prune(this.activeCredentialReferences());
     return this.bind(accountId);
   }
 
@@ -240,6 +240,13 @@ export class AccountDirectory {
       "SELECT COUNT(*) AS count FROM accounts WHERE credential_state = 'active'",
     ).get() as { count: number };
     return row.count;
+  }
+
+  private activeCredentialReferences(): ReadonlyMap<AccountId, number> {
+    const active = this.database.prepare(
+      "SELECT account_id, credential_generation FROM accounts WHERE credential_state = 'active' AND credential_generation IS NOT NULL",
+    ).all() as Array<{ account_id: string; credential_generation: number }>;
+    return new Map(active.map((row) => [row.account_id, row.credential_generation]));
   }
 
   private readPrefs(): { revision: number; default_account_id: string | null } {

--- a/src/accounts/credential_generation_lock.ts
+++ b/src/accounts/credential_generation_lock.ts
@@ -1,0 +1,57 @@
+export async function withCredentialGenerationLock<T>(
+  accountId: string,
+  work: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const previous = locks.get(accountId) ?? Promise.resolve();
+  let release: () => void = () => undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => current);
+  locks.set(accountId, queued);
+  try {
+    await waitForPrevious(previous, signal);
+  } catch (error: unknown) {
+    release();
+    void queued.finally(() => {
+      if (locks.get(accountId) === queued) {
+        locks.delete(accountId);
+      }
+    });
+    throw error;
+  }
+  try {
+    return await work();
+  } finally {
+    release();
+    if (locks.get(accountId) === queued) {
+      locks.delete(accountId);
+    }
+  }
+}
+
+const locks = new Map<string, Promise<void>>();
+
+async function waitForPrevious(previous: Promise<void>, signal: AbortSignal | undefined): Promise<void> {
+  throwIfAborted(signal);
+  if (signal === undefined) {
+    await previous;
+    return;
+  }
+  let removeAbortListener = (): void => undefined;
+  await Promise.race([
+    previous,
+    new Promise<void>((_resolve, reject) => {
+      const onAbort = (): void => reject(new DOMException("aborted", "AbortError"));
+      signal.addEventListener("abort", onAbort, { once: true });
+      removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+    }),
+  ]).finally(removeAbortListener);
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) {
+    throw new DOMException("aborted", "AbortError");
+  }
+}

--- a/src/copilot/token_refresh.ts
+++ b/src/copilot/token_refresh.ts
@@ -1,5 +1,6 @@
 import type { BoundAccount } from "../accounts/account_directory.js";
 import type { CredentialStore, SecretCredential } from "../accounts/credential_store.js";
+import { withCredentialGenerationLock } from "../accounts/credential_generation_lock.js";
 
 export const REFRESH_SKEW_MS = 60_000;
 
@@ -10,37 +11,6 @@ export class TokenRefreshError extends Error {
     super(message);
     this.name = "TokenRefreshError";
     this.code = code;
-  }
-}
-
-const locks = new Map<string, Promise<void>>();
-
-export async function withAccountLock(accountId: string, work: () => Promise<void>, signal?: AbortSignal): Promise<void> {
-  const previous = locks.get(accountId) ?? Promise.resolve();
-  let release: () => void = () => undefined;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queued = previous.then(() => current);
-  locks.set(accountId, queued);
-  try {
-    await waitForPrevious(previous, signal);
-  } catch (error: unknown) {
-    release();
-    void queued.finally(() => {
-      if (locks.get(accountId) === queued) {
-        locks.delete(accountId);
-      }
-    });
-    throw error;
-  }
-  try {
-    await work();
-  } finally {
-    release();
-    if (locks.get(accountId) === queued) {
-      locks.delete(accountId);
-    }
   }
 }
 
@@ -71,7 +41,7 @@ export async function getValidToken(
   if (account.environment.kind === "ghes") {
     return current.githubToken;
   }
-  await withAccountLock(account.accountId, async () => {
+  await withCredentialGenerationLock(account.accountId, async () => {
     throwIfAborted(signal);
     const again = await store.readGeneration(account.accountId, generation);
     throwIfAborted(signal);
@@ -96,23 +66,6 @@ export async function getValidToken(
     throw new TokenRefreshError("missing", "copilot token missing");
   }
   return current.copilotToken;
-}
-
-async function waitForPrevious(previous: Promise<void>, signal: AbortSignal | undefined): Promise<void> {
-  throwIfAborted(signal);
-  if (signal === undefined) {
-    await previous;
-    return;
-  }
-  let removeAbortListener = (): void => undefined;
-  await Promise.race([
-    previous,
-    new Promise<void>((_resolve, reject) => {
-      const onAbort = (): void => reject(new DOMException("aborted", "AbortError"));
-      signal.addEventListener("abort", onAbort, { once: true });
-      removeAbortListener = () => signal.removeEventListener("abort", onAbort);
-    }),
-  ]).finally(removeAbortListener);
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {

--- a/tests/refactor/unit/account_identity.test.ts
+++ b/tests/refactor/unit/account_identity.test.ts
@@ -15,6 +15,7 @@ import { closeDatabase, openDatabase } from "../../../src/persistence/database.j
 import { embedMigration } from "../../../src/persistence/migrations.js";
 import { migration as runtimeConfigMigration } from "../../../src/persistence/migrations/001_runtime_config.js";
 import { migration as accountsMigration } from "../../../src/persistence/migrations/010_accounts.js";
+import { getValidToken } from "../../../src/copilot/token_refresh.js";
 
 const nowMs = (): number => 1_700_000_000_000;
 
@@ -386,6 +387,48 @@ describe("RM-06 account directory", () => {
       });
     } finally {
       closeDatabase(database);
+    }
+  });
+
+  it("serializes relogin with token refresh so old generations cannot be resurrected", async () => {
+    const { directory: accounts, credentials, close } = await directory();
+    let releaseRefresh: () => void = () => undefined;
+    let refreshStarted = false;
+    try {
+      const bound = await accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "old" },
+      });
+      const refresh = getValidToken(credentials, bound, nowMs(), async () => {
+        refreshStarted = true;
+        await new Promise<void>((resolve) => {
+          releaseRefresh = resolve;
+        });
+        return { token: "copilot-old", expiresAtMs: nowMs() + 120_000 };
+      });
+      for (let index = 0; index < 20 && !refreshStarted; index += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
+      expect(refreshStarted).toBe(true);
+
+      const relogin = accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "new" },
+      });
+      releaseRefresh();
+      await refresh;
+      const rebound = await relogin;
+
+      expect(rebound.credentialGeneration).toBe(2);
+      expect(await credentials.readGeneration(bound.accountId, 1)).toBeNull();
+      expect(await credentials.readGeneration(bound.accountId, 2)).toEqual({
+        generation: 2,
+        githubToken: "new",
+      });
+    } finally {
+      close();
     }
   });
 

--- a/tests/refactor/unit/account_identity.test.ts
+++ b/tests/refactor/unit/account_identity.test.ts
@@ -196,6 +196,40 @@ describe("RM-06 account directory", () => {
     }
   });
 
+  it("does not reactivate an account while removal cleanup is pending", async () => {
+    class FlakyRemoveCredentialStore extends MemoryCredentialStore {
+      override async removeAccount(): Promise<void> {
+        throw new Error("credential removal failed");
+      }
+    }
+
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-acc-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const credentials = new FlakyRemoveCredentialStore();
+    const accounts = new AccountDirectory(database, credentials, nowMs);
+    try {
+      const bound = await accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "secret" },
+      });
+      await expect(accounts.remove(bound.accountId, 1)).rejects.toThrow(/credential removal failed/u);
+      await expect(accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "new" },
+      })).rejects.toBeInstanceOf(AccountDirectoryError);
+      expect(accounts.list()[0]?.state).toBe("removing");
+      expect(await credentials.readGeneration(bound.accountId, 2)).toBeNull();
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
   it("reconciles removing rows on startup", async () => {
     const { directory: accounts, database, close } = await directory();
     try {

--- a/tests/refactor/unit/account_identity.test.ts
+++ b/tests/refactor/unit/account_identity.test.ts
@@ -284,6 +284,66 @@ describe("RM-06 account directory", () => {
     }
   });
 
+  it("does not let a failed activation prune another committed credential", async () => {
+    const { directory: accounts, credentials, database, close } = await directory();
+    try {
+      database.prepare(
+        "CREATE TRIGGER fail_user_one_insert BEFORE INSERT ON accounts WHEN NEW.numeric_user_id = '1' BEGIN SELECT RAISE(ABORT, 'account insert failed'); END",
+      ).run();
+      const other = await accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "2",
+        secret: { generation: 0, githubToken: "other" },
+      });
+      await expect(accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "failed" },
+      })).rejects.toThrow(/account insert failed/u);
+      expect(await credentials.readGeneration(other.accountId, other.credentialGeneration)).toEqual({
+        generation: 1,
+        githubToken: "other",
+      });
+      expect(await credentials.readGeneration("github.com/1", 1)).toBeNull();
+    } finally {
+      close();
+    }
+  });
+
+  it("serializes concurrent same-account activation across generation pruning", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-acc-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const credentials = new MemoryCredentialStore();
+    const accounts = new AccountDirectory(database, credentials, nowMs);
+    try {
+      const first = accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "first" },
+      });
+      const second = accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "second" },
+      });
+      const settled = await Promise.allSettled([first, second]);
+      expect(settled.filter((result) => result.status === "fulfilled")).toHaveLength(2);
+      const bound = await accounts.bindDefault();
+      expect(bound.credentialGeneration).toBe(2);
+      expect(await credentials.readGeneration(bound.accountId, 1)).toBeNull();
+      expect(await credentials.readGeneration(bound.accountId, 2)).toEqual({
+        generation: 2,
+        githubToken: "second",
+      });
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
   it("marks missing preferred models invalid without choosing another", async () => {
     const { directory: accounts, close } = await directory();
     try {

--- a/tests/refactor/unit/account_identity.test.ts
+++ b/tests/refactor/unit/account_identity.test.ts
@@ -156,6 +156,44 @@ describe("RM-06 account directory", () => {
     }
   });
 
+  it("retries removing cleanup with the original revision after credential removal fails", async () => {
+    class FlakyRemoveCredentialStore extends MemoryCredentialStore {
+      private failures = 1;
+
+      override async removeAccount(accountId: string): Promise<void> {
+        if (this.failures > 0) {
+          this.failures -= 1;
+          throw new Error("credential removal failed");
+        }
+        await super.removeAccount(accountId);
+      }
+    }
+
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-acc-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const credentials = new FlakyRemoveCredentialStore();
+    const accounts = new AccountDirectory(database, credentials, nowMs);
+    try {
+      const bound = await accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "secret" },
+      });
+      await expect(accounts.remove(bound.accountId, 1)).rejects.toThrow(/credential removal failed/u);
+      expect(accounts.list()[0]?.state).toBe("removing");
+
+      const removed = await accounts.remove(bound.accountId, 1);
+      expect(removed.state).toBe("removed");
+      expect(await credentials.readGeneration(bound.accountId, 1)).toBeNull();
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
   it("reconciles removing rows on startup", async () => {
     const { directory: accounts, database, close } = await directory();
     try {

--- a/tests/refactor/unit/account_identity.test.ts
+++ b/tests/refactor/unit/account_identity.test.ts
@@ -184,9 +184,11 @@ describe("RM-06 account directory", () => {
         secret: { generation: 0, githubToken: "secret" },
       });
       await expect(accounts.remove(bound.accountId, 1)).rejects.toThrow(/credential removal failed/u);
-      expect(accounts.list()[0]?.state).toBe("removing");
+      const removing = accounts.list()[0];
+      expect(removing?.state).toBe("removing");
+      expect(removing?.revision).toBe(2);
 
-      const removed = await accounts.remove(bound.accountId, 1);
+      const removed = await accounts.remove(bound.accountId, 2);
       expect(removed.state).toBe("removed");
       expect(await credentials.readGeneration(bound.accountId, 1)).toBeNull();
     } finally {

--- a/tests/refactor/unit/account_identity.test.ts
+++ b/tests/refactor/unit/account_identity.test.ts
@@ -310,6 +310,51 @@ describe("RM-06 account directory", () => {
     }
   });
 
+  it("rolls back account row and prunes credential when default preference update fails", async () => {
+    const { directory: accounts, credentials, database, close } = await directory();
+    try {
+      database.prepare(
+        "CREATE TRIGGER fail_default_update BEFORE UPDATE ON gateway_preferences BEGIN SELECT RAISE(ABORT, 'default update failed'); END",
+      ).run();
+      await expect(accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "failed" },
+      })).rejects.toThrow(/default update failed/u);
+      expect(accounts.list()).toEqual([]);
+      expect(await credentials.readGeneration("github.com/1", 1)).toBeNull();
+    } finally {
+      close();
+    }
+  });
+
+  it("serializes different-account activation across capacity and prune", async () => {
+    const { directory: accounts, credentials, close } = await directory(1);
+    try {
+      const first = accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "one" },
+      });
+      const second = accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "2",
+        secret: { generation: 0, githubToken: "two" },
+      });
+      const settled = await Promise.allSettled([first, second]);
+      expect(settled.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+      const active = accounts.list();
+      expect(active).toHaveLength(1);
+      const account = active[0];
+      expect(account).toBeDefined();
+      if (account !== undefined) {
+        expect(await credentials.readGeneration(account.accountId, 1)).not.toBeNull();
+      }
+    } finally {
+      close();
+    }
+  });
+
   it("serializes concurrent same-account activation across generation pruning", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-acc-"));
     const database = openDatabase({

--- a/tests/refactor/unit/account_identity.test.ts
+++ b/tests/refactor/unit/account_identity.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { AccountDirectory, AccountDirectoryError } from "../../../src/accounts/account_directory.js";
-import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
+import { MemoryCredentialStore, type CredentialStore, type SecretCredential } from "../../../src/accounts/credential_store.js";
 import {
   canonicalUserId,
   formatAccountId,
@@ -201,6 +201,86 @@ describe("RM-06 account directory", () => {
       });
     } finally {
       close();
+    }
+  });
+
+  it("prunes a newly written credential if account activation rolls back", async () => {
+    const { directory: accounts, credentials, database, close } = await directory();
+    try {
+      database.prepare(
+        "CREATE TRIGGER fail_account_insert BEFORE INSERT ON accounts BEGIN SELECT RAISE(ABORT, 'account insert failed'); END",
+      ).run();
+      await expect(accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "orphan" },
+      })).rejects.toThrow(/account insert failed/u);
+      expect(await credentials.readGeneration("github.com/1", 1)).toBeNull();
+      expect(accounts.list()).toEqual([]);
+    } finally {
+      close();
+    }
+  });
+
+  it("keeps the previous active generation if relogin activation rolls back", async () => {
+    const { directory: accounts, credentials, database, close } = await directory();
+    try {
+      const first = await accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "old" },
+      });
+      database.prepare(
+        "CREATE TRIGGER fail_account_update BEFORE UPDATE ON accounts BEGIN SELECT RAISE(ABORT, 'account update failed'); END",
+      ).run();
+      await expect(accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "new" },
+      })).rejects.toThrow(/account update failed/u);
+      expect(await credentials.readGeneration(first.accountId, 1)).toEqual({
+        generation: 1,
+        githubToken: "old",
+      });
+      expect(await credentials.readGeneration(first.accountId, 2)).toBeNull();
+      expect((await accounts.bindDefault()).credentialGeneration).toBe(1);
+    } finally {
+      close();
+    }
+  });
+
+  it("does not mutate account state when the credential write fails first", async () => {
+    class FailingCredentialStore implements CredentialStore {
+      async readGeneration(): Promise<SecretCredential | null> {
+        return null;
+      }
+
+      async putGeneration(): Promise<void> {
+        throw new Error("credential write failed");
+      }
+
+      async removeAccount(): Promise<void> {}
+
+      async prune(): Promise<void> {}
+    }
+
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-acc-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const accounts = new AccountDirectory(database, new FailingCredentialStore(), nowMs);
+    try {
+      await expect(accounts.upsertAuthenticated({
+        host: "github.com",
+        userId: "1",
+        secret: { generation: 0, githubToken: "new" },
+      })).rejects.toThrow(/credential write failed/u);
+      expect(accounts.list()).toEqual([]);
+      await expect(accounts.bindDefault()).rejects.toBeInstanceOf(AccountDirectoryError);
+    } finally {
+      closeDatabase(database);
     }
   });
 


### PR DESCRIPTION
## Summary
- Makes account activation SQLite writes transactional and prunes failed credential generations from current durable account state.
- Serializes account/credential lifecycle mutations and token refresh writes using a shared credential-generation lock.
- Preserves remove CAS semantics while allowing retries with the durable removing revision and preventing relogin during pending removal cleanup.
- Adds failure-injection and concurrency tests for insert/update/default update failure, credential write failure, cross-account capacity/prune, same-account relogin, token refresh, and remove retry paths.

Closes #45

## Validation
- `npm run typecheck:refactor`
- `npm run lint:refactor`
- `npm run test:refactor -- tests/refactor/unit/account_identity.test.ts tests/refactor/integration/copilot_transport.test.ts tests/refactor/integration/credential_store_permissions.test.ts tests/refactor/integration/device_flow.test.ts`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check origin/refactor...HEAD`

## Code review
- Standards review: no blockers.
- Spec review: no blockers.