### PR TITLE
Preserve CAPI routing metadata for Responses planning

### DIFF
--- a/src/copilot/model_catalog.ts
+++ b/src/copilot/model_catalog.ts
@@ -98,14 +98,44 @@ export function parseCapiModels(raw: CapiModelsResponse | unknown): CopilotCatal
     if (record.model_picker_enabled !== true) {
       continue;
     }
-    models.push({
+    const routing = routingFromRecord(record).routing;
+    const model = {
       id: record.id,
       name: record.name,
       vendor: record.vendor,
       modelPickerEnabled: true,
-    });
+    };
+    models.push(routing === undefined ? model : { ...model, routing });
   }
   return models;
+}
+
+function routingFromRecord(record: Record<string, unknown>): { readonly routing?: CopilotCatalogModel["routing"] } {
+  const raw = modelInfoRecord(record);
+  const mode = typeof raw?.mode === "string" ? raw.mode : undefined;
+  const supportedEndpoints = Array.isArray(raw?.supported_endpoints)
+    ? raw.supported_endpoints.filter((item): item is string => typeof item === "string")
+    : undefined;
+  if (mode !== undefined && supportedEndpoints !== undefined) {
+    return { routing: { mode, supportedEndpoints } };
+  }
+  if (mode !== undefined) {
+    return { routing: { mode } };
+  }
+  if (supportedEndpoints !== undefined) {
+    return { routing: { supportedEndpoints } };
+  }
+  return {};
+}
+
+function modelInfoRecord(record: Record<string, unknown>): Record<string, unknown> | undefined {
+  for (const key of ["model_info", "capabilities"]) {
+    const value = record[key];
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+  }
+  return undefined;
 }
 
 export function toRfc3339Nano(date: Date): string {

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -36,10 +36,46 @@ describe("RM-08 CAPI parse and cache", () => {
   it("keeps picker-enabled models in upstream order including duplicates", () => {
     const models = parseCapiModels(CAPI);
     expect(models.map((model) => model.id)).toEqual(["keep", "keep"]);
+    expect(models[0]?.routing).toEqual({
+      mode: "chat",
+      supportedEndpoints: ["/v1/chat/completions"],
+    });
   });
 
   it("rejects incomplete CAPI items", () => {
     expect(() => parseCapiModels({ data: [{ id: "x" }] })).toThrow(/invalid/u);
+  });
+
+  it("captures private routing metadata and ignores malformed routing values", () => {
+    const models = parseCapiModels({
+      data: [
+        {
+          id: "native",
+          name: "Native",
+          vendor: "openai",
+          model_picker_enabled: true,
+          model_info: {
+            mode: "responses",
+            supported_endpoints: ["/v1/responses", 1, null, "/v1/chat/completions"],
+          },
+        },
+        {
+          id: "malformed",
+          name: "Malformed",
+          vendor: "openai",
+          model_picker_enabled: true,
+          model_info: {
+            mode: false,
+            supported_endpoints: "nope",
+          },
+        },
+      ],
+    });
+    expect(models[0]?.routing).toEqual({
+      mode: "responses",
+      supportedEndpoints: ["/v1/responses", "/v1/chat/completions"],
+    });
+    expect(models[1]?.routing).toBeUndefined();
   });
 
   it("does not write cache after invalidate generation change", async () => {

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -370,7 +370,22 @@ describe("RM-08 serializers", () => {
     };
     const openai = JSON.parse(serializeOpenAiModels(catalog, new Map())) as { data: Array<Record<string, unknown>> };
     expect(openai.data[0]?.supported_endpoints).toBeUndefined();
-    expect(JSON.parse(serializeAnthropicModels(catalog, new Map())).data[0].display_name).toBe("m");
-    expect(JSON.parse(serializeOllamaTags(catalog)).models[0].modified_at).toBe("2026-08-30T05:00:00Z");
+    expect(openai.data[0]?.supportedEndpoints).toBeUndefined();
+    expect(openai.data[0]?.routing).toBeUndefined();
+    expect(openai.data[0]?.mode).toBeUndefined();
+
+    const anthropic = JSON.parse(serializeAnthropicModels(catalog, new Map())) as { data: Array<Record<string, unknown>> };
+    expect(anthropic.data[0]?.display_name).toBe("m");
+    expect(anthropic.data[0]?.supported_endpoints).toBeUndefined();
+    expect(anthropic.data[0]?.supportedEndpoints).toBeUndefined();
+    expect(anthropic.data[0]?.routing).toBeUndefined();
+    expect(anthropic.data[0]?.mode).toBeUndefined();
+
+    const ollama = JSON.parse(serializeOllamaTags(catalog)) as { models: Array<Record<string, unknown>> };
+    expect(ollama.models[0]?.modified_at).toBe("2026-08-30T05:00:00Z");
+    expect(ollama.models[0]?.supported_endpoints).toBeUndefined();
+    expect(ollama.models[0]?.supportedEndpoints).toBeUndefined();
+    expect(ollama.models[0]?.routing).toBeUndefined();
+    expect(ollama.models[0]?.mode).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Captures private CAPI routing metadata (`mode`, `supported_endpoints`) from model info/capabilities into catalog snapshots.
- Filters malformed routing metadata safely to unknown/absent internal routing.
- Strengthens public serializer tests to prove routing metadata stays private.

Closes #49

## Validation
- `npm run typecheck:refactor`
- `npm run lint:refactor`
- `npm run test:refactor -- tests/refactor/contract/model_catalog.test.ts tests/refactor/integration/model_routes.test.ts`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check origin/refactor...HEAD`

## Code review
- Standards review: no blockers.
- Spec review: no blockers.