### PR TITLE
Canonicalize GitHub host default ports

### DIFF
--- a/src/accounts/github_environment.ts
+++ b/src/accounts/github_environment.ts
@@ -49,7 +49,7 @@ export function normalizeGitHubHost(input: string): string {
     throw new GitHubEnvironmentError("GitHub host is not a valid domain");
   }
 
-  if (portPart === undefined || portPart === "443") {
+  if (portPart === undefined) {
     return ascii;
   }
   if (!/^[0-9]+$/u.test(portPart)) {
@@ -58,6 +58,9 @@ export function normalizeGitHubHost(input: string): string {
   const port = Number.parseInt(portPart, 10);
   if (port < 1 || port > 65_535) {
     throw new GitHubEnvironmentError("GitHub host port must be in 1..65535");
+  }
+  if (port === 443) {
+    return ascii;
   }
   return `${ascii}:${port}`;
 }

--- a/tests/refactor/unit/account_identity.test.ts
+++ b/tests/refactor/unit/account_identity.test.ts
@@ -44,11 +44,18 @@ describe("RM-06 GitHub host and account id", () => {
   it("normalizes host case, trailing dot, default port, and IDNA", () => {
     expect(normalizeGitHubHost("GitHub.COM.")).toBe("github.com");
     expect(normalizeGitHubHost("github.com:443")).toBe("github.com");
+    expect(normalizeGitHubHost("github.com:0443")).toBe("github.com");
+    expect(resolveGitHubEnvironment("github.com:0443").kind).toBe("github.com");
     expect(normalizeGitHubHost("ghe.example.com:8443")).toBe("ghe.example.com:8443");
+    expect(normalizeGitHubHost("ghe.example.com:0443")).toBe("ghe.example.com");
+    expect(normalizeGitHubHost("ghe.example.com:08443")).toBe("ghe.example.com:8443");
     expect(normalizeGitHubHost("bücher.example")).toBe(normalizeGitHubHost("xn--bcher-kva.example"));
     expect(() => normalizeGitHubHost("github.com/path")).toThrow(GitHubEnvironmentError);
     expect(() => normalizeGitHubHost("https://github.com")).toThrow(GitHubEnvironmentError);
     expect(() => normalizeGitHubHost("user@github.com")).toThrow(GitHubEnvironmentError);
+    expect(() => normalizeGitHubHost("github.com:abc")).toThrow(GitHubEnvironmentError);
+    expect(() => normalizeGitHubHost("github.com:0")).toThrow(GitHubEnvironmentError);
+    expect(() => normalizeGitHubHost("github.com:65536")).toThrow(GitHubEnvironmentError);
     expect(canonicalUserId("00789")).toBe("789");
     expect(formatAccountId("github.com", "00789")).toBe("github.com/789");
   });


### PR DESCRIPTION
## Summary
- Parses host ports before default-port handling so decimal 443 forms canonicalize consistently.
- Keeps non-default GHES ports canonicalized and preserved.
- Adds coverage for github.com:0443, GHES leading-zero non-default ports, and invalid ports.

Closes #47

## Validation
- `npm run typecheck:refactor`
- `npm run lint:refactor`
- `npm run test:refactor -- tests/refactor/unit/account_identity.test.ts`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check origin/refactor...HEAD`

## Code review
- Standards review: no blockers.
- Spec review: no blockers.