### PR TITLE
Reuse CAPI model dispatcher

### DIFF
--- a/src/copilot/model_catalog.ts
+++ b/src/copilot/model_catalog.ts
@@ -24,6 +24,7 @@ export interface CapiModelsResponse {
 
 export interface CopilotModelsSource {
   fetch(accountId: string, signal: AbortSignal): Promise<CapiModelsResponse>;
+  close?(): Promise<void> | void;
 }
 
 export interface ModelInfoLookup {
@@ -43,6 +44,7 @@ interface CacheEntry {
 export class CopilotModelCatalog {
   private readonly cache = new Map<string, CacheEntry>();
   private readonly generations = new Map<string, number>();
+  private closed = false;
 
   constructor(
     private readonly source: CopilotModelsSource,
@@ -50,12 +52,18 @@ export class CopilotModelCatalog {
   ) {}
 
   async get(accountId: string, signal: AbortSignal): Promise<CatalogSnapshot> {
+    if (this.closed) {
+      throw new DOMException("closed", "AbortError");
+    }
     const hit = this.cache.get(accountId);
     if (hit !== undefined) {
       return hit.catalog;
     }
     const generation = this.generations.get(accountId) ?? 0;
     const raw = await this.source.fetch(accountId, signal);
+    if (this.closed) {
+      throw new DOMException("closed", "AbortError");
+    }
     const models = parseCapiModels(raw);
     const fetchedAt = toRfc3339Nano(this.now());
     const catalog: CatalogSnapshot = { accountId, models, fetchedAt, generation };
@@ -75,6 +83,12 @@ export class CopilotModelCatalog {
       this.generations.set(accountId, (this.generations.get(accountId) ?? 0) + 1);
     }
     this.cache.clear();
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    this.clear();
+    await this.source.close?.();
   }
 }
 

--- a/src/copilot/models_source.ts
+++ b/src/copilot/models_source.ts
@@ -1,5 +1,6 @@
 import type { IncomingHttpHeaders } from "node:http";
 import { Agent, errors as undiciErrors, request as undiciRequest } from "undici";
+import type { Dispatcher } from "undici";
 import { copilotHeaders } from "./identity.js";
 import { capiModelsUrl, type CapiModelsResponse, type CopilotModelsSource } from "./model_catalog.js";
 import { MAX_REDIRECTS, stripSecretsOnRedirect } from "./endpoint_discovery.js";
@@ -25,6 +26,8 @@ const DEFAULT_CAPI_LIMITS: CapiTransportLimits = {
   bodyLimitBytes: 33_554_432,
 };
 
+const CAPI_DISPATCHER_CONNECTIONS = 8;
+
 export class CapiFetchError extends Error {
   constructor(
     readonly status: number,
@@ -37,16 +40,31 @@ export class CapiFetchError extends Error {
 }
 
 export class HttpCopilotModelsSource implements CopilotModelsSource {
+  private dispatcher: Dispatcher | undefined;
+  private closed = false;
+
   constructor(
     private readonly resolve: (accountId: string, signal: AbortSignal) => Promise<{ token: string; endpoint: string }>,
     private readonly fetchImpl: typeof fetch = fetch,
     private readonly limits: CapiTransportLimits = DEFAULT_CAPI_LIMITS,
+    private readonly createDispatcher: (limits: CapiTransportLimits) => Dispatcher = defaultCapiDispatcher,
   ) {}
 
   async fetch(accountId: string, signal: AbortSignal): Promise<CapiModelsResponse> {
+    if (this.closed) {
+      throw new DOMException("closed", "AbortError");
+    }
     const { token, endpoint } = await this.resolve(accountId, signal);
     const deadlineMs = Date.now() + this.limits.totalTimeoutMs;
-    const response = await getWithRedirects(this.fetchImpl, capiModelsUrl(endpoint), token, signal, deadlineMs, this.limits);
+    const response = await getWithRedirects(
+      this.fetchImpl,
+      capiModelsUrl(endpoint),
+      token,
+      signal,
+      deadlineMs,
+      this.limits,
+      this.fetchImpl === fetch ? this.sharedDispatcher() : undefined,
+    );
     if (response.status < 200 || response.status >= 300) {
       await response.cancel();
       const status = response.status >= 300 && response.status < 400 ? 502 : response.status;
@@ -70,6 +88,31 @@ export class HttpCopilotModelsSource implements CopilotModelsSource {
       throw new CapiFetchError(502, undefined, "invalid_upstream_response");
     }
   }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    const dispatcher = this.dispatcher;
+    this.dispatcher = undefined;
+    if (dispatcher !== undefined) {
+      await dispatcher.close();
+    }
+  }
+
+  private sharedDispatcher(): Dispatcher {
+    if (this.closed) {
+      throw new DOMException("closed", "AbortError");
+    }
+    this.dispatcher ??= this.createDispatcher(this.limits);
+    return this.dispatcher;
+  }
+}
+
+function defaultCapiDispatcher(limits: CapiTransportLimits): Dispatcher {
+  return new Agent({
+    connectTimeout: limits.connectTimeoutMs,
+    connections: CAPI_DISPATCHER_CONNECTIONS,
+    pipelining: 1,
+  });
 }
 
 async function getWithRedirects(
@@ -79,12 +122,13 @@ async function getWithRedirects(
   signal: AbortSignal,
   deadlineMs: number,
   limits: CapiTransportLimits,
+  dispatcher: Dispatcher | undefined,
 ): Promise<CapiHttpResponse> {
   let current = url;
   let headers = new Headers({ ...copilotHeaders(), authorization: `Bearer ${token}`, "content-type": "application/json" });
   for (let attempt = 0; attempt <= MAX_REDIRECTS; attempt += 1) {
-    const response = fetchImpl === fetch
-      ? await undiciWithTimeout(current, headers, signal, deadlineMs, limits)
+    const response = fetchImpl === fetch && dispatcher !== undefined
+      ? await undiciWithTimeout(current, headers, signal, deadlineMs, dispatcher)
       : await fetchWithTimeout(fetchImpl, current, headers, signal, deadlineMs, limits);
     if (response.status < 300 || response.status >= 400) {
       return response;
@@ -146,13 +190,8 @@ async function undiciWithTimeout(
   headers: Headers,
   signal: AbortSignal,
   deadlineMs: number,
-  limits: CapiTransportLimits,
+  dispatcher: Dispatcher,
 ): Promise<CapiHttpResponse> {
-  const dispatcher = new Agent({
-    connectTimeout: limits.connectTimeoutMs,
-    headersTimeout: positiveTimeoutMs(deadlineMs),
-    bodyTimeout: 0,
-  });
   const timeout = timeoutPromise<Awaited<ReturnType<typeof undiciRequest>>>(remainingMs(deadlineMs), signal);
   try {
     const response = await Promise.race([undiciRequest(url, {
@@ -160,19 +199,19 @@ async function undiciWithTimeout(
       headers: headersToRecord(headers),
       signal: timeout.signal,
       dispatcher,
+      headersTimeout: positiveTimeoutMs(deadlineMs),
+      bodyTimeout: 0,
     }), timeout.promise]);
     const body = response.body;
     return {
       status: response.statusCode,
       headers: incomingHeadersToHeaders(response.headers),
-      body: undiciBody(body, dispatcher),
+      body: undiciBody(body),
       cancel: async () => {
         destroyUndiciBody(body);
-        await dispatcher.close().catch(() => undefined);
       },
     };
   } catch (error: unknown) {
-    await dispatcher.close().catch(() => undefined);
     if (timeout.timedOut() || isUndiciTimeout(error)) {
       throw new CapiFetchError(502, undefined, "upstream_timeout");
     }
@@ -322,15 +361,17 @@ function createWebBody(body: ReadableStream<Uint8Array>): { readonly bytes: Asyn
 
 async function* undiciBody(
   body: AsyncIterable<Uint8Array | Buffer | string> & { destroy(error?: Error): void; on(event: "error", listener: (error: Error) => void): unknown },
-  dispatcher: Agent,
 ): AsyncIterable<Uint8Array> {
+  let completed = false;
   try {
     for await (const chunk of body) {
       yield chunk instanceof Uint8Array ? chunk : Buffer.from(chunk);
     }
+    completed = true;
   } finally {
-    destroyUndiciBody(body);
-    await dispatcher.close().catch(() => undefined);
+    if (!completed) {
+      destroyUndiciBody(body);
+    }
   }
 }
 

--- a/src/gateway/create_gateway.ts
+++ b/src/gateway/create_gateway.ts
@@ -28,6 +28,7 @@ export interface GatewayDependencies {
   readonly delay?: DelayFn;
   readonly createRequestId?: () => string;
   readonly isReady?: () => boolean;
+  readonly onClose?: () => Promise<void> | void;
 }
 
 export type { RouteRegistration };
@@ -88,16 +89,25 @@ export async function createGateway(
       admission.close();
       const current = listener;
       listener = undefined;
+      let listenerCloseError: unknown;
       if (current !== undefined) {
-        await new Promise<void>((resolve, reject) => {
-          current.close((error?: Error) => {
-            if (error !== undefined) {
-              reject(error);
-              return;
-            }
-            resolve();
+        try {
+          await new Promise<void>((resolve, reject) => {
+            current.close((error?: Error) => {
+              if (error !== undefined) {
+                reject(error);
+                return;
+              }
+              resolve();
+            });
           });
-        });
+        } catch (error: unknown) {
+          listenerCloseError = error;
+        }
+      }
+      await dependencies.onClose?.();
+      if (listenerCloseError !== undefined) {
+        throw listenerCloseError;
       }
     },
   };

--- a/tests/refactor/contract/model_catalog.test.ts
+++ b/tests/refactor/contract/model_catalog.test.ts
@@ -1,8 +1,10 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { createServer } from "node:http";
+import type { Socket } from "node:net";
 import { gzipSync } from "node:zlib";
 import path from "node:path";
+import { Agent } from "undici";
 import { describe, expect, it } from "vitest";
 import { AccountDirectory } from "../../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
@@ -225,6 +227,84 @@ describe("RM-08 CAPI parse and cache", () => {
       );
       await expect(source.fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ status: 502 });
     } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("reuses a bounded CAPI dispatcher and closes it on gateway shutdown", async () => {
+    const sockets = new Set<Socket>();
+    let createdDispatchers = 0;
+    let requests = 0;
+    const server = createServer((request, response) => {
+      requests += 1;
+      expect(request.url).toBe("/models");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end("{\"data\":[]}");
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected TCP server address");
+    }
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-cat-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+    await accounts.upsertAuthenticated({
+      host: "github.com",
+      userId: "1",
+      secret: { generation: 0, githubToken: "t" },
+    });
+    const source = new HttpCopilotModelsSource(
+      async () => ({ token: "token", endpoint: `http://127.0.0.1:${address.port}` }),
+      fetch,
+      { connectTimeoutMs: 100, totalTimeoutMs: 1_000, bodyLimitBytes: 32 },
+      (limits) => {
+        createdDispatchers += 1;
+        return new Agent({
+          connectTimeout: limits.connectTimeoutMs,
+          connections: 1,
+          pipelining: 1,
+        });
+      },
+    );
+    const catalog = new CopilotModelCatalog(source);
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: dir }),
+      runtime: defaultRuntimeConfigSnapshot(),
+    }, createModelCatalogRoutes({
+      directory: accounts,
+      catalog,
+      preferences: accounts.preferences,
+    }), { onClose: () => catalog.close() });
+    try {
+      expect((await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"))).status).toBe(200);
+      catalog.invalidate("github.com/1");
+      expect((await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"))).status).toBe(200);
+      expect(requests).toBe(2);
+      expect(createdDispatchers).toBe(1);
+      expect(sockets.size).toBeLessThanOrEqual(1);
+
+      await gw.close();
+      for (let index = 0; index < 20 && sockets.size > 0; index += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
+      expect(sockets.size).toBe(0);
+      await expect(catalog.get("github.com/1", new AbortController().signal)).rejects.toMatchObject({ name: "AbortError" });
+      await expect(source.fetch("github.com/1", new AbortController().signal)).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      await gw.close();
+      closeDatabase(database);
+      for (const socket of sockets) {
+        socket.destroy();
+      }
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });


### PR DESCRIPTION
## Summary
- Reuses a bounded source-owned Undici dispatcher for CAPI `/models` requests instead of creating a short-lived Agent per request.
- Adds catalog/source shutdown lifecycle so production composition can close the dispatcher through gateway shutdown.
- Preserves #48 timeout, redirect, no-decompression, abort, body cleanup, and safe error behavior.
- Adds coverage for bounded dispatcher reuse, gateway shutdown cleanup, and closed-source rejection.

Closes #57

## Validation
- `npm run typecheck:refactor`
- `npm run test:refactor -- tests/refactor/contract/model_catalog.test.ts tests/refactor/integration/model_routes.test.ts tests/refactor/contract/gateway_http_contracts.test.ts`
- `npm run lint:refactor`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check`

## Code review
- Standards review: no blockers under `docs/specs/refactor_master_spec.md` section 12.3.
- Spec review: no blockers for #57 acceptance criteria.