### PR TITLE
Complete Ollama stream and NDJSON contract

### DIFF
--- a/scripts/refactor/fixtures.ts
+++ b/scripts/refactor/fixtures.ts
@@ -216,12 +216,15 @@ async function verifyOllamaFixtures(entries: readonly FixtureManifestEntry[]): P
 }
 
 async function expectedOllamaFixture(entry: FixtureManifestEntry): Promise<string | undefined> {
-  if (entry.caseId !== "ollama.request.capture" && entry.caseId !== "ollama.nonstream.success") {
+  if (entry.caseId !== "ollama.request.capture" && entry.caseId !== "ollama.nonstream.success" && entry.caseId !== "ollama.stream.success") {
     return undefined;
   }
   const input = await readFile(path.join(FIXTURE_ROOT, "ollama", entry.input), "utf8");
   if (entry.caseId === "ollama.nonstream.success") {
     return ollamaNonstreamSuccessReference();
+  }
+  if (entry.caseId === "ollama.stream.success") {
+    return ollamaStreamSuccessReference();
   }
   const backend = new FixtureOllamaBackend();
   const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-ollama-fixture-"));
@@ -257,6 +260,42 @@ async function expectedOllamaFixture(entry: FixtureManifestEntry): Promise<strin
   } finally {
     await gateway.close();
     closeDatabase(database);
+  }
+
+  function ollamaStreamSuccessReference(): string {
+    return `${stringifyGoReference(goObject([
+      { key: "model", value: "gpt" },
+      { key: "remote_model", value: undefined, omitEmpty: true },
+      { key: "remote_host", value: undefined, omitEmpty: true },
+      { key: "created_at", value: "2026-01-02T03:04:05.12Z" },
+      { key: "message", value: goObject([
+        { key: "role", value: "assistant" },
+        { key: "content", value: "hello" },
+        { key: "thinking", value: undefined, omitEmpty: true },
+        { key: "images", value: undefined, omitEmpty: true },
+        { key: "tool_calls", value: undefined, omitEmpty: true },
+        { key: "tool_name", value: undefined, omitEmpty: true },
+        { key: "tool_call_id", value: undefined, omitEmpty: true },
+      ]) },
+      { key: "done", value: false },
+      { key: "done_reason", value: undefined, omitEmpty: true },
+    ]))}\n${stringifyGoReference(goObject([
+      { key: "model", value: "gpt" },
+      { key: "remote_model", value: undefined, omitEmpty: true },
+      { key: "remote_host", value: undefined, omitEmpty: true },
+      { key: "created_at", value: "2026-01-02T03:04:05.12Z" },
+      { key: "message", value: goObject([
+        { key: "role", value: "assistant" },
+        { key: "content", value: "" },
+        { key: "thinking", value: undefined, omitEmpty: true },
+        { key: "images", value: undefined, omitEmpty: true },
+        { key: "tool_calls", value: undefined, omitEmpty: true },
+        { key: "tool_name", value: undefined, omitEmpty: true },
+        { key: "tool_call_id", value: undefined, omitEmpty: true },
+      ]) },
+      { key: "done", value: true },
+      { key: "done_reason", value: "stop", omitEmpty: true },
+    ]))}\n`;
   }
 
   function ollamaNonstreamSuccessReference(): string {

--- a/src/gateway/failures.ts
+++ b/src/gateway/failures.ts
@@ -11,6 +11,8 @@ export type GatewayFailure =
   | { readonly kind: "upstream_http"; readonly status: number; readonly retryAfter?: string }
   | { readonly kind: "upstream_timeout"; readonly cause?: unknown }
   | { readonly kind: "upstream_network"; readonly cause?: unknown }
+  | { readonly kind: "upstream_stream_error"; readonly cause?: unknown }
+  | { readonly kind: "upstream_stream_truncated"; readonly cause?: unknown }
   | { readonly kind: "invalid_upstream_response"; readonly cause?: unknown }
   | { readonly kind: "invalid_tool_arguments"; readonly cause?: unknown }
   | { readonly kind: "invalid_logprobs"; readonly cause?: unknown }

--- a/src/protocols/ollama_chat/bridge.ts
+++ b/src/protocols/ollama_chat/bridge.ts
@@ -31,9 +31,9 @@ export function ollamaNonstreamResponse(
   }
   const reduced = reduceMessage(message);
   const toolCalls = toolCallsFromMessage(message);
-  const doneReason = doneReasonFromChoice(choice, toolCalls.length);
+  const doneReason = ollamaDoneReason(memberValues(choice, "finish_reason")[0], toolCalls.length);
   const usage = usageCounts(root, chatMessages, reduced.content, tokenCounter);
-  const logprobs = logprobsFromChoice(choice);
+  const logprobs = ollamaLogprobsFromChoice(choice);
   return {
     model,
     created_at: createdAtFromUpstream(root, now),
@@ -147,7 +147,7 @@ function toolCallFromChat(value: WireJson, position: number): Record<string, unk
   if (typeof name !== "string" || typeof args !== "string") {
     throw new GatewayFailureError({ kind: "invalid_upstream_response" });
   }
-  const parsedArgs = parseToolArguments(args);
+  const parsedArgs = parseOllamaToolArguments(args);
   const call: Record<string, unknown> = {};
   if (id !== undefined && id.length > 0) {
     call.id = id;
@@ -160,7 +160,7 @@ function toolCallFromChat(value: WireJson, position: number): Record<string, unk
   return call;
 }
 
-function parseToolArguments(value: string): WireJsonObject {
+export function parseOllamaToolArguments(value: string): WireJsonObject {
   const bytes = new TextEncoder().encode(value);
   try {
     const parsed = parseWireJson(bytes, { maxBytes: Math.max(bytes.byteLength, 1), maxDepth: 64 });
@@ -176,7 +176,7 @@ function parseToolArguments(value: string): WireJsonObject {
   }
 }
 
-function logprobsFromChoice(choice: WireJsonObject): Array<Record<string, unknown>> | undefined {
+export function ollamaLogprobsFromChoice(choice: WireJsonObject): Array<Record<string, unknown>> | undefined {
   const logprobs = memberValues(choice, "logprobs")[0];
   if (logprobs === undefined || logprobs === null) {
     return undefined;
@@ -226,8 +226,7 @@ function logprobItem(value: WireJson, allowTop: boolean): Record<string, unknown
   return result;
 }
 
-function doneReasonFromChoice(choice: WireJsonObject, toolCallCount: number): "stop" | "length" {
-  const finish = memberValues(choice, "finish_reason")[0];
+export function ollamaDoneReason(finish: WireJson | undefined, toolCallCount: number): "stop" | "length" {
   if (finish === undefined || finish === null || finish === "stop" || finish === "content_filter") {
     return "stop";
   }

--- a/src/protocols/ollama_chat/endpoint.ts
+++ b/src/protocols/ollama_chat/endpoint.ts
@@ -1,7 +1,6 @@
 import { VERSION } from "../../version.js";
 import type { BoundCopilot, CopilotBackend } from "../../copilot/backend.js";
 import type { AccountDirectory } from "../../accounts/account_directory.js";
-import { iterateChatFrames } from "../../copilot/backend.js";
 import {
   UpstreamBodyLimitError,
   UpstreamTimeoutError,
@@ -18,9 +17,9 @@ import {
   type WireJsonArray,
   type WireJsonObject,
 } from "../../serialization/wire_json.js";
-import { createStreamResponseWriter } from "../../gateway/stream_response.js";
-import { encodeNdjson, ollamaCreatedAt, ollamaErrorBody, ollamaJsonStringify } from "./wire.js";
+import { ollamaCreatedAt, ollamaErrorBody, ollamaJsonStringify } from "./wire.js";
 import { ollamaNonstreamResponse, type OllamaTokenCounter } from "./bridge.js";
+import { createOllamaStreamResponse } from "./stream.js";
 import type { ChatRequest } from "../chat_completions/types.js";
 
 export interface OllamaRouteDependencies {
@@ -103,12 +102,7 @@ export function createOllamaChatRoutes(dependencies: OllamaRouteDependencies): r
             dependencies.tokenCounter,
           )), { headers: JSON_HEADERS });
         }
-        const createdAt = ollamaCreatedAt((dependencies.now ?? (() => new Date()))());
-        const writer = createStreamResponseWriter({
-          signal: scope.signal,
-          headers: { "Content-Type": "application/x-ndjson" },
-        });
-        const upstream = await copilot.openChatStream({
+        const upstream = await openChatStream(copilot, {
           model,
           body: chatBody,
           stream: true,
@@ -118,50 +112,16 @@ export function createOllamaChatRoutes(dependencies: OllamaRouteDependencies): r
           firstByteTimeoutMs: scope.config.timeouts.firstByteMs,
           signal: scope.signal,
         });
-        void (async () => {
-          try {
-            for await (const frame of iterateChatFrames(upstream)) {
-              if (scope.signal.aborted) {
-                writer.abort();
-                return;
-              }
-              if (frame.kind === "chunk") {
-                const content = textFromWire(frame.chunk.payload);
-                if (content.length > 0) {
-                  await writer.enqueue(encodeNdjson({
-                    model,
-                    created_at: createdAt,
-                    message: { role: "assistant", content },
-                    done: false,
-                  }));
-                }
-              }
-              if (frame.kind === "done") {
-                await writer.enqueue(encodeNdjson({
-                  model,
-                  created_at: createdAt,
-                  message: { role: "assistant", content: "" },
-                  done: true,
-                  done_reason: "stop",
-                }));
-                writer.close();
-                return;
-              }
-              if (frame.kind === "error") {
-                await writer.enqueue(encodeNdjson({ error: "upstream stream error" }));
-                writer.close();
-                return;
-              }
-            }
-            writer.close();
-          } catch (_error) {
-            if (writer.committed) {
-              await writer.enqueue(encodeNdjson({ error: "upstream stream error" }));
-            }
-            writer.close();
-          }
-        })();
-        return writer.response;
+        if (upstream.status < 200 || upstream.status >= 300) {
+          await upstream.cancel();
+          throw new GatewayFailureError({ kind: "upstream_http", status: upstream.status });
+        }
+        return await createOllamaStreamResponse({
+          upstream,
+          model,
+          createdAt: ollamaCreatedAt((dependencies.now ?? (() => new Date()))()),
+          scope,
+        });
       },
     },
   ];
@@ -180,6 +140,10 @@ function ollamaFailureStatusAndText(failure: Parameters<FailurePresenter>[0]): {
     return { status: failure.status, text: "upstream request failed" };
   case "upstream_network":
     return { status: 502, text: "upstream request failed" };
+  case "upstream_stream_error":
+    return { status: 502, text: "upstream stream error" };
+  case "upstream_stream_truncated":
+    return { status: 502, text: "upstream stream truncated" };
   case "invalid_upstream_response":
     return { status: 502, text: "invalid upstream response" };
   case "invalid_tool_arguments":
@@ -646,6 +610,14 @@ async function completeChat(copilot: BoundCopilot, request: Readonly<ChatRequest
   }
 }
 
+async function openChatStream(copilot: BoundCopilot, request: Readonly<ChatRequest>) {
+  try {
+    return await copilot.openChatStream(request);
+  } catch (error: unknown) {
+    throw upstreamCallFailure(error);
+  }
+}
+
 function upstreamCallFailure(error: unknown): GatewayFailureError {
   if (error instanceof GatewayFailureError) {
     return error;
@@ -660,20 +632,4 @@ function upstreamCallFailure(error: unknown): GatewayFailureError {
     return new GatewayFailureError({ kind: "upstream_timeout", cause: error });
   }
   return new GatewayFailureError({ kind: "upstream_network", cause: error });
-}
-
-function textFromWire(value: WireJson): string {
-  if (!isWireJsonObject(value)) {
-    return "";
-  }
-  const choices = memberValues(value, "choices")[0];
-  if (!isWireJsonArray(choices) || choices.items[0] === undefined || !isWireJsonObject(choices.items[0])) {
-    return "";
-  }
-  const delta = memberValues(choices.items[0], "delta")[0];
-  if (!isWireJsonObject(delta)) {
-    return "";
-  }
-  const content = memberValues(delta, "content")[0];
-  return typeof content === "string" ? content : "";
 }

--- a/src/protocols/ollama_chat/stream.ts
+++ b/src/protocols/ollama_chat/stream.ts
@@ -57,7 +57,12 @@ export async function createOllamaStreamResponse(input: {
         }
       } catch (error: unknown) {
         await closeUpstream(input.upstream, frames);
-        controller.enqueue(streamErrorBytes(error));
+        const failure = streamGatewayFailure(error).failure;
+        if (failure.kind === "aborted") {
+          controller.close();
+          return;
+        }
+        controller.enqueue(streamErrorBytes(failure.kind));
         controller.close();
       }
     },
@@ -143,12 +148,22 @@ class OllamaStreamReducer {
     let emitted = false;
     if (reasoningContentValues.length > 0) {
       const thinking = optionalString(reasoningContentValues[0]);
+      const content = optionalString(contentValues[0]);
+      if (content.length > 0) {
+        message.content = content;
+        emitted = true;
+      }
       if (thinking.length > 0) {
         message.thinking = thinking;
         emitted = true;
       }
     } else if (reasoningValues.length > 0) {
       const thinking = optionalString(reasoningValues[0]);
+      const content = optionalString(contentValues[0]);
+      if (content.length > 0) {
+        message.content = content;
+        emitted = true;
+      }
       if (thinking.length > 0) {
         message.thinking = thinking;
         emitted = true;
@@ -338,16 +353,21 @@ function streamGatewayFailure(error: unknown): GatewayFailureError {
   return new GatewayFailureError({ kind: "upstream_stream_error", cause: error });
 }
 
-function streamErrorBytes(error: unknown): Uint8Array {
-  const failure = streamGatewayFailure(error).failure;
-  if (failure.kind === "upstream_stream_truncated") {
+function streamErrorBytes(kind: ReturnType<typeof streamGatewayFailure>["failure"]["kind"]): Uint8Array {
+  if (kind === "upstream_stream_truncated") {
     return encodeNdjson({ error: "upstream stream truncated" });
   }
-  if (failure.kind === "invalid_tool_arguments") {
+  if (kind === "invalid_upstream_response") {
+    return encodeNdjson({ error: "invalid upstream response" });
+  }
+  if (kind === "invalid_tool_arguments") {
     return encodeNdjson({ error: "invalid tool arguments" });
   }
-  if (failure.kind === "invalid_logprobs") {
+  if (kind === "invalid_logprobs") {
     return encodeNdjson({ error: "invalid logprobs" });
+  }
+  if (kind === "upstream_timeout") {
+    return encodeNdjson({ error: "upstream timeout" });
   }
   return encodeNdjson({ error: "upstream stream error" });
 }
@@ -382,7 +402,7 @@ async function* withBodyTimeouts(
       yield next.value;
     }
   } finally {
-    await iterator.return?.();
+    void iterator.return?.().catch(() => undefined);
   }
 }
 

--- a/src/protocols/ollama_chat/stream.ts
+++ b/src/protocols/ollama_chat/stream.ts
@@ -1,0 +1,489 @@
+import { ChatSseError, parseChatSse } from "../../copilot/chat_sse.js";
+import { GatewayFailureError } from "../../gateway/failures.js";
+import type { RequestScope } from "../../gateway/request_scope.js";
+import type { ChatStreamFrame, UpstreamByteStream } from "../chat_completions/types.js";
+import {
+  isWireJsonArray,
+  isWireJsonNumber,
+  isWireJsonObject,
+  memberValues,
+  type WireJson,
+  type WireJsonArray,
+  type WireJsonObject,
+} from "../../serialization/wire_json.js";
+import {
+  ollamaDoneReason,
+  ollamaLogprobsFromChoice,
+  parseOllamaToolArguments,
+} from "./bridge.js";
+import { encodeNdjson } from "./wire.js";
+
+export async function createOllamaStreamResponse(input: {
+  readonly upstream: UpstreamByteStream;
+  readonly model: string;
+  readonly createdAt: string;
+  readonly scope: Readonly<RequestScope>;
+}): Promise<Response> {
+  const reducer = new OllamaStreamReducer(input.model, input.createdAt);
+  const frames = parseChatSse(withBodyTimeouts(input.upstream.bytes, input.scope), input.scope.config.limits.sseEventBytes);
+  let pending: Uint8Array | undefined = await firstOutput(reducer, frames, input.upstream, input.scope);
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller): Promise<void> {
+      if (input.scope.signal.aborted) {
+        await closeUpstream(input.upstream, frames);
+        controller.close();
+        return;
+      }
+      if (pending !== undefined) {
+        controller.enqueue(pending);
+        pending = undefined;
+        if (reducer.terminal) {
+          await closeUpstream(input.upstream, frames);
+          controller.close();
+        }
+        return;
+      }
+      try {
+        for (;;) {
+          const output = await nextOutput(reducer, frames, input.scope);
+          if (output !== undefined) {
+            controller.enqueue(output);
+            if (reducer.terminal) {
+              await closeUpstream(input.upstream, frames);
+              controller.close();
+            }
+            return;
+          }
+        }
+      } catch (error: unknown) {
+        await closeUpstream(input.upstream, frames);
+        controller.enqueue(streamErrorBytes(error));
+        controller.close();
+      }
+    },
+    async cancel(): Promise<void> {
+      await closeUpstream(input.upstream, frames);
+    },
+  });
+  input.scope.signal.addEventListener("abort", () => {
+    void closeUpstream(input.upstream, frames);
+  }, { once: true });
+  return new Response(stream, { headers: { "Content-Type": "application/x-ndjson" } });
+}
+
+class OllamaStreamReducer {
+  private readonly tools = new Map<number, ToolAccumulator>();
+  private finishReason: WireJson | undefined;
+  private promptTokens: number | undefined;
+  private completionTokens: number | undefined;
+  private thinkingStarted = false;
+  private thinkingFinished = false;
+  private phase: "open" | "finished" | "errored" = "open";
+
+  constructor(
+    private readonly model: string,
+    private readonly createdAt: string,
+  ) {}
+
+  get terminal(): boolean {
+    return this.phase !== "open";
+  }
+
+  apply(frame: ChatStreamFrame): readonly Uint8Array[] {
+    if (this.phase !== "open") {
+      return [];
+    }
+    if (frame.kind === "error") {
+      this.phase = "errored";
+      throw new GatewayFailureError({ kind: "upstream_stream_error" });
+    }
+    if (frame.kind === "done") {
+      this.phase = "finished";
+      return [encodeNdjson(this.terminalObject())];
+    }
+    return this.applyChunk(frame.chunk.payload);
+  }
+
+  private applyChunk(payload: WireJson): readonly Uint8Array[] {
+    const root = objectOrStreamError(payload);
+    this.mergeUsage(memberValues(root, "usage")[0]);
+    const choices = memberValues(root, "choices")[0];
+    if (!isWireJsonArray(choices)) {
+      throw new GatewayFailureError({ kind: "upstream_stream_error" });
+    }
+    if (choices.items.length === 0) {
+      return [];
+    }
+    const choice = selectedChoice(choices);
+    this.recordFinish(memberValues(choice, "finish_reason")[0]);
+    const delta = memberValues(choice, "delta")[0];
+    if (!isWireJsonObject(delta)) {
+      throw new GatewayFailureError({ kind: "upstream_stream_error" });
+    }
+    this.mergeToolCalls(memberValues(delta, "tool_calls")[0]);
+    const message = this.messageFromDelta(delta);
+    const logprobs = ollamaLogprobsFromChoice(choice);
+    if (message === undefined && (logprobs === undefined || logprobs.length === 0)) {
+      return [];
+    }
+    return [encodeNdjson({
+      model: this.model,
+      created_at: this.createdAt,
+      message: message ?? { role: "assistant", content: "" },
+      done: false,
+      ...(logprobs === undefined || logprobs.length === 0 ? {} : { logprobs }),
+    })];
+  }
+
+  private messageFromDelta(delta: WireJsonObject): Record<string, unknown> | undefined {
+    const contentValues = memberValues(delta, "content");
+    const reasoningContentValues = memberValues(delta, "reasoning_content");
+    const reasoningValues = memberValues(delta, "reasoning");
+    const message: Record<string, unknown> = { role: "assistant", content: "" };
+    let emitted = false;
+    if (reasoningContentValues.length > 0) {
+      const thinking = optionalString(reasoningContentValues[0]);
+      if (thinking.length > 0) {
+        message.thinking = thinking;
+        emitted = true;
+      }
+    } else if (reasoningValues.length > 0) {
+      const thinking = optionalString(reasoningValues[0]);
+      if (thinking.length > 0) {
+        message.thinking = thinking;
+        emitted = true;
+      }
+    } else if (contentValues.length > 0) {
+      const reduced = this.reduceContent(optionalString(contentValues[0]));
+      if (reduced.content.length > 0) {
+        message.content = reduced.content;
+        emitted = true;
+      }
+      if (reduced.thinking.length > 0) {
+        message.thinking = reduced.thinking;
+        emitted = true;
+      }
+    }
+    return emitted ? message : undefined;
+  }
+
+  private reduceContent(fragment: string): { readonly content: string; readonly thinking: string } {
+    if (fragment.length === 0) {
+      return { content: "", thinking: "" };
+    }
+    if (this.thinkingStarted && !this.thinkingFinished) {
+      this.thinkingFinished = true;
+    }
+    let reduced = fragment;
+    if (reduced.includes("<think>")) {
+      reduced = reduced.replaceAll("<think>", "");
+      this.thinkingStarted = true;
+      this.thinkingFinished = false;
+    }
+    if (reduced.includes("</think>") && this.thinkingStarted) {
+      reduced = reduced.replaceAll("</think>", "");
+      this.thinkingFinished = true;
+    }
+    if (this.thinkingStarted && !this.thinkingFinished) {
+      return { content: "", thinking: reduced };
+    }
+    return { content: reduced, thinking: "" };
+  }
+
+  private mergeToolCalls(value: WireJson | undefined): void {
+    if (value === undefined) {
+      return;
+    }
+    if (!isWireJsonArray(value)) {
+      throw new GatewayFailureError({ kind: "upstream_stream_error" });
+    }
+    for (const item of value.items) {
+      this.mergeToolCall(item);
+    }
+  }
+
+  private mergeToolCall(value: WireJson): void {
+    const call = objectOrStreamError(value);
+    const index = requiredInteger(memberValues(call, "index")[0]);
+    const current = this.tools.get(index) ?? { argumentFragments: [] };
+    const id = memberValues(call, "id")[0];
+    if (id !== undefined && id !== null) {
+      if (typeof id !== "string") {
+        throw new GatewayFailureError({ kind: "upstream_stream_error" });
+      }
+      lockValue(current.id, id, () => { current.id = id; });
+    }
+    const fn = memberValues(call, "function")[0];
+    if (fn !== undefined) {
+      const functionObject = objectOrStreamError(fn);
+      const name = memberValues(functionObject, "name")[0];
+      if (name !== undefined && name !== null) {
+        if (typeof name !== "string") {
+          throw new GatewayFailureError({ kind: "upstream_stream_error" });
+        }
+        lockValue(current.name, name, () => { current.name = name; });
+      }
+      const args = memberValues(functionObject, "arguments")[0];
+      if (args !== undefined && args !== null) {
+        if (typeof args !== "string") {
+          throw new GatewayFailureError({ kind: "upstream_stream_error" });
+        }
+        current.argumentFragments.push(args);
+      }
+    }
+    this.tools.set(index, current);
+  }
+
+  private recordFinish(value: WireJson | undefined): void {
+    if (value === undefined || value === null) {
+      return;
+    }
+    if (typeof value !== "string") {
+      throw new GatewayFailureError({ kind: "upstream_stream_error" });
+    }
+    if (this.finishReason !== undefined && this.finishReason !== value) {
+      throw new GatewayFailureError({ kind: "upstream_stream_error" });
+    }
+    this.finishReason = value;
+  }
+
+  private mergeUsage(value: WireJson | undefined): void {
+    if (value === undefined || value === null) {
+      return;
+    }
+    const usage = objectOrStreamError(value);
+    const prompt = streamUsageCount(usage, "prompt_tokens");
+    const completion = streamUsageCount(usage, "completion_tokens");
+    this.promptTokens = prompt ?? this.promptTokens;
+    this.completionTokens = completion ?? this.completionTokens;
+  }
+
+  private terminalObject(): Record<string, unknown> {
+    const toolCalls = [...this.tools.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([index, tool]) => toolCallObject(index, tool));
+    return {
+      model: this.model,
+      created_at: this.createdAt,
+      message: {
+        role: "assistant",
+        content: "",
+        ...(toolCalls.length === 0 ? {} : { tool_calls: toolCalls }),
+      },
+      done: true,
+      done_reason: ollamaDoneReason(this.finishReason, toolCalls.length),
+      ...((this.promptTokens ?? 0) === 0 ? {} : { prompt_eval_count: this.promptTokens ?? 0 }),
+      ...((this.completionTokens ?? 0) === 0 ? {} : { eval_count: this.completionTokens ?? 0 }),
+    };
+  }
+}
+
+interface ToolAccumulator {
+  id?: string;
+  name?: string;
+  argumentFragments: string[];
+}
+
+async function firstOutput(
+  reducer: OllamaStreamReducer,
+  frames: AsyncGenerator<ChatStreamFrame>,
+  upstream: UpstreamByteStream,
+  scope: Readonly<RequestScope>,
+): Promise<Uint8Array> {
+  try {
+    for (;;) {
+      const output = await nextOutput(reducer, frames, scope);
+      if (output !== undefined) {
+        return output;
+      }
+    }
+  } catch (error: unknown) {
+    await closeUpstream(upstream, frames);
+    throw streamGatewayFailure(error);
+  }
+}
+
+async function nextOutput(
+  reducer: OllamaStreamReducer,
+  frames: AsyncGenerator<ChatStreamFrame>,
+  scope: Readonly<RequestScope>,
+): Promise<Uint8Array | undefined> {
+  if (scope.signal.aborted) {
+    throw new GatewayFailureError({ kind: "aborted" });
+  }
+  try {
+    const next = await frames.next();
+    if (next.done === true) {
+      throw new GatewayFailureError({ kind: "upstream_stream_truncated" });
+    }
+    return reducer.apply(next.value)[0];
+  } catch (error: unknown) {
+    throw streamGatewayFailure(error);
+  }
+}
+
+function streamGatewayFailure(error: unknown): GatewayFailureError {
+  if (error instanceof GatewayFailureError) {
+    return error;
+  }
+  if (error instanceof ChatSseError) {
+    return new GatewayFailureError({
+      kind: error.code === "truncated" ? "upstream_stream_truncated" : "upstream_stream_error",
+      cause: error,
+    });
+  }
+  if (error instanceof Error && error.name === "AbortError") {
+    return new GatewayFailureError({ kind: "aborted" });
+  }
+  return new GatewayFailureError({ kind: "upstream_stream_error", cause: error });
+}
+
+function streamErrorBytes(error: unknown): Uint8Array {
+  const failure = streamGatewayFailure(error).failure;
+  if (failure.kind === "upstream_stream_truncated") {
+    return encodeNdjson({ error: "upstream stream truncated" });
+  }
+  if (failure.kind === "invalid_tool_arguments") {
+    return encodeNdjson({ error: "invalid tool arguments" });
+  }
+  if (failure.kind === "invalid_logprobs") {
+    return encodeNdjson({ error: "invalid logprobs" });
+  }
+  return encodeNdjson({ error: "upstream stream error" });
+}
+
+async function closeUpstream(upstream: UpstreamByteStream, frames: AsyncGenerator<ChatStreamFrame>): Promise<void> {
+  await upstream.cancel().catch(() => undefined);
+  await frames.return(undefined).catch(() => undefined);
+}
+
+async function* withBodyTimeouts(
+  bytes: AsyncIterable<Uint8Array>,
+  scope: Readonly<RequestScope>,
+): AsyncIterable<Uint8Array> {
+  const iterator = bytes[Symbol.asyncIterator]();
+  let seenBytes = false;
+  try {
+    for (;;) {
+      const timeout = bodyTimeout(seenBytes ? scope.config.timeouts.streamIdleMs : scope.config.timeouts.firstByteMs, scope.signal);
+      let next: IteratorResult<Uint8Array>;
+      try {
+        next = await Promise.race([
+          iterator.next(),
+          timeout.promise,
+        ]);
+      } finally {
+        timeout.clear();
+      }
+      if (next.done === true) {
+        return;
+      }
+      seenBytes = true;
+      yield next.value;
+    }
+  } finally {
+    await iterator.return?.();
+  }
+}
+
+function bodyTimeout(ms: number, signal: AbortSignal): {
+  readonly promise: Promise<IteratorResult<Uint8Array>>;
+  readonly clear: () => void;
+} {
+  let clear = (): void => undefined;
+  const promise = new Promise<IteratorResult<Uint8Array>>((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(new GatewayFailureError({ kind: "aborted" }));
+      return;
+    }
+    const timer = setTimeout(() => reject(new GatewayFailureError({ kind: "upstream_timeout" })), ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new GatewayFailureError({ kind: "aborted" }));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    clear = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    };
+  });
+  return { promise, clear };
+}
+
+function selectedChoice(choices: WireJsonArray): WireJsonObject {
+  const selected = choices.items.filter((choice): choice is WireJsonObject => {
+    if (!isWireJsonObject(choice)) {
+      throw new GatewayFailureError({ kind: "upstream_stream_error" });
+    }
+    const index = memberValues(choice, "index")[0];
+    return isWireJsonNumber(index) && index.lexeme === "0";
+  });
+  if (selected.length !== 1) {
+    throw new GatewayFailureError({ kind: "upstream_stream_error" });
+  }
+  return selected[0] as WireJsonObject;
+}
+
+function objectOrStreamError(value: WireJson): WireJsonObject {
+  if (!isWireJsonObject(value)) {
+    throw new GatewayFailureError({ kind: "upstream_stream_error" });
+  }
+  return value;
+}
+
+function optionalString(value: WireJson | undefined): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (typeof value !== "string") {
+    throw new GatewayFailureError({ kind: "upstream_stream_error" });
+  }
+  return value;
+}
+
+function requiredInteger(value: WireJson | undefined): number {
+  if (!isIntegerInRange(value, 0, Number.MAX_SAFE_INTEGER)) {
+    throw new GatewayFailureError({ kind: "upstream_stream_error" });
+  }
+  return Number.parseInt(value.lexeme, 10);
+}
+
+function streamUsageCount(usage: WireJsonObject, key: string): number | undefined {
+  const values = memberValues(usage, key);
+  if (values.length === 0) {
+    return undefined;
+  }
+  if (!isIntegerInRange(values[0], 0, Number.MAX_SAFE_INTEGER)) {
+    throw new GatewayFailureError({ kind: "upstream_stream_error" });
+  }
+  return Number.parseInt(values[0].lexeme, 10);
+}
+
+function isIntegerInRange(value: WireJson | undefined, min: number, max: number): value is { readonly kind: "number"; readonly lexeme: string } {
+  if (!isWireJsonNumber(value) || !/^(?:0|[1-9]\d*)$/u.test(value.lexeme)) {
+    return false;
+  }
+  const parsed = Number.parseInt(value.lexeme, 10);
+  return Number.isSafeInteger(parsed) && parsed >= min && parsed <= max;
+}
+
+function lockValue(current: string | undefined, next: string, set: () => void): void {
+  if (next.length === 0) {
+    return;
+  }
+  if (current !== undefined && current !== next) {
+    throw new GatewayFailureError({ kind: "upstream_stream_error" });
+  }
+  set();
+}
+
+function toolCallObject(index: number, tool: ToolAccumulator): Record<string, unknown> {
+  return {
+    ...(tool.id === undefined ? {} : { id: tool.id }),
+    function: {
+      index,
+      name: tool.name ?? "",
+      arguments: parseOllamaToolArguments(tool.argumentFragments.join("")),
+    },
+  };
+}

--- a/src/protocols/openai_chat/endpoint.ts
+++ b/src/protocols/openai_chat/endpoint.ts
@@ -784,6 +784,8 @@ function statusForFailure(failure: Readonly<GatewayFailure>): number {
   case "queue_timeout":
     return 503;
   case "upstream_network":
+  case "upstream_stream_error":
+  case "upstream_stream_truncated":
   case "invalid_upstream_response":
   case "invalid_tool_arguments":
   case "invalid_logprobs":
@@ -820,6 +822,8 @@ function messageForFailure(failure: Readonly<GatewayFailure>): string {
   case "upstream_timeout":
     return "upstream timeout";
   case "invalid_upstream_response":
+  case "upstream_stream_error":
+  case "upstream_stream_truncated":
   case "invalid_tool_arguments":
   case "invalid_logprobs":
     return "invalid upstream response";

--- a/tests/refactor/contract/ollama_stream.test.ts
+++ b/tests/refactor/contract/ollama_stream.test.ts
@@ -1,9 +1,226 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { encodeNdjson } from "../../../src/protocols/ollama_chat/wire.js";
+import { AccountDirectory, type BoundAccount } from "../../../src/accounts/account_directory.js";
+import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
+import type { BoundCopilot, CopilotBackend, CopilotTarget } from "../../../src/copilot/backend.js";
+import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
+import { parseStartupConfig } from "../../../src/config/startup_config.js";
+import { createGateway } from "../../../src/gateway/create_gateway.js";
+import { closeDatabase, openDatabase } from "../../../src/persistence/database.js";
+import { embedMigration } from "../../../src/persistence/migrations.js";
+import { migration as runtimeConfigMigration } from "../../../src/persistence/migrations/001_runtime_config.js";
+import { migration as accountsMigration } from "../../../src/persistence/migrations/010_accounts.js";
+import { createOllamaChatRoutes } from "../../../src/protocols/ollama_chat/endpoint.js";
+import type { ChatRequest, ChatResponse, NativeResponsesUpstreamRequest, UpstreamByteResponse, UpstreamByteStream } from "../../../src/protocols/chat_completions/types.js";
 
-describe("RM-10 Ollama stream wire", () => {
-  it("encodes one compact JSON object and a trailing LF", () => {
-    const bytes = encodeNdjson({ done: true });
-    expect(new TextDecoder().decode(bytes)).toBe("{\"done\":true}\n");
+const nowMs = (): number => 1_700_000_000_000;
+
+class StreamBackend implements CopilotBackend {
+  status = 200;
+  chunks: Uint8Array[] | AsyncIterable<Uint8Array> = [];
+  canceled = 0;
+
+  async bind(account: Readonly<BoundAccount>, _signal: AbortSignal): Promise<BoundCopilot> {
+    const target: CopilotTarget = { endpoint: "https://api.githubcopilot.com", token: "t" };
+    return {
+      accountId: account.accountId,
+      target,
+      completeChat: async (_request: Readonly<ChatRequest>): Promise<ChatResponse> => {
+        throw new Error("non-stream must not be called");
+      },
+      openChatStream: async (_request: Readonly<ChatRequest>): Promise<UpstreamByteStream> => ({
+        status: this.status,
+        headers: new Headers({ "content-type": "text/event-stream" }),
+        bytes: Array.isArray(this.chunks) ? streamBytes(...this.chunks) : this.chunks,
+        cancel: async () => { this.canceled += 1; },
+      }),
+      completeResponses: async (_request: Readonly<NativeResponsesUpstreamRequest>): Promise<UpstreamByteResponse> => {
+        throw new Error("responses must not be called");
+      },
+      openResponsesStream: async (_request: Readonly<NativeResponsesUpstreamRequest>): Promise<UpstreamByteStream> => {
+        throw new Error("responses stream must not be called");
+      },
+    };
+  }
+}
+
+async function ollamaGateway(backend: CopilotBackend) {
+  const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-ollama-stream-"));
+  const database = openDatabase({
+    path: path.join(dir, "state.db"),
+    migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+    nowMs,
+  });
+  const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+  await accounts.upsertAuthenticated({
+    host: "github.com",
+    userId: "1",
+    secret: { generation: 0, githubToken: "t" },
+  });
+  const gw = await createGateway({
+    startup: parseStartupConfig([], {}, { homedir: dir }),
+    runtime: defaultRuntimeConfigSnapshot(),
+  }, createOllamaChatRoutes({
+    directory: accounts,
+    copilot: backend,
+    now: () => new Date("2026-01-02T03:04:05.120Z"),
+    tokenCounter: () => 0,
+  }));
+  return { gw, close: async () => { await gw.close(); closeDatabase(database); } };
+}
+
+describe("RM-10 Ollama stream", () => {
+  it("reduces sparse Chat chunks to exact Ollama NDJSON", async () => {
+    const backend = new StreamBackend();
+    backend.chunks = [
+      sse({ choices: [{ index: 0, delta: { content: "<think>hidden" }, logprobs: { content: [{ token: "hidden", logprob: -0.25, bytes: [104] }] } }] }),
+      sse({ choices: [{ index: 0, delta: { content: "visible < &" } }] }),
+      sse({ choices: [{ index: 0, delta: { reasoning_content: "explicit" } }] }),
+      sse({ choices: [{ index: 0, delta: { tool_calls: [{ index: 1, id: "call_1", function: { name: "weather", arguments: "{\"2\":\"two\"," } }] } }] }),
+      sse({ choices: [{ index: 0, delta: { tool_calls: [{ index: 1, function: { arguments: "\"1\":\"one\"}" } }] } }], usage: { prompt_tokens: 12 } }),
+      sse({ choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }], usage: { completion_tokens: 6 } }),
+      done(),
+    ];
+    const { gw, close } = await ollamaGateway(backend);
+    try {
+      const response = await gw.fetch(request({ model: "gpt", stream: true, messages: [{ role: "user", content: "hi" }] }));
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(
+        "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"\",\"thinking\":\"hidden\"},\"done\":false,\"logprobs\":[{\"token\":\"hidden\",\"logprob\":-0.25,\"bytes\":[104]}]}\n"
+        + "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"visible \\u003c \\u0026\"},\"done\":false}\n"
+        + "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"\",\"thinking\":\"explicit\"},\"done\":false}\n"
+        + "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"\",\"tool_calls\":[{\"id\":\"call_1\",\"function\":{\"index\":1,\"name\":\"weather\",\"arguments\":{\"2\":\"two\",\"1\":\"one\"}}}]},\"done\":true,\"done_reason\":\"stop\",\"prompt_eval_count\":12,\"eval_count\":6}\n",
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("maps stream finish reason terminal transitions", async () => {
+    const cases = [
+      { finish: "length", expected: "length" },
+      { finish: "content_filter", expected: "stop" },
+      { expected: "stop" },
+    ];
+    for (const item of cases) {
+      const backend = new StreamBackend();
+      const choice = item.finish === undefined
+        ? { index: 0, delta: {} }
+        : { index: 0, delta: {}, finish_reason: item.finish };
+      backend.chunks = [sse({ choices: [choice] }), done()];
+      const { gw, close } = await ollamaGateway(backend);
+      try {
+        const response = await gw.fetch(request({ model: "gpt", messages: [{ role: "user", content: "hi" }] }));
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe(
+          `{"model":"gpt","created_at":"2026-01-02T03:04:05.12Z","message":{"role":"assistant","content":""},"done":true,"done_reason":"${item.expected}"}\n`,
+        );
+      } finally {
+        await close();
+      }
+    }
+
+    const backend = new StreamBackend();
+    backend.chunks = [sse({ choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] }), done()];
+    const { gw, close } = await ollamaGateway(backend);
+    try {
+      const response = await gw.fetch(request({ model: "gpt", messages: [{ role: "user", content: "hi" }] }));
+      expect(response.status).toBe(502);
+      expect(await response.text()).toBe("{\"error\":\"invalid upstream response\"}");
+    } finally {
+      await close();
+    }
+  });
+
+  it("returns pre-commit safe errors for upstream status, error frames, and truncation", async () => {
+    for (const item of [
+      { status: 503, chunks: [done()], expectedStatus: 503, expectedBody: "{\"error\":\"upstream request failed\"}" },
+      { chunks: [sse({ error: "boom" })], expectedStatus: 502, expectedBody: "{\"error\":\"upstream stream error\"}" },
+      { chunks: [], expectedStatus: 502, expectedBody: "{\"error\":\"upstream stream truncated\"}" },
+    ]) {
+      const backend = new StreamBackend();
+      backend.status = item.status ?? 200;
+      backend.chunks = item.chunks;
+      const { gw, close } = await ollamaGateway(backend);
+      try {
+        const response = await gw.fetch(request({ model: "gpt", messages: [{ role: "user", content: "hi" }] }));
+        expect(response.status).toBe(item.expectedStatus);
+        expect(await response.text()).toBe(item.expectedBody);
+      } finally {
+        await close();
+      }
+    }
+  });
+
+  it("writes one post-commit error and no synthetic terminal on truncation", async () => {
+    const backend = new StreamBackend();
+    backend.chunks = [sse({ choices: [{ index: 0, delta: { content: "hello" } }] })];
+    const { gw, close } = await ollamaGateway(backend);
+    try {
+      const response = await gw.fetch(request({ model: "gpt", messages: [{ role: "user", content: "hi" }] }));
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(
+        "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"hello\"},\"done\":false}\n"
+        + "{\"error\":\"upstream stream truncated\"}\n",
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("aborts without writing error or done after commit and cancels upstream", async () => {
+    const backend = new StreamBackend();
+    let resume = (): void => undefined;
+    backend.chunks = delayedStream(sse({ choices: [{ index: 0, delta: { content: "hello" } }] }), new Promise<void>((resolve) => {
+      resume = resolve;
+    }));
+    const { gw, close } = await ollamaGateway(backend);
+    try {
+      const controller = new AbortController();
+      const response = await gw.fetch(request({ model: "gpt", messages: [{ role: "user", content: "hi" }] }, controller.signal));
+      const reader = response.body?.getReader();
+      const first = await reader?.read();
+      expect(new TextDecoder().decode(first?.value)).toBe(
+        "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"hello\"},\"done\":false}\n",
+      );
+      controller.abort();
+      resume();
+      const next = await reader?.read().catch(() => ({ done: true, value: undefined }));
+      expect(next?.value === undefined ? "" : new TextDecoder().decode(next.value)).toBe("");
+      expect(backend.canceled).toBeGreaterThan(0);
+    } finally {
+      await close();
+    }
   });
 });
+
+function request(body: unknown, signal?: AbortSignal): Request {
+  const init: RequestInit = {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  };
+  if (signal !== undefined) {
+    init.signal = signal;
+  }
+  return new Request("http://127.0.0.1:31400/api/chat", init);
+}
+
+function sse(value: unknown): Uint8Array {
+  return new TextEncoder().encode(`data: ${JSON.stringify(value)}\n\n`);
+}
+
+function done(): Uint8Array {
+  return new TextEncoder().encode("data: [DONE]\n\n");
+}
+
+async function* streamBytes(...chunks: Uint8Array[]): AsyncIterable<Uint8Array> {
+  yield* chunks;
+}
+
+async function* delayedStream(first: Uint8Array, wait: Promise<void>): AsyncIterable<Uint8Array> {
+  yield first;
+  await wait;
+}

--- a/tests/refactor/contract/ollama_stream.test.ts
+++ b/tests/refactor/contract/ollama_stream.test.ts
@@ -6,6 +6,7 @@ import { AccountDirectory, type BoundAccount } from "../../../src/accounts/accou
 import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
 import type { BoundCopilot, CopilotBackend, CopilotTarget } from "../../../src/copilot/backend.js";
 import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
+import type { RuntimeConfigSnapshot } from "../../../src/config/schema.js";
 import { parseStartupConfig } from "../../../src/config/startup_config.js";
 import { createGateway } from "../../../src/gateway/create_gateway.js";
 import { closeDatabase, openDatabase } from "../../../src/persistence/database.js";
@@ -46,7 +47,10 @@ class StreamBackend implements CopilotBackend {
   }
 }
 
-async function ollamaGateway(backend: CopilotBackend) {
+async function ollamaGateway(
+  backend: CopilotBackend,
+  configureRuntime: (runtime: RuntimeConfigSnapshot) => void = () => undefined,
+) {
   const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-ollama-stream-"));
   const database = openDatabase({
     path: path.join(dir, "state.db"),
@@ -59,9 +63,11 @@ async function ollamaGateway(backend: CopilotBackend) {
     userId: "1",
     secret: { generation: 0, githubToken: "t" },
   });
+  const runtime = defaultRuntimeConfigSnapshot();
+  configureRuntime(runtime);
   const gw = await createGateway({
     startup: parseStartupConfig([], {}, { homedir: dir }),
-    runtime: defaultRuntimeConfigSnapshot(),
+    runtime,
   }, createOllamaChatRoutes({
     directory: accounts,
     copilot: backend,
@@ -92,6 +98,25 @@ describe("RM-10 Ollama stream", () => {
         + "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"visible \\u003c \\u0026\"},\"done\":false}\n"
         + "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"\",\"thinking\":\"explicit\"},\"done\":false}\n"
         + "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"\",\"tool_calls\":[{\"id\":\"call_1\",\"function\":{\"index\":1,\"name\":\"weather\",\"arguments\":{\"2\":\"two\",\"1\":\"one\"}}}]},\"done\":true,\"done_reason\":\"stop\",\"prompt_eval_count\":12,\"eval_count\":6}\n",
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("keeps same-chunk explicit reasoning and visible content together", async () => {
+    const backend = new StreamBackend();
+    backend.chunks = [
+      sse({ choices: [{ index: 0, delta: { content: "visible", reasoning_content: "think" } }] }),
+      done(),
+    ];
+    const { gw, close } = await ollamaGateway(backend);
+    try {
+      const response = await gw.fetch(request({ model: "gpt", messages: [{ role: "user", content: "hi" }] }));
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(
+        "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"visible\",\"thinking\":\"think\"},\"done\":false}\n"
+        + "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,\"done_reason\":\"stop\"}\n",
       );
     } finally {
       await close();
@@ -167,6 +192,43 @@ describe("RM-10 Ollama stream", () => {
       );
     } finally {
       await close();
+    }
+  });
+
+  it("uses documented post-commit error text for invalid terminal state and idle timeout", async () => {
+    const invalidFinish = new StreamBackend();
+    invalidFinish.chunks = [
+      sse({ choices: [{ index: 0, delta: { content: "hello" } }] }),
+      sse({ choices: [{ index: 0, delta: {}, finish_reason: "weird" }] }),
+      done(),
+    ];
+    const invalid = await ollamaGateway(invalidFinish);
+    try {
+      const response = await invalid.gw.fetch(request({ model: "gpt", messages: [{ role: "user", content: "hi" }] }));
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(
+        "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"hello\"},\"done\":false}\n"
+        + "{\"error\":\"invalid upstream response\"}\n",
+      );
+    } finally {
+      await invalid.close();
+    }
+
+    const timeout = new StreamBackend();
+    timeout.chunks = delayedStream(sse({ choices: [{ index: 0, delta: { content: "hello" } }] }), new Promise(() => undefined));
+    const timed = await ollamaGateway(timeout, (runtime) => {
+      runtime.timeouts.streamIdleMs = 1;
+    });
+    try {
+      const response = await timed.gw.fetch(request({ model: "gpt", messages: [{ role: "user", content: "hi" }] }));
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(
+        "{\"model\":\"gpt\",\"created_at\":\"2026-01-02T03:04:05.12Z\",\"message\":{\"role\":\"assistant\",\"content\":\"hello\"},\"done\":false}\n"
+        + "{\"error\":\"upstream timeout\"}\n",
+      );
+      expect(timeout.canceled).toBeGreaterThan(0);
+    } finally {
+      await timed.close();
     }
   });
 

--- a/tests/refactor/contract/ollama_wire.test.ts
+++ b/tests/refactor/contract/ollama_wire.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { ollamaErrorBody } from "../../../src/protocols/ollama_chat/wire.js";
+import { encodeNdjson, ollamaErrorBody } from "../../../src/protocols/ollama_chat/wire.js";
 import { VERSION } from "../../../src/version.js";
 
 describe("RM-10 Ollama wire helpers", () => {
   it("uses the fixed error envelope and gateway version", () => {
     expect(ollamaErrorBody("invalid request")).toBe("{\"error\":\"invalid request\"}");
     expect(VERSION).toBe("0.1.0");
+  });
+
+  it("matches Go escaping for HTML, Unicode separators, controls, and final LF", () => {
+    const bytes = encodeNdjson({ message: { content: "<>&\u2028\u2029\nok" } });
+    expect(new TextDecoder().decode(bytes)).toBe("{\"message\":{\"content\":\"\\u003c\\u003e\\u0026\\u2028\\u2029\\nok\"}}\n");
   });
 });

--- a/tests/refactor/fixtures/ollama/manifest.json
+++ b/tests/refactor/fixtures/ollama/manifest.json
@@ -14,5 +14,13 @@
     "input": "nonstream/success.input.json",
     "expected": "nonstream/success.expected.json",
     "encoder": "go-encoding-json-reference-bytes"
+  },
+  {
+    "caseId": "ollama.stream.success",
+    "owner": "RM-10",
+    "source": "docs/ollama_chat_to_chat_completions.md#7-stream-reducer",
+    "input": "stream/success.input.txt",
+    "expected": "stream/success.expected.txt",
+    "encoder": "go-encoding-json-reference-bytes"
   }
 ]

--- a/tests/refactor/fixtures/ollama/stream/success.expected.txt
+++ b/tests/refactor/fixtures/ollama/stream/success.expected.txt
@@ -1,0 +1,2 @@
+{"model":"gpt","created_at":"2026-01-02T03:04:05.12Z","message":{"role":"assistant","content":"hello"},"done":false}
+{"model":"gpt","created_at":"2026-01-02T03:04:05.12Z","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}

--- a/tests/refactor/fixtures/ollama/stream/success.input.txt
+++ b/tests/refactor/fixtures/ollama/stream/success.input.txt
@@ -1,0 +1,6 @@
+data: {"choices":[{"index":0,"delta":{"content":"hello"}}]}
+
+data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+


### PR DESCRIPTION
## Summary
- Complete Ollama stream reducer with sparse chunk handling, reasoning/content reduction, tool-call aggregation, usage, finish transitions, and safe truncation/error behavior.
- Move stream state into `src/protocols/ollama_chat/stream.ts` and keep `/api/chat` stream status validation before response commit.
- Extend NDJSON/wire tests and Ollama stream fixture coverage for exact Go-compatible bytes.

## Validation
- `npm run typecheck:refactor`
- `npx vitest run --config vitest.refactor.config.ts tests/refactor/contract/ollama_stream.test.ts tests/refactor/contract/ollama_wire.test.ts`
- `npm run fixtures:verify`
- `npm run lint:refactor`
- `npm run test:refactor`
- `npm run build:refactor`
- `git --no-pager diff --check`

## Code review
- Standards axis: no findings.
- Spec axis: no significant issues found.

Closes #52