### PR TITLE
Verify Windows credential ACL protection

### DIFF
--- a/src/accounts/credential_store.ts
+++ b/src/accounts/credential_store.ts
@@ -139,6 +139,7 @@ export function ensureProtectedDirectory(directory: string): void {
   assertOwnedByCurrentUser(stat);
   if (process.platform === "win32") {
     restrictWindowsAcl(directory);
+    assertWindowsAclCurrentUserOnly(directory);
     return;
   }
   chmodSync(directory, 0o700);
@@ -152,6 +153,9 @@ function assertProtectedFile(filePath: string): void {
   assertOwnedByCurrentUser(stat);
   if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
     throw new Error("credential file permissions must be 0600");
+  }
+  if (process.platform === "win32") {
+    assertWindowsAclCurrentUserOnly(filePath);
   }
 }
 
@@ -167,15 +171,64 @@ function assertOwnedByCurrentUser(stat: { uid: number }): void {
 function protectFile(filePath: string): void {
   if (process.platform === "win32") {
     restrictWindowsAcl(filePath);
+    assertWindowsAclCurrentUserOnly(filePath);
     return;
   }
   chmodSync(filePath, 0o600);
 }
 
 function restrictWindowsAcl(target: string): void {
-  execFileSync("icacls", [target, "/inheritance:r", "/grant:r", `${process.env.USERNAME ?? ""}:(F)`], {
-    stdio: "ignore",
-  });
+  const current = currentWindowsIdentity();
+  const grant = isDirectory(target) ? `*${current.sid}:(OI)(CI)(F)` : `*${current.sid}:(F)`;
+  execFileSync("icacls", [target, "/inheritance:r", "/grant:r", grant], { stdio: "ignore" });
+  for (const identity of windowsAclIdentities(target)) {
+    if (!isCurrentWindowsIdentity(identity, current)) {
+      execFileSync("icacls", [target, "/remove:g", identity], { stdio: "ignore" });
+    }
+  }
+}
+
+function assertWindowsAclCurrentUserOnly(target: string): void {
+  const current = currentWindowsIdentity();
+  const identities = windowsAclIdentities(target);
+  if (identities.length !== 1 || !isCurrentWindowsIdentity(identities[0] ?? "", current)) {
+    throw new Error("credential ACL must be restricted to the current user");
+  }
+}
+
+function currentWindowsIdentity(): { readonly name: string; readonly sid: string } {
+  const csv = execFileSync("whoami", ["/user", "/fo", "csv", "/nh"], { encoding: "utf8" }).trim();
+  const match = /^"([^"]+)","([^"]+)"$/u.exec(csv);
+  if (match === null || match[1] === undefined || match[2] === undefined) {
+    throw new Error("unable to resolve current Windows identity");
+  }
+  return { name: match[1].toLowerCase(), sid: match[2].toLowerCase() };
+}
+
+function windowsAclIdentities(target: string): readonly string[] {
+  const output = execFileSync("icacls", [target], { encoding: "utf8" });
+  const identities: string[] = [];
+  for (const rawLine of output.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("Successfully processed") || line.startsWith("Failed processing")) {
+      continue;
+    }
+    const entry = rawLine.startsWith(target) ? rawLine.slice(target.length).trim() : line;
+    const separator = entry.indexOf(":(");
+    if (separator > 0) {
+      identities.push(entry.slice(0, separator));
+    }
+  }
+  return identities;
+}
+
+function isCurrentWindowsIdentity(identity: string, current: { readonly name: string; readonly sid: string }): boolean {
+  const normalized = identity.toLowerCase();
+  return normalized === current.name || normalized === current.sid;
+}
+
+function isDirectory(target: string): boolean {
+  return lstatSync(target).isDirectory();
 }
 
 function isNotFound(error: unknown): boolean {

--- a/tests/refactor/integration/credential_store_permissions.test.ts
+++ b/tests/refactor/integration/credential_store_permissions.test.ts
@@ -1,4 +1,5 @@
 import { lstatSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -16,7 +17,10 @@ describe("RM-06 credential file protection", () => {
     await store.putGeneration("github.com/1", 1, { generation: 1, githubToken: "tok" });
     const stat = lstatSync(filePath);
     expect(stat.isSymbolicLink()).toBe(false);
-    if (process.platform !== "win32") {
+    if (process.platform === "win32") {
+      expect(windowsAclPrincipals(filePath)).toHaveLength(1);
+      expect(windowsAclPrincipals(dir)).toHaveLength(1);
+    } else {
       expect(stat.mode & 0o777).toBe(0o600);
       expect(lstatSync(dir).mode & 0o777).toBe(0o700);
     }
@@ -24,6 +28,18 @@ describe("RM-06 credential file protection", () => {
     expect(read?.githubToken).toBe("tok");
     await store.removeAccount("github.com/1");
     expect(await store.readGeneration("github.com/1", 1)).toBeNull();
+  });
+
+  it("rejects broad Windows credential ACLs", async () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-cred-"));
+    const filePath = path.join(dir, "credentials.json");
+    const store = new FileCredentialStore(filePath);
+    await store.putGeneration("github.com/1", 1, { generation: 1, githubToken: "tok" });
+    execFileSync("icacls", [filePath, "/grant", "*S-1-1-0:(R)"], { stdio: "ignore" });
+    await expect(store.readGeneration("github.com/1", 1)).rejects.toThrow();
   });
 
   it("rejects a symlink credential directory", async () => {
@@ -37,6 +53,23 @@ describe("RM-06 credential file protection", () => {
     symlinkSync(real, link);
     expect(() => ensureProtectedDirectory(link)).toThrow(/symlink/u);
   });
+
+  function windowsAclPrincipals(target: string): readonly string[] {
+    const output = execFileSync("icacls", [target], { encoding: "utf8" });
+    const principals: string[] = [];
+    for (const rawLine of output.split(/\r?\n/u)) {
+      const line = rawLine.trim();
+      if (line.length === 0 || line.startsWith("Successfully processed") || line.startsWith("Failed processing")) {
+        continue;
+      }
+      const entry = rawLine.startsWith(target) ? rawLine.slice(target.length).trim() : line;
+      const separator = entry.indexOf(":(");
+      if (separator > 0) {
+        principals.push(entry.slice(0, separator));
+      }
+    }
+    return principals;
+  }
 
   it("does not persist secrets into sqlite-shaped documents beyond the protected file", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-cred-"));


### PR DESCRIPTION
## Summary
- Restricts Windows credential file and directory ACLs to the current user and verifies the effective ACL after protection.
- Fails closed when broad/inherited principals can read the credential path.
- Adds Windows-gated ACL tests while preserving Unix permission assertions.

Closes #46

## Validation
- `npm run typecheck:refactor`
- `npm run lint:refactor`
- `npm run test:refactor -- tests/refactor/integration/credential_store_permissions.test.ts`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check origin/refactor...HEAD`

## Code review
- Standards review: no blockers.
- Spec review: no blockers.