### PR TITLE
Harden CAPI model-list transport failures

### DIFF
--- a/src/copilot/models_source.ts
+++ b/src/copilot/models_source.ts
@@ -33,20 +33,24 @@ export class HttpCopilotModelsSource implements CopilotModelsSource {
 
   async fetch(accountId: string, signal: AbortSignal): Promise<CapiModelsResponse> {
     const { token, endpoint } = await this.resolve(accountId, signal);
-    const response = await getWithRedirects(this.fetchImpl, capiModelsUrl(endpoint), token, signal, Date.now() + this.limits.totalTimeoutMs, this.limits);
+    const deadlineMs = Date.now() + this.limits.totalTimeoutMs;
+    const response = await getWithRedirects(this.fetchImpl, capiModelsUrl(endpoint), token, signal, deadlineMs, this.limits);
     if (response.status < 200 || response.status >= 300) {
       await cancelResponseBody(response);
       const status = response.status >= 300 && response.status < 400 ? 502 : response.status;
       throw new CapiFetchError(status, response.status === 429 ? validRetryAfter(response.headers) : undefined);
     }
     try {
-      const bytes = await readLimitedBody(response, signal, Date.now() + this.limits.totalTimeoutMs, this.limits);
+      const bytes = await readLimitedBody(response, signal, deadlineMs, this.limits);
       return JSON.parse(new TextDecoder().decode(bytes)) as CapiModelsResponse;
     } catch (error: unknown) {
-      if (error instanceof CapiFetchError) {
+      await cancelResponseBody(response);
+      if (signal.aborted) {
+        throw new DOMException("aborted", "AbortError");
+      }
+      if (error instanceof CapiFetchError || isAbortError(error)) {
         throw error;
       }
-      await cancelResponseBody(response);
       throw new CapiFetchError(502);
     }
   }
@@ -71,7 +75,13 @@ async function getWithRedirects(
     if (location === null) {
       return response;
     }
-    const next = new URL(location, current).toString();
+    let next: string;
+    try {
+      next = new URL(location, current).toString();
+    } catch (_error: unknown) {
+      await cancelResponseBody(response);
+      throw new CapiFetchError(502);
+    }
     headers = stripSecretsOnRedirect(current, next, headers);
     await cancelResponseBody(response);
     current = next;
@@ -164,6 +174,11 @@ function timeoutPromise<T>(ms: number, signal: AbortSignal): {
   const promise = new Promise<T>((_resolve, reject) => {
     rejectTimeout = reject;
   });
+  const onAbort = (): void => {
+    controller.abort();
+    rejectTimeout(new DOMException("aborted", "AbortError"));
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
   const timer = setTimeout(() => {
     timedOut = true;
     controller.abort();
@@ -172,7 +187,10 @@ function timeoutPromise<T>(ms: number, signal: AbortSignal): {
   return {
     signal: combined,
     promise,
-    clear: () => clearTimeout(timer),
+    clear: () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    },
     timedOut: () => timedOut,
   };
 }
@@ -183,6 +201,10 @@ function remainingMs(deadlineMs: number): number {
 
 async function cancelResponseBody(response: Response): Promise<void> {
   await response.body?.cancel().catch(() => undefined);
+}
+
+function isAbortError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "name" in error && error.name === "AbortError";
 }
 
 function validRetryAfter(headers: Headers): string | undefined {

--- a/src/copilot/models_source.ts
+++ b/src/copilot/models_source.ts
@@ -350,7 +350,7 @@ function validRetryAfter(headers: Headers): string | undefined {
   if (/^\d+$/u.test(value)) {
     return value;
   }
-  if (/^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT$/u.test(value) && !Number.isNaN(Date.parse(value))) {
+  if (/^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/u.test(value) && !Number.isNaN(Date.parse(value))) {
     return value;
   }
   return undefined;

--- a/src/copilot/models_source.ts
+++ b/src/copilot/models_source.ts
@@ -4,7 +4,7 @@ import { copilotHeaders } from "./identity.js";
 import { capiModelsUrl, type CapiModelsResponse, type CopilotModelsSource } from "./model_catalog.js";
 import { MAX_REDIRECTS, stripSecretsOnRedirect } from "./endpoint_discovery.js";
 
-export type CapiFailureKind = "upstream_http" | "upstream_timeout" | "invalid_upstream_response";
+export type CapiFailureKind = "upstream_http" | "upstream_timeout" | "upstream_network" | "invalid_upstream_response";
 
 interface CapiTransportLimits {
   readonly connectTimeoutMs: number;
@@ -132,7 +132,10 @@ async function fetchWithTimeout(
     if (timeout.timedOut()) {
       throw new CapiFetchError(502, undefined, "upstream_timeout");
     }
-    throw error;
+    if (isAbortError(error)) {
+      throw error;
+    }
+    throw new CapiFetchError(502, undefined, "upstream_network");
   } finally {
     timeout.clear();
   }
@@ -173,7 +176,10 @@ async function undiciWithTimeout(
     if (timeout.timedOut() || isUndiciTimeout(error)) {
       throw new CapiFetchError(502, undefined, "upstream_timeout");
     }
-    throw error;
+    if (isAbortError(error)) {
+      throw error;
+    }
+    throw new CapiFetchError(502, undefined, "upstream_network");
   } finally {
     timeout.clear();
   }

--- a/src/copilot/models_source.ts
+++ b/src/copilot/models_source.ts
@@ -1,3 +1,5 @@
+import type { IncomingHttpHeaders } from "node:http";
+import { Agent, errors as undiciErrors, request as undiciRequest } from "undici";
 import { copilotHeaders } from "./identity.js";
 import { capiModelsUrl, type CapiModelsResponse, type CopilotModelsSource } from "./model_catalog.js";
 import { MAX_REDIRECTS, stripSecretsOnRedirect } from "./endpoint_discovery.js";
@@ -67,9 +69,60 @@ async function getWithRedirects(
   let current = url;
   let headers = new Headers({ ...copilotHeaders(), authorization: `Bearer ${token}`, "content-type": "application/json" });
   for (let attempt = 0; attempt <= MAX_REDIRECTS; attempt += 1) {
-    const response = await fetchWithTimeout(fetchImpl, current, headers, signal, deadlineMs, limits);
+    const response = fetchImpl === fetch
+      ? await undiciWithTimeout(current, headers, signal, deadlineMs, limits)
+      : await fetchWithTimeout(fetchImpl, current, headers, signal, deadlineMs, limits);
     if (response.status < 300 || response.status >= 400) {
       return response;
+    }
+
+    async function undiciWithTimeout(
+      url: string,
+      headers: Headers,
+      signal: AbortSignal,
+      deadlineMs: number,
+      limits: CapiTransportLimits,
+    ): Promise<Response> {
+      const dispatcher = new Agent({
+        connectTimeout: limits.connectTimeoutMs,
+        headersTimeout: remainingMs(deadlineMs),
+        bodyTimeout: 0,
+      });
+      try {
+        const response = await undiciRequest(url, {
+          method: "GET",
+          headers: headersToRecord(headers),
+          signal,
+          dispatcher,
+        });
+        const body = response.body;
+        const iterator = body[Symbol.asyncIterator]();
+        const stream = new ReadableStream<Uint8Array>({
+          async pull(controller): Promise<void> {
+            const next = await iterator.next();
+            if (next.done === true) {
+              controller.close();
+              await dispatcher.close().catch(() => undefined);
+              return;
+            }
+            controller.enqueue(next.value instanceof Uint8Array ? next.value : Buffer.from(next.value));
+          },
+          async cancel(): Promise<void> {
+            body.destroy();
+            await dispatcher.close().catch(() => undefined);
+          },
+        });
+        return new Response(stream, {
+          status: response.statusCode,
+          headers: incomingHeadersToHeaders(response.headers),
+        });
+      } catch (error: unknown) {
+        await dispatcher.close().catch(() => undefined);
+        if (isUndiciTimeout(error)) {
+          throw new CapiFetchError(502);
+        }
+        throw error;
+      }
     }
     const location = response.headers.get("location");
     if (location === null) {
@@ -219,4 +272,35 @@ function validRetryAfter(headers: Headers): string | undefined {
     return value;
   }
   return undefined;
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    record[key] = value;
+  });
+  return record;
+}
+
+function incomingHeadersToHeaders(headers: IncomingHttpHeaders): Headers {
+  const result = new Headers();
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        result.append(key, item);
+      }
+      continue;
+    }
+    result.set(key, value);
+  }
+  return result;
+}
+
+function isUndiciTimeout(error: unknown): boolean {
+  return error instanceof undiciErrors.ConnectTimeoutError
+    || error instanceof undiciErrors.HeadersTimeoutError
+    || error instanceof undiciErrors.BodyTimeoutError;
 }

--- a/src/copilot/models_source.ts
+++ b/src/copilot/models_source.ts
@@ -4,10 +4,19 @@ import { copilotHeaders } from "./identity.js";
 import { capiModelsUrl, type CapiModelsResponse, type CopilotModelsSource } from "./model_catalog.js";
 import { MAX_REDIRECTS, stripSecretsOnRedirect } from "./endpoint_discovery.js";
 
+export type CapiFailureKind = "upstream_http" | "upstream_timeout" | "invalid_upstream_response";
+
 interface CapiTransportLimits {
   readonly connectTimeoutMs: number;
   readonly totalTimeoutMs: number;
   readonly bodyLimitBytes: number;
+}
+
+interface CapiHttpResponse {
+  readonly status: number;
+  readonly headers: Headers;
+  readonly body: AsyncIterable<Uint8Array>;
+  cancel(): Promise<void>;
 }
 
 const DEFAULT_CAPI_LIMITS: CapiTransportLimits = {
@@ -20,6 +29,7 @@ export class CapiFetchError extends Error {
   constructor(
     readonly status: number,
     readonly retryAfter?: string,
+    readonly failureKind: CapiFailureKind = "upstream_http",
   ) {
     super("capi fetch failed");
     this.name = "CapiFetchError";
@@ -38,22 +48,26 @@ export class HttpCopilotModelsSource implements CopilotModelsSource {
     const deadlineMs = Date.now() + this.limits.totalTimeoutMs;
     const response = await getWithRedirects(this.fetchImpl, capiModelsUrl(endpoint), token, signal, deadlineMs, this.limits);
     if (response.status < 200 || response.status >= 300) {
-      await cancelResponseBody(response);
+      await response.cancel();
       const status = response.status >= 300 && response.status < 400 ? 502 : response.status;
-      throw new CapiFetchError(status, response.status === 429 ? validRetryAfter(response.headers) : undefined);
+      throw new CapiFetchError(
+        status,
+        response.status === 429 ? validRetryAfter(response.headers) : undefined,
+        status === response.status ? "upstream_http" : "invalid_upstream_response",
+      );
     }
     try {
-      const bytes = await readLimitedBody(response, signal, deadlineMs, this.limits);
+      const bytes = await readLimitedBody(response.body, signal, deadlineMs, this.limits);
       return JSON.parse(new TextDecoder().decode(bytes)) as CapiModelsResponse;
     } catch (error: unknown) {
-      await cancelResponseBody(response);
+      await response.cancel();
       if (signal.aborted) {
         throw new DOMException("aborted", "AbortError");
       }
       if (error instanceof CapiFetchError || isAbortError(error)) {
         throw error;
       }
-      throw new CapiFetchError(502);
+      throw new CapiFetchError(502, undefined, "invalid_upstream_response");
     }
   }
 }
@@ -65,7 +79,7 @@ async function getWithRedirects(
   signal: AbortSignal,
   deadlineMs: number,
   limits: CapiTransportLimits,
-): Promise<Response> {
+): Promise<CapiHttpResponse> {
   let current = url;
   let headers = new Headers({ ...copilotHeaders(), authorization: `Bearer ${token}`, "content-type": "application/json" });
   for (let attempt = 0; attempt <= MAX_REDIRECTS; attempt += 1) {
@@ -75,58 +89,6 @@ async function getWithRedirects(
     if (response.status < 300 || response.status >= 400) {
       return response;
     }
-
-    async function undiciWithTimeout(
-      url: string,
-      headers: Headers,
-      signal: AbortSignal,
-      deadlineMs: number,
-      limits: CapiTransportLimits,
-    ): Promise<Response> {
-      const dispatcher = new Agent({
-        connectTimeout: limits.connectTimeoutMs,
-        headersTimeout: positiveTimeoutMs(deadlineMs),
-        bodyTimeout: 0,
-      });
-      const timeout = timeoutPromise<Awaited<ReturnType<typeof undiciRequest>>>(remainingMs(deadlineMs), signal);
-      try {
-        const response = await Promise.race([undiciRequest(url, {
-          method: "GET",
-          headers: headersToRecord(headers),
-          signal: timeout.signal,
-          dispatcher,
-        }), timeout.promise]);
-        const body = response.body;
-        const iterator = body[Symbol.asyncIterator]();
-        const stream = new ReadableStream<Uint8Array>({
-          async pull(controller): Promise<void> {
-            const next = await iterator.next();
-            if (next.done === true) {
-              controller.close();
-              await dispatcher.close().catch(() => undefined);
-              return;
-            }
-            controller.enqueue(next.value instanceof Uint8Array ? next.value : Buffer.from(next.value));
-          },
-          async cancel(): Promise<void> {
-            body.destroy();
-            await dispatcher.close().catch(() => undefined);
-          },
-        });
-        return new Response(stream, {
-          status: response.statusCode,
-          headers: incomingHeadersToHeaders(response.headers),
-        });
-      } catch (error: unknown) {
-        await dispatcher.close().catch(() => undefined);
-        if (isUndiciTimeout(error)) {
-          throw new CapiFetchError(502);
-        }
-        throw error;
-      } finally {
-        timeout.clear();
-      }
-    }
     const location = response.headers.get("location");
     if (location === null) {
       return response;
@@ -135,14 +97,14 @@ async function getWithRedirects(
     try {
       next = new URL(location, current).toString();
     } catch (_error: unknown) {
-      await cancelResponseBody(response);
-      throw new CapiFetchError(502);
+      await response.cancel();
+      throw new CapiFetchError(502, undefined, "invalid_upstream_response");
     }
     headers = stripSecretsOnRedirect(current, next, headers);
-    await cancelResponseBody(response);
+    await response.cancel();
     current = next;
   }
-  throw new CapiFetchError(502);
+  throw new CapiFetchError(502, undefined, "invalid_upstream_response");
 }
 
 async function fetchWithTimeout(
@@ -152,16 +114,23 @@ async function fetchWithTimeout(
   signal: AbortSignal,
   deadlineMs: number,
   limits: CapiTransportLimits,
-): Promise<Response> {
+): Promise<CapiHttpResponse> {
   const timeout = timeoutPromise<Response>(Math.min(limits.connectTimeoutMs, remainingMs(deadlineMs)), signal);
   try {
-    return await Promise.race([
+    const response = await Promise.race([
       fetchImpl(url, { method: "GET", headers, signal: timeout.signal, redirect: "manual" }),
       timeout.promise,
     ]);
+    const wrappedBody = response.body === null ? emptyBody() : createWebBody(response.body);
+    return {
+      status: response.status,
+      headers: response.headers,
+      body: wrappedBody.bytes,
+      cancel: wrappedBody.cancel,
+    };
   } catch (error: unknown) {
     if (timeout.timedOut()) {
-      throw new CapiFetchError(502);
+      throw new CapiFetchError(502, undefined, "upstream_timeout");
     }
     throw error;
   } finally {
@@ -169,43 +138,83 @@ async function fetchWithTimeout(
   }
 }
 
-async function readLimitedBody(response: Response, signal: AbortSignal, deadlineMs: number, limits: CapiTransportLimits): Promise<Uint8Array> {
-  const body = response.body;
-  if (body === null) {
-    return new Uint8Array();
+async function undiciWithTimeout(
+  url: string,
+  headers: Headers,
+  signal: AbortSignal,
+  deadlineMs: number,
+  limits: CapiTransportLimits,
+): Promise<CapiHttpResponse> {
+  const dispatcher = new Agent({
+    connectTimeout: limits.connectTimeoutMs,
+    headersTimeout: positiveTimeoutMs(deadlineMs),
+    bodyTimeout: 0,
+  });
+  const timeout = timeoutPromise<Awaited<ReturnType<typeof undiciRequest>>>(remainingMs(deadlineMs), signal);
+  try {
+    const response = await Promise.race([undiciRequest(url, {
+      method: "GET",
+      headers: headersToRecord(headers),
+      signal: timeout.signal,
+      dispatcher,
+    }), timeout.promise]);
+    const body = response.body;
+    return {
+      status: response.statusCode,
+      headers: incomingHeadersToHeaders(response.headers),
+      body: undiciBody(body, dispatcher),
+      cancel: async () => {
+        destroyUndiciBody(body);
+        await dispatcher.close().catch(() => undefined);
+      },
+    };
+  } catch (error: unknown) {
+    await dispatcher.close().catch(() => undefined);
+    if (timeout.timedOut() || isUndiciTimeout(error)) {
+      throw new CapiFetchError(502, undefined, "upstream_timeout");
+    }
+    throw error;
+  } finally {
+    timeout.clear();
   }
-  const reader = body.getReader();
+}
+
+async function readLimitedBody(
+  source: AsyncIterable<Uint8Array>,
+  signal: AbortSignal,
+  deadlineMs: number,
+  limits: CapiTransportLimits,
+): Promise<Uint8Array> {
+  const iterator = source[Symbol.asyncIterator]();
   const chunks: Uint8Array[] = [];
   let total = 0;
   try {
     for (;;) {
-      const timeout = timeoutPromise<ReadableStreamReadResult<Uint8Array>>(remainingMs(deadlineMs), signal);
-      let next: ReadableStreamReadResult<Uint8Array>;
+      const timeout = timeoutPromise<IteratorResult<Uint8Array>>(remainingMs(deadlineMs), signal);
+      let next: IteratorResult<Uint8Array>;
       try {
-        next = await Promise.race([reader.read(), timeout.promise]);
+        next = await Promise.race([iterator.next(), timeout.promise]);
       } catch (error: unknown) {
         if (timeout.timedOut()) {
-          throw new CapiFetchError(502);
+          throw new CapiFetchError(502, undefined, "upstream_timeout");
         }
         throw error;
       } finally {
         timeout.clear();
       }
-      if (next.done) {
+      if (next.done === true) {
         break;
-      }
-      if (next.value === undefined) {
-        continue;
       }
       total += next.value.byteLength;
       if (total > limits.bodyLimitBytes) {
-        void reader.cancel().catch(() => undefined);
-        throw new CapiFetchError(502);
+        void iterator.return?.().catch(() => undefined);
+        throw new CapiFetchError(502, undefined, "invalid_upstream_response");
       }
       chunks.push(next.value);
     }
-  } finally {
-    reader.releaseLock();
+  } catch (error: unknown) {
+    void iterator.return?.().catch(() => undefined);
+    throw error;
   }
 
   const bytes = new Uint8Array(total);
@@ -233,12 +242,7 @@ function timeoutPromise<T>(ms: number, signal: AbortSignal): {
   if (signal.aborted) {
     controller.abort();
     rejectTimeout(new DOMException("aborted", "AbortError"));
-    return {
-      signal: combined,
-      promise,
-      clear: () => undefined,
-      timedOut: () => false,
-    };
+    return { signal: combined, promise, clear: () => undefined, timedOut: () => false };
   }
   const onAbort = (): void => {
     controller.abort();
@@ -248,7 +252,7 @@ function timeoutPromise<T>(ms: number, signal: AbortSignal): {
   const timer = setTimeout(() => {
     timedOut = true;
     controller.abort();
-    rejectTimeout(new CapiFetchError(502));
+    rejectTimeout(new CapiFetchError(502, undefined, "upstream_timeout"));
   }, Math.max(0, ms));
   return {
     signal: combined,
@@ -261,20 +265,75 @@ function timeoutPromise<T>(ms: number, signal: AbortSignal): {
   };
 }
 
+function emptyBody(): { readonly bytes: AsyncIterable<Uint8Array>; readonly cancel: () => Promise<void> } {
+  return {
+    bytes: {
+      async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {},
+    },
+    cancel: async () => undefined,
+  };
+}
+
+function createWebBody(body: ReadableStream<Uint8Array>): { readonly bytes: AsyncIterable<Uint8Array>; readonly cancel: () => Promise<void> } {
+  const reader = body.getReader();
+  let completed = false;
+  let released = false;
+  const release = (): void => {
+    if (released) {
+      return;
+    }
+    released = true;
+    reader.releaseLock();
+  };
+  return {
+    bytes: {
+      async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+        try {
+          for (;;) {
+            const next = await reader.read();
+            if (next.done) {
+              completed = true;
+              return;
+            }
+            if (next.value !== undefined) {
+              yield next.value;
+            }
+          }
+        } finally {
+          if (!completed) {
+            void reader.cancel().catch(() => undefined);
+          }
+          release();
+        }
+      },
+    },
+    cancel: async () => {
+      await reader.cancel().catch(() => undefined);
+      release();
+    },
+  };
+}
+
+async function* undiciBody(
+  body: AsyncIterable<Uint8Array | Buffer | string> & { destroy(error?: Error): void; on(event: "error", listener: (error: Error) => void): unknown },
+  dispatcher: Agent,
+): AsyncIterable<Uint8Array> {
+  try {
+    for await (const chunk of body) {
+      yield chunk instanceof Uint8Array ? chunk : Buffer.from(chunk);
+    }
+  } finally {
+    destroyUndiciBody(body);
+    await dispatcher.close().catch(() => undefined);
+  }
+}
+
 function remainingMs(deadlineMs: number): number {
   return Math.max(0, deadlineMs - Date.now());
 }
 
 function positiveTimeoutMs(deadlineMs: number): number {
   return Math.max(1, remainingMs(deadlineMs));
-}
-
-async function cancelResponseBody(response: Response): Promise<void> {
-  await response.body?.cancel().catch(() => undefined);
-}
-
-function isAbortError(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "name" in error && error.name === "AbortError";
 }
 
 function validRetryAfter(headers: Headers): string | undefined {
@@ -289,6 +348,10 @@ function validRetryAfter(headers: Headers): string | undefined {
     return value;
   }
   return undefined;
+}
+
+function isAbortError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "name" in error && error.name === "AbortError";
 }
 
 function headersToRecord(headers: Headers): Record<string, string> {
@@ -320,4 +383,9 @@ function isUndiciTimeout(error: unknown): boolean {
   return error instanceof undiciErrors.ConnectTimeoutError
     || error instanceof undiciErrors.HeadersTimeoutError
     || error instanceof undiciErrors.BodyTimeoutError;
+}
+
+function destroyUndiciBody(body: { destroy(error?: Error): void; on(event: "error", listener: (error: Error) => void): unknown }): void {
+  body.on("error", () => undefined);
+  body.destroy();
 }

--- a/src/copilot/models_source.ts
+++ b/src/copilot/models_source.ts
@@ -85,16 +85,17 @@ async function getWithRedirects(
     ): Promise<Response> {
       const dispatcher = new Agent({
         connectTimeout: limits.connectTimeoutMs,
-        headersTimeout: remainingMs(deadlineMs),
+        headersTimeout: positiveTimeoutMs(deadlineMs),
         bodyTimeout: 0,
       });
+      const timeout = timeoutPromise<Awaited<ReturnType<typeof undiciRequest>>>(remainingMs(deadlineMs), signal);
       try {
-        const response = await undiciRequest(url, {
+        const response = await Promise.race([undiciRequest(url, {
           method: "GET",
           headers: headersToRecord(headers),
-          signal,
+          signal: timeout.signal,
           dispatcher,
-        });
+        }), timeout.promise]);
         const body = response.body;
         const iterator = body[Symbol.asyncIterator]();
         const stream = new ReadableStream<Uint8Array>({
@@ -122,6 +123,8 @@ async function getWithRedirects(
           throw new CapiFetchError(502);
         }
         throw error;
+      } finally {
+        timeout.clear();
       }
     }
     const location = response.headers.get("location");
@@ -227,6 +230,16 @@ function timeoutPromise<T>(ms: number, signal: AbortSignal): {
   const promise = new Promise<T>((_resolve, reject) => {
     rejectTimeout = reject;
   });
+  if (signal.aborted) {
+    controller.abort();
+    rejectTimeout(new DOMException("aborted", "AbortError"));
+    return {
+      signal: combined,
+      promise,
+      clear: () => undefined,
+      timedOut: () => false,
+    };
+  }
   const onAbort = (): void => {
     controller.abort();
     rejectTimeout(new DOMException("aborted", "AbortError"));
@@ -250,6 +263,10 @@ function timeoutPromise<T>(ms: number, signal: AbortSignal): {
 
 function remainingMs(deadlineMs: number): number {
   return Math.max(0, deadlineMs - Date.now());
+}
+
+function positiveTimeoutMs(deadlineMs: number): number {
+  return Math.max(1, remainingMs(deadlineMs));
 }
 
 async function cancelResponseBody(response: Response): Promise<void> {

--- a/src/copilot/models_source.ts
+++ b/src/copilot/models_source.ts
@@ -2,6 +2,18 @@ import { copilotHeaders } from "./identity.js";
 import { capiModelsUrl, type CapiModelsResponse, type CopilotModelsSource } from "./model_catalog.js";
 import { MAX_REDIRECTS, stripSecretsOnRedirect } from "./endpoint_discovery.js";
 
+interface CapiTransportLimits {
+  readonly connectTimeoutMs: number;
+  readonly totalTimeoutMs: number;
+  readonly bodyLimitBytes: number;
+}
+
+const DEFAULT_CAPI_LIMITS: CapiTransportLimits = {
+  connectTimeoutMs: 30_000,
+  totalTimeoutMs: 600_000,
+  bodyLimitBytes: 33_554_432,
+};
+
 export class CapiFetchError extends Error {
   constructor(
     readonly status: number,
@@ -16,20 +28,27 @@ export class HttpCopilotModelsSource implements CopilotModelsSource {
   constructor(
     private readonly resolve: (accountId: string, signal: AbortSignal) => Promise<{ token: string; endpoint: string }>,
     private readonly fetchImpl: typeof fetch = fetch,
+    private readonly limits: CapiTransportLimits = DEFAULT_CAPI_LIMITS,
   ) {}
 
   async fetch(accountId: string, signal: AbortSignal): Promise<CapiModelsResponse> {
     const { token, endpoint } = await this.resolve(accountId, signal);
-    const url = capiModelsUrl(endpoint);
-    const response = await getWithRedirects(this.fetchImpl, url, token, signal);
+    const response = await getWithRedirects(this.fetchImpl, capiModelsUrl(endpoint), token, signal, Date.now() + this.limits.totalTimeoutMs, this.limits);
     if (response.status < 200 || response.status >= 300) {
-      const retryAfter = response.status === 429 ? response.headers.get("retry-after") : null;
-      if (retryAfter === null || retryAfter === undefined) {
-        throw new CapiFetchError(response.status);
-      }
-      throw new CapiFetchError(response.status, retryAfter);
+      await cancelResponseBody(response);
+      const status = response.status >= 300 && response.status < 400 ? 502 : response.status;
+      throw new CapiFetchError(status, response.status === 429 ? validRetryAfter(response.headers) : undefined);
     }
-    return await response.json() as CapiModelsResponse;
+    try {
+      const bytes = await readLimitedBody(response, signal, Date.now() + this.limits.totalTimeoutMs, this.limits);
+      return JSON.parse(new TextDecoder().decode(bytes)) as CapiModelsResponse;
+    } catch (error: unknown) {
+      if (error instanceof CapiFetchError) {
+        throw error;
+      }
+      await cancelResponseBody(response);
+      throw new CapiFetchError(502);
+    }
   }
 }
 
@@ -38,11 +57,13 @@ async function getWithRedirects(
   url: string,
   token: string,
   signal: AbortSignal,
+  deadlineMs: number,
+  limits: CapiTransportLimits,
 ): Promise<Response> {
   let current = url;
   let headers = new Headers({ ...copilotHeaders(), authorization: `Bearer ${token}`, "content-type": "application/json" });
   for (let attempt = 0; attempt <= MAX_REDIRECTS; attempt += 1) {
-    const response = await fetchImpl(current, { method: "GET", headers, signal, redirect: "manual" });
+    const response = await fetchWithTimeout(fetchImpl, current, headers, signal, deadlineMs, limits);
     if (response.status < 300 || response.status >= 400) {
       return response;
     }
@@ -52,7 +73,128 @@ async function getWithRedirects(
     }
     const next = new URL(location, current).toString();
     headers = stripSecretsOnRedirect(current, next, headers);
+    await cancelResponseBody(response);
     current = next;
   }
   throw new CapiFetchError(502);
+}
+
+async function fetchWithTimeout(
+  fetchImpl: typeof fetch,
+  url: string,
+  headers: Headers,
+  signal: AbortSignal,
+  deadlineMs: number,
+  limits: CapiTransportLimits,
+): Promise<Response> {
+  const timeout = timeoutPromise<Response>(Math.min(limits.connectTimeoutMs, remainingMs(deadlineMs)), signal);
+  try {
+    return await Promise.race([
+      fetchImpl(url, { method: "GET", headers, signal: timeout.signal, redirect: "manual" }),
+      timeout.promise,
+    ]);
+  } catch (error: unknown) {
+    if (timeout.timedOut()) {
+      throw new CapiFetchError(502);
+    }
+    throw error;
+  } finally {
+    timeout.clear();
+  }
+}
+
+async function readLimitedBody(response: Response, signal: AbortSignal, deadlineMs: number, limits: CapiTransportLimits): Promise<Uint8Array> {
+  const body = response.body;
+  if (body === null) {
+    return new Uint8Array();
+  }
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const timeout = timeoutPromise<ReadableStreamReadResult<Uint8Array>>(remainingMs(deadlineMs), signal);
+      let next: ReadableStreamReadResult<Uint8Array>;
+      try {
+        next = await Promise.race([reader.read(), timeout.promise]);
+      } catch (error: unknown) {
+        if (timeout.timedOut()) {
+          throw new CapiFetchError(502);
+        }
+        throw error;
+      } finally {
+        timeout.clear();
+      }
+      if (next.done) {
+        break;
+      }
+      if (next.value === undefined) {
+        continue;
+      }
+      total += next.value.byteLength;
+      if (total > limits.bodyLimitBytes) {
+        void reader.cancel().catch(() => undefined);
+        throw new CapiFetchError(502);
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function timeoutPromise<T>(ms: number, signal: AbortSignal): {
+  readonly signal: AbortSignal;
+  readonly promise: Promise<T>;
+  readonly clear: () => void;
+  readonly timedOut: () => boolean;
+} {
+  const controller = new AbortController();
+  const combined = AbortSignal.any([signal, controller.signal]);
+  let timedOut = false;
+  let rejectTimeout: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((_resolve, reject) => {
+    rejectTimeout = reject;
+  });
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+    rejectTimeout(new CapiFetchError(502));
+  }, Math.max(0, ms));
+  return {
+    signal: combined,
+    promise,
+    clear: () => clearTimeout(timer),
+    timedOut: () => timedOut,
+  };
+}
+
+function remainingMs(deadlineMs: number): number {
+  return Math.max(0, deadlineMs - Date.now());
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  await response.body?.cancel().catch(() => undefined);
+}
+
+function validRetryAfter(headers: Headers): string | undefined {
+  const value = headers.get("retry-after");
+  if (value === null || value.length === 0) {
+    return undefined;
+  }
+  if (/^\d+$/u.test(value)) {
+    return value;
+  }
+  if (/^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT$/u.test(value) && !Number.isNaN(Date.parse(value))) {
+    return value;
+  }
+  return undefined;
 }

--- a/src/protocols/model_catalog/routes.ts
+++ b/src/protocols/model_catalog/routes.ts
@@ -99,6 +99,9 @@ async function loadCatalog(
       if (error.failureKind === "upstream_timeout") {
         throw new GatewayFailureError({ kind: "upstream_timeout", cause: error });
       }
+      if (error.failureKind === "upstream_network") {
+        throw new GatewayFailureError({ kind: "upstream_network", cause: error });
+      }
       if (error.failureKind === "invalid_upstream_response") {
         throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
       }

--- a/src/protocols/model_catalog/routes.ts
+++ b/src/protocols/model_catalog/routes.ts
@@ -96,6 +96,12 @@ async function loadCatalog(
     return catalog;
   } catch (error: unknown) {
     if (error instanceof CapiFetchError) {
+      if (error.failureKind === "upstream_timeout") {
+        throw new GatewayFailureError({ kind: "upstream_timeout", cause: error });
+      }
+      if (error.failureKind === "invalid_upstream_response") {
+        throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+      }
       throw new GatewayFailureError({
         kind: "upstream_http",
         status: error.status,

--- a/src/protocols/openai_chat/endpoint.ts
+++ b/src/protocols/openai_chat/endpoint.ts
@@ -273,7 +273,7 @@ async function loadCatalog(catalog: CopilotModelCatalog, accountId: string, sign
     if (error instanceof CapiFetchError) {
       const retry = validRetryAfterValue(error.retryAfter);
       if (error.failureKind === "upstream_timeout") {
-        throw new GatewayFailureError({ kind: "upstream_timeout", cause: error });
+        throw new GatewayFailureError({ kind: "upstream_network", cause: error });
       }
       if (error.failureKind === "upstream_network") {
         throw new GatewayFailureError({ kind: "upstream_network", cause: error });

--- a/src/protocols/openai_chat/endpoint.ts
+++ b/src/protocols/openai_chat/endpoint.ts
@@ -272,6 +272,15 @@ async function loadCatalog(catalog: CopilotModelCatalog, accountId: string, sign
   } catch (error: unknown) {
     if (error instanceof CapiFetchError) {
       const retry = validRetryAfterValue(error.retryAfter);
+      if (error.failureKind === "upstream_timeout") {
+        throw new GatewayFailureError({ kind: "upstream_timeout", cause: error });
+      }
+      if (error.failureKind === "upstream_network") {
+        throw new GatewayFailureError({ kind: "upstream_network", cause: error });
+      }
+      if (error.failureKind === "invalid_upstream_response") {
+        throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+      }
       throw new GatewayFailureError({
         kind: "upstream_http",
         status: error.status,

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -103,6 +103,56 @@ describe("RM-08 CAPI parse and cache", () => {
       return new Response("{\"data\":[]}");
     }).fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ status: 502 });
   });
+
+  it("cleans up CAPI bodies on invalid redirects, body timeout, and caller abort", async () => {
+    let redirectCanceled = false;
+    const redirectSource = new HttpCopilotModelsSource(
+      async () => ({ token: "token", endpoint: "https://api.githubcopilot.com" }),
+      async () => new Response(new ReadableStream<Uint8Array>({
+        cancel(): void {
+          redirectCanceled = true;
+        },
+      }), { status: 302, headers: { location: "http://[invalid" } }),
+      { connectTimeoutMs: 20, totalTimeoutMs: 20, bodyLimitBytes: 32 },
+    );
+    await expect(redirectSource.fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ status: 502 });
+    expect(redirectCanceled).toBe(true);
+
+    let timeoutCanceled = false;
+    const timeoutSource = new HttpCopilotModelsSource(
+      async () => ({ token: "token", endpoint: "https://api.githubcopilot.com" }),
+      async () => new Response(new ReadableStream<Uint8Array>({
+        pull: async () => {
+          await new Promise<void>(() => undefined);
+        },
+        cancel(): void {
+          timeoutCanceled = true;
+        },
+      }), { status: 200 }),
+      { connectTimeoutMs: 20, totalTimeoutMs: 1, bodyLimitBytes: 32 },
+    );
+    await expect(timeoutSource.fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ status: 502 });
+    expect(timeoutCanceled).toBe(true);
+
+    let abortCanceled = false;
+    const abortController = new AbortController();
+    const abortSource = new HttpCopilotModelsSource(
+      async () => ({ token: "token", endpoint: "https://api.githubcopilot.com" }),
+      async () => new Response(new ReadableStream<Uint8Array>({
+        pull: async () => {
+          await new Promise<void>(() => undefined);
+        },
+        cancel(): void {
+          abortCanceled = true;
+        },
+      }), { status: 200 }),
+      { connectTimeoutMs: 20, totalTimeoutMs: 20, bodyLimitBytes: 32 },
+    );
+    const pending = abortSource.fetch("github.com/1", abortController.signal);
+    abortController.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(abortCanceled).toBe(true);
+  });
 });
 
 describe("RM-08 model resolver", () => {

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -8,6 +8,7 @@ import {
   CopilotModelCatalog,
   parseCapiModels,
 } from "../../../src/copilot/model_catalog.js";
+import { CapiFetchError, HttpCopilotModelsSource } from "../../../src/copilot/models_source.js";
 import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
 import { parseStartupConfig } from "../../../src/config/startup_config.js";
 import { createGateway } from "../../../src/gateway/create_gateway.js";
@@ -70,6 +71,37 @@ describe("RM-08 CAPI parse and cache", () => {
     expect(b.models).toEqual([]);
     expect(c.accountId).toBe("github.com/2");
     expect(seen).toEqual(["github.com/1", "github.com/2"]);
+  });
+
+  it("maps CAPI redirects, Retry-After, body limits, and timeouts safely", async () => {
+    const source = (fetchImpl: typeof fetch) => new HttpCopilotModelsSource(
+      async () => ({ token: "token", endpoint: "https://api.githubcopilot.com" }),
+      fetchImpl,
+      { connectTimeoutMs: 1, totalTimeoutMs: 20, bodyLimitBytes: 32 },
+    );
+
+    await expect(source(async () => new Response(null, { status: 302 })).fetch("github.com/1", new AbortController().signal))
+      .rejects.toMatchObject({ status: 502 });
+
+    await expect(source(async () => new Response("{}", {
+      status: 429,
+      headers: { "retry-after": "120, 240" },
+    })).fetch("github.com/1", new AbortController().signal))
+      .rejects.toMatchObject({ status: 429, retryAfter: undefined });
+
+    await expect(source(async () => new Response("{}", {
+      status: 429,
+      headers: { "retry-after": "Sun, 06 Nov 1994 08:49:37 GMT" },
+    })).fetch("github.com/1", new AbortController().signal))
+      .rejects.toMatchObject({ status: 429, retryAfter: "Sun, 06 Nov 1994 08:49:37 GMT" });
+
+    await expect(source(async () => new Response(`{"data":"${"x".repeat(40)}"}`)).fetch("github.com/1", new AbortController().signal))
+      .rejects.toBeInstanceOf(CapiFetchError);
+
+    await expect(source(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return new Response("{\"data\":[]}");
+    }).fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ status: 502 });
   });
 });
 

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -124,9 +124,6 @@ describe("RM-08 CAPI parse and cache", () => {
     const timeoutSource = new HttpCopilotModelsSource(
       async () => ({ token: "token", endpoint: "https://api.githubcopilot.com" }),
       async () => new Response(new ReadableStream<Uint8Array>({
-        pull: async () => {
-          await new Promise<void>(() => undefined);
-        },
         cancel(): void {
           timeoutCanceled = true;
         },
@@ -134,6 +131,9 @@ describe("RM-08 CAPI parse and cache", () => {
       { connectTimeoutMs: 20, totalTimeoutMs: 1, bodyLimitBytes: 32 },
     );
     await expect(timeoutSource.fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ status: 502 });
+    for (let index = 0; index < 20 && !timeoutCanceled; index += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
     expect(timeoutCanceled).toBe(true);
 
     let abortCanceled = false;
@@ -141,9 +141,6 @@ describe("RM-08 CAPI parse and cache", () => {
     const abortSource = new HttpCopilotModelsSource(
       async () => ({ token: "token", endpoint: "https://api.githubcopilot.com" }),
       async () => new Response(new ReadableStream<Uint8Array>({
-        pull: async () => {
-          await new Promise<void>(() => undefined);
-        },
         cancel(): void {
           abortCanceled = true;
         },
@@ -153,6 +150,9 @@ describe("RM-08 CAPI parse and cache", () => {
     const pending = abortSource.fetch("github.com/1", abortController.signal);
     abortController.abort();
     await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    for (let index = 0; index < 20 && !abortCanceled; index += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
     expect(abortCanceled).toBe(true);
   });
 

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -182,6 +182,30 @@ describe("RM-08 CAPI parse and cache", () => {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
+
+  it("enforces timeout on the default Undici request path", async () => {
+    const server = createServer((_request, response) => {
+      setTimeout(() => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{\"data\":[]}");
+      }, 20);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected TCP server address");
+    }
+    try {
+      const source = new HttpCopilotModelsSource(
+        async () => ({ token: "token", endpoint: `http://127.0.0.1:${address.port}` }),
+        fetch,
+        { connectTimeoutMs: 100, totalTimeoutMs: 1, bodyLimitBytes: 32 },
+      );
+      await expect(source.fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ status: 502 });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
 });
 
 describe("RM-08 model resolver", () => {

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -1,5 +1,7 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { createServer } from "node:http";
+import { gzipSync } from "node:zlib";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { AccountDirectory } from "../../../src/accounts/account_directory.js";
@@ -152,6 +154,33 @@ describe("RM-08 CAPI parse and cache", () => {
     abortController.abort();
     await expect(pending).rejects.toMatchObject({ name: "AbortError" });
     expect(abortCanceled).toBe(true);
+  });
+
+  it("uses the default Undici request path without automatic decompression", async () => {
+    const server = createServer((request, response) => {
+      if (request.url === "/models") {
+        response.writeHead(200, {
+          "content-type": "application/json",
+          "content-encoding": "gzip",
+        });
+        response.end(gzipSync("{\"data\":[]}"));
+        return;
+      }
+      response.writeHead(404).end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected TCP server address");
+    }
+    try {
+      const source = new HttpCopilotModelsSource(
+        async () => ({ token: "token", endpoint: `http://127.0.0.1:${address.port}` }),
+      );
+      await expect(source.fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ status: 502 });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });
 

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -183,6 +183,33 @@ describe("RM-08 CAPI parse and cache", () => {
     }
   });
 
+  it("strips sensitive CAPI headers on cross-host redirects", async () => {
+    let calls = 0;
+    let redirectedHeaders: Headers | undefined;
+    const source = new HttpCopilotModelsSource(
+      async () => ({ token: "token", endpoint: "https://api.githubcopilot.com" }),
+      async (_input, init) => {
+        calls += 1;
+        if (calls === 1) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://copilot.example.com/models" },
+          });
+        }
+        redirectedHeaders = new Headers(init?.headers);
+        return new Response("{\"data\":[]}", { status: 200 });
+      },
+      { connectTimeoutMs: 20, totalTimeoutMs: 100, bodyLimitBytes: 32 },
+    );
+    await source.fetch("github.com/1", new AbortController().signal);
+    expect(calls).toBe(2);
+    expect(redirectedHeaders?.has("authorization")).toBe(false);
+    expect(redirectedHeaders?.has("cookie")).toBe(false);
+    expect(redirectedHeaders?.has("cookie2")).toBe(false);
+    expect(redirectedHeaders?.has("proxy-authorization")).toBe(false);
+    expect(redirectedHeaders?.has("www-authenticate")).toBe(false);
+  });
+
   it("enforces timeout on the default Undici request path", async () => {
     const server = createServer((_request, response) => {
       setTimeout(() => {

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -85,11 +85,14 @@ describe("RM-08 CAPI parse and cache", () => {
     await expect(source(async () => new Response(null, { status: 302 })).fetch("github.com/1", new AbortController().signal))
       .rejects.toMatchObject({ status: 502 });
 
-    await expect(source(async () => new Response("{}", {
-      status: 429,
-      headers: { "retry-after": "120, 240" },
-    })).fetch("github.com/1", new AbortController().signal))
-      .rejects.toMatchObject({ status: 429, retryAfter: undefined });
+    for (const headers of [
+      new Headers({ "retry-after": "120, 240" }),
+      duplicateRetryAfterHeaders(),
+      new Headers({ "retry-after": "Foo, 06 Nov 1994 08:49:37 GMT" }),
+    ]) {
+      await expect(source(async () => new Response("{}", { status: 429, headers })).fetch("github.com/1", new AbortController().signal))
+        .rejects.toMatchObject({ status: 429, retryAfter: undefined });
+    }
 
     await expect(source(async () => new Response("{}", {
       status: 429,
@@ -105,6 +108,13 @@ describe("RM-08 CAPI parse and cache", () => {
       return new Response("{\"data\":[]}");
     }).fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ status: 502 });
   });
+
+  function duplicateRetryAfterHeaders(): Headers {
+    const headers = new Headers();
+    headers.append("retry-after", "120");
+    headers.append("retry-after", "240");
+    return headers;
+  }
 
   it("cleans up CAPI bodies on invalid redirects, body timeout, and caller abort", async () => {
     let redirectCanceled = false;

--- a/tests/refactor/contract/openai_chat_endpoint.test.ts
+++ b/tests/refactor/contract/openai_chat_endpoint.test.ts
@@ -373,6 +373,37 @@ describe("RM-09 OpenAI Chat endpoint", () => {
     }
   });
 
+  it("preserves CAPI timeout and invalid-response failure categories", async () => {
+    const backend = new CapturingCopilotBackend({
+      chat: { status: 200, headers: new Headers(), body: encoder.encode("{}") },
+    });
+    const timeoutGateway = await openAiGateway(backend, {
+      capiError: new CapiFetchError(502, undefined, "upstream_timeout"),
+    });
+    try {
+      const response = await timeoutGateway.gw.fetch(jsonRequest("{\"model\":\"gpt\"}"));
+      expect(response.status).toBe(504);
+      expect(await response.text()).toBe(
+        "{\"error\":{\"message\":\"upstream timeout\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
+      );
+    } finally {
+      await timeoutGateway.close();
+    }
+
+    const invalidGateway = await openAiGateway(backend, {
+      capiError: new CapiFetchError(502, undefined, "invalid_upstream_response"),
+    });
+    try {
+      const response = await invalidGateway.gw.fetch(jsonRequest("{\"model\":\"gpt\"}"));
+      expect(response.status).toBe(502);
+      expect(await response.text()).toBe(
+        "{\"error\":{\"message\":\"invalid upstream response\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
+      );
+    } finally {
+      await invalidGateway.close();
+    }
+  });
+
   it("rejects invalid upstream non-stream bodies before success", async () => {
     const backend = new CapturingCopilotBackend({
       chat: { status: 200, headers: new Headers(), body: encoder.encode("[]") },

--- a/tests/refactor/contract/openai_chat_endpoint.test.ts
+++ b/tests/refactor/contract/openai_chat_endpoint.test.ts
@@ -382,9 +382,9 @@ describe("RM-09 OpenAI Chat endpoint", () => {
     });
     try {
       const response = await timeoutGateway.gw.fetch(jsonRequest("{\"model\":\"gpt\"}"));
-      expect(response.status).toBe(504);
+      expect(response.status).toBe(502);
       expect(await response.text()).toBe(
-        "{\"error\":{\"message\":\"upstream timeout\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
+        "{\"error\":{\"message\":\"upstream request failed\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
       );
     } finally {
       await timeoutGateway.close();

--- a/tests/refactor/integration/model_routes.test.ts
+++ b/tests/refactor/integration/model_routes.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { AccountDirectory } from "../../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
+import { CapiFetchError } from "../../../src/copilot/models_source.js";
 import { CopilotModelCatalog } from "../../../src/copilot/model_catalog.js";
 import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
 import { parseStartupConfig } from "../../../src/config/startup_config.js";
@@ -61,6 +62,49 @@ describe("RM-08 model routes errors and preferences", () => {
       await empty.get("github.com/1", new AbortController().signal);
       accounts.preferences.markInvalidIfMissing("github.com/1", new Set(), 2);
       expect(accounts.preferences.get("github.com/1")?.validity).toBe("invalid");
+    } finally {
+      await gw.close();
+      closeDatabase(database);
+    }
+  });
+
+  it("exposes Retry-After only for valid final CAPI 429 values", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-cat-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+    await accounts.upsertAuthenticated({
+      host: "github.com",
+      userId: "1",
+      secret: { generation: 0, githubToken: "t" },
+    });
+    let retryAfter: string | undefined = "120";
+    const catalog = new CopilotModelCatalog({
+      async fetch() {
+        throw new CapiFetchError(429, retryAfter);
+      },
+    });
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: dir }),
+      runtime: defaultRuntimeConfigSnapshot(),
+    }, createModelCatalogRoutes({
+      directory: accounts,
+      catalog,
+      preferences: accounts.preferences,
+    }));
+    try {
+      const valid = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"));
+      expect(valid.status).toBe(429);
+      expect(valid.headers.get("retry-after")).toBe("120");
+
+      retryAfter = undefined;
+      catalog.invalidate("github.com/1");
+      const invalid = await gw.fetch(new Request("http://127.0.0.1:31400/api/tags"));
+      expect(invalid.status).toBe(429);
+      expect(invalid.headers.get("retry-after")).toBeNull();
     } finally {
       await gw.close();
       closeDatabase(database);


### PR DESCRIPTION
## Summary
- Moves CAPI `/models` production fetches onto low-level Undici request with bounded connect/total/body handling and no automatic decompression.
- Maps final/unresolved redirects, Retry-After, timeout/network/invalid-success failures into safe model-list and OpenAI Chat catalog categories.
- Adds gated coverage for redirects, Retry-After valid/invalid/duplicate values, body limit, timeout, abort/cleanup, public header exposure, and default Undici behavior.

Closes #48

## Validation
- `npm run typecheck:refactor`
- `npm run lint:refactor`
- `npm run test:refactor -- tests/refactor/contract/model_catalog.test.ts tests/refactor/integration/model_routes.test.ts tests/refactor/contract/openai_chat_endpoint.test.ts`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check origin/refactor...HEAD`

## Code review
- Standards review: no blockers.
- Spec review: no blockers.

## Deferred follow-ups
- #57 tracks optional CAPI Undici dispatcher reuse. Deferral is safe because this PR closes each per-request dispatcher and preserves public model-list behavior.