### PR TITLE
Implement RM-11 Anthropic endpoint

### DIFF
--- a/src/protocols/anthropic_messages/bridge.ts
+++ b/src/protocols/anthropic_messages/bridge.ts
@@ -1,0 +1,214 @@
+import { GatewayFailureError } from "../../gateway/failures.js";
+import type { ChatResponse } from "../chat_completions/types.js";
+import { asRecord, normalizeToolId, positiveInteger } from "./common.js";
+
+function parseJsonObject(bytes: Uint8Array): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+    const object = asRecord(parsed);
+    if (object === undefined) {
+      throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+    }
+    return object;
+  } catch (error: unknown) {
+    if (error instanceof GatewayFailureError) {
+      throw error;
+    }
+    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+  }
+}
+export function convertChatResponse(response: ChatResponse): unknown {
+  const payload = parseJsonObject(response.body);
+  const choices = Array.isArray(payload.choices) ? payload.choices : undefined;
+  if (choices === undefined || choices.length === 0) {
+    throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+  }
+  const content: unknown[] = [];
+  for (const choice of choices) {
+    if (choice === null || typeof choice !== "object" || Array.isArray(choice)) {
+      continue;
+    }
+    appendChoiceContent(content, choice as Record<string, unknown>);
+  }
+  return {
+    id: typeof payload.id === "string" ? payload.id : "",
+    type: "message",
+    role: "assistant",
+    model: typeof payload.model === "string" ? payload.model : "unknown-model",
+    content,
+    stop_reason: anthropicStopReason((choices[0] as Record<string, unknown>).finish_reason),
+    stop_sequence: null,
+    usage: anthropicUsage(payload.usage),
+  };
+}
+
+function appendChoiceContent(content: unknown[], choice: Record<string, unknown>): void {
+  const message = choice.message;
+  if (message === null || typeof message !== "object" || Array.isArray(message)) {
+    return;
+  }
+  const record = message as Record<string, unknown>;
+  const thinkingBlocks = Array.isArray(record.thinking_blocks) ? record.thinking_blocks : undefined;
+  if (thinkingBlocks !== undefined && thinkingBlocks.length > 0) {
+    for (const block of thinkingBlocks) {
+      appendThinkingBlock(content, block);
+    }
+  } else if (typeof record.reasoning_content === "string" && record.reasoning_content.length > 0) {
+    content.push({ type: "thinking", thinking: record.reasoning_content, signature: null });
+  }
+  if (record.content !== null && record.content !== undefined) {
+    content.push({ type: "text", text: String(record.content) });
+  }
+  if (Array.isArray(record.tool_calls)) {
+    for (const toolCall of record.tool_calls) {
+      content.push(convertChatToolCall(toolCall));
+    }
+  }
+}
+
+function appendThinkingBlock(content: unknown[], block: unknown): void {
+  if (block === null || typeof block !== "object" || Array.isArray(block)) {
+    return;
+  }
+  const record = block as Record<string, unknown>;
+  if (record.type === "redacted_thinking") {
+    content.push({ type: "redacted_thinking", data: typeof record.data === "string" ? record.data : "" });
+    return;
+  }
+  if (record.type === "thinking" && typeof record.thinking === "string" && record.thinking.trim().length > 0) {
+    content.push({
+      type: "thinking",
+      thinking: record.thinking,
+      signature: typeof record.signature === "string" ? record.signature : null,
+    });
+  }
+}
+
+function convertChatToolCall(value: unknown): unknown {
+  const outer = value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const fn = outer.function !== null && typeof outer.function === "object" && !Array.isArray(outer.function)
+    ? outer.function as Record<string, unknown>
+    : {};
+  const rawId = typeof outer.id === "string" ? outer.id : "";
+  const block: Record<string, unknown> = {
+    type: "tool_use",
+    id: normalizeToolId(rawId).id,
+    name: typeof fn.name === "string" ? fn.name : "",
+    input: parseToolArguments(typeof fn.arguments === "string" ? fn.arguments : ""),
+  };
+  const signature = typeof outer.thought_signature === "string" && outer.thought_signature.length > 0
+    ? outer.thought_signature
+    : typeof fn.thought_signature === "string" && fn.thought_signature.length > 0
+      ? fn.thought_signature
+      : undefined;
+  if (signature !== undefined) {
+    block.provider_specific_fields = { signature };
+  }
+  return block;
+}
+
+function parseToolArguments(value: string): unknown {
+  if (value.trim().length === 0) {
+    return {};
+  }
+  try {
+    return JSON.parse(value) as unknown;
+  } catch (_error: unknown) {
+    const repaired = repairJson(value);
+    if (repaired === undefined) {
+      throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+    }
+    try {
+      return JSON.parse(repaired) as unknown;
+    } catch (error: unknown) {
+      throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+    }
+  }
+}
+
+function repairJson(value: string): string | undefined {
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+  for (const char of value) {
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === "\"") {
+      inString = true;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      stack.push(char);
+      continue;
+    }
+    if (char === "}" || char === "]") {
+      stack.pop();
+    }
+  }
+  if (inString || stack.length === 0) {
+    return undefined;
+  }
+  let repaired = value.replace(/,\s*$/u, "").replace(/,\s*([}\]])/gu, "$1");
+  while (stack.length > 0) {
+    const opener = stack.pop();
+    repaired += opener === "{" ? "}" : "]";
+  }
+  return repaired;
+}
+
+export function anthropicStopReason(value: unknown): "end_turn" | "max_tokens" | "tool_use" {
+  if (value === "length") {
+    return "max_tokens";
+  }
+  if (value === "tool_calls") {
+    return "tool_use";
+  }
+  return "end_turn";
+}
+
+export function anthropicUsage(value: unknown): Record<string, unknown> {
+  const usage = value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const details = usage.prompt_tokens_details !== null
+    && typeof usage.prompt_tokens_details === "object"
+    && !Array.isArray(usage.prompt_tokens_details)
+    ? usage.prompt_tokens_details as Record<string, unknown>
+    : {};
+  const cacheRead = positiveInteger(usage.cache_read_input_tokens)
+    ?? positiveInteger(usage._cache_read_input_tokens)
+    ?? positiveInteger(details.cached_tokens)
+    ?? 0;
+  const cacheCreation = positiveInteger(usage.cache_creation_input_tokens)
+    ?? positiveInteger(usage._cache_creation_input_tokens)
+    ?? positiveInteger(details.cache_creation_tokens)
+    ?? positiveInteger(details.cache_write_tokens)
+    ?? 0;
+  const promptTokens = positiveInteger(usage.prompt_tokens) ?? 0;
+  const completionTokens = positiveInteger(usage.completion_tokens) ?? 0;
+  const result: Record<string, unknown> = {
+    input_tokens: Math.max(0, promptTokens - cacheRead - cacheCreation),
+    output_tokens: completionTokens,
+  };
+  if (cacheRead > 0) {
+    result.cache_read_input_tokens = cacheRead;
+  }
+  if (cacheCreation > 0) {
+    result.cache_creation_input_tokens = cacheCreation;
+  }
+  const webSearch = positiveInteger(details.web_search_requests);
+  if (webSearch !== undefined) {
+    result.server_tool_use = { web_search_requests: webSearch };
+  }
+  return result;
+}

--- a/src/protocols/anthropic_messages/common.ts
+++ b/src/protocols/anthropic_messages/common.ts
@@ -1,0 +1,50 @@
+import {
+  isWireJsonNumber,
+  memberValues,
+  serializeWireJson,
+  type WireJson,
+  type WireJsonObject,
+} from "../../serialization/wire_json.js";
+
+export function firstMember(object: WireJsonObject, key: string): WireJson | undefined {
+  return memberValues(object, key)[0];
+}
+
+export function wireToJson(value: WireJson): unknown {
+  return JSON.parse(new TextDecoder().decode(serializeWireJson(value))) as unknown;
+}
+
+export function emptyWireObject(): WireJsonObject {
+  return { kind: "object", members: [] };
+}
+
+export function positiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+export function unsignedInteger(value: WireJson | undefined): number | undefined {
+  if (!isWireJsonNumber(value)) {
+    return undefined;
+  }
+  const parsed = Number(value.lexeme);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+export function normalizeToolId(raw: string): { readonly id: string; readonly signature?: string } {
+  const thoughtIndex = raw.indexOf("__thought__");
+  const base = thoughtIndex >= 0 ? raw.slice(0, thoughtIndex) : raw;
+  const signature = thoughtIndex >= 0 ? raw.slice(thoughtIndex + "__thought__".length) : undefined;
+  const id = base.replace(/[^a-zA-Z0-9_-]/gu, "_") || "tool_use_id";
+  return signature === undefined || signature.length === 0 ? { id } : { id, signature };
+}
+
+export function isTextPart(value: unknown): value is { readonly type: "text"; readonly text: string } {
+  const record = asRecord(value);
+  return record?.type === "text" && typeof record.text === "string";
+}

--- a/src/protocols/anthropic_messages/endpoint.ts
+++ b/src/protocols/anthropic_messages/endpoint.ts
@@ -1,0 +1,275 @@
+import { AccountDirectoryError, type AccountDirectory } from "../../accounts/account_directory.js";
+import type { AccountModelPreferences } from "../../accounts/model_preferences.js";
+import type { CopilotBackend } from "../../copilot/backend.js";
+import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
+import { CapiFetchError } from "../../copilot/models_source.js";
+import { GatewayFailureError, type GatewayFailure } from "../../gateway/failures.js";
+import type { RouteRegistration } from "../../gateway/hono_app.js";
+import { memberValues, type WireJsonObject } from "../../serialization/wire_json.js";
+import type { ChatRequest } from "../chat_completions/types.js";
+import { resolveModel } from "../model_catalog/resolver.js";
+import { convertChatResponse } from "./bridge.js";
+import { convertAnthropicRequest } from "./request.js";
+import { createAnthropicStreamResponse } from "./stream.js";
+import { anthropicErrorBody, type AnthropicErrorType } from "./wire.js";
+
+export interface AnthropicMessagesRouteDependencies {
+  readonly directory: AccountDirectory;
+  readonly catalog: CopilotModelCatalog;
+  readonly preferences: AccountModelPreferences;
+  readonly copilot: CopilotBackend;
+  readonly createUuid?: () => string;
+}
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+} as const;
+
+export function createAnthropicMessagesRoute(dependencies: AnthropicMessagesRouteDependencies): RouteRegistration {
+  return {
+    method: "POST",
+    path: "/v1/messages",
+    admission: "inference",
+    body: "wire-json-object",
+    presentFailure: presentAnthropicFailure,
+    endpoint: async (request, scope) => {
+      if (request.body === undefined) {
+        throw new GatewayFailureError({ kind: "invalid_request" });
+      }
+      assertAnthropicVersion(request.headers);
+      const requestedModel = readRequestedModel(request.body);
+      const account = await bindAccount(dependencies, scope.signal);
+      const catalog = await loadCatalog(dependencies, account.accountId, scope.signal);
+      const resolved = resolveModel(catalog, requestedModel.value, dependencies.preferences.get(account.accountId));
+      if ("kind" in resolved) {
+        throw new GatewayFailureError({ kind: resolved.kind });
+      }
+      const chatBody = convertAnthropicRequest(request.body, resolved.upstreamModel, requestedModel.value);
+      const stream = chatBody.stream === true;
+      const copilot = await dependencies.copilot.bind(account, scope.signal);
+      const chatRequest: ChatRequest = {
+        model: resolved.upstreamModel,
+        body: new TextEncoder().encode(JSON.stringify(chatBody)),
+        stream,
+        hasVisionInput: hasVisionInput(chatBody.messages),
+        nonstreamBodyBytes: scope.config.limits.nonstreamBodyBytes,
+        connectTimeoutMs: scope.config.timeouts.connectMs,
+        firstByteTimeoutMs: scope.config.timeouts.firstByteMs,
+        signal: scope.signal,
+      };
+
+      if (!stream) {
+        const upstream = await copilot.completeChat(chatRequest);
+        throwIfUpstreamHttp(upstream);
+        if (upstream.body.byteLength > scope.config.limits.nonstreamBodyBytes) {
+          throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+        }
+        const body = convertChatResponse(upstream);
+        return new Response(JSON.stringify(body), {
+          headers: { ...JSON_HEADERS, "request-id": scope.requestId },
+        });
+      }
+
+      const upstream = await copilot.openChatStream(chatRequest);
+      throwIfUpstreamHttp(upstream);
+      return createAnthropicStreamResponse({
+        upstream,
+        model: resolved.upstreamModel,
+        createUuid: dependencies.createUuid ?? crypto.randomUUID.bind(crypto),
+        scope,
+      });
+    },
+  };
+}
+
+function presentAnthropicFailure(failure: Readonly<GatewayFailure>, requestId: string): Response {
+  const mapped = mapAnthropicFailure(failure);
+  const headers = new Headers({ ...JSON_HEADERS, "request-id": requestId });
+  if (failure.kind === "upstream_http" && failure.retryAfter !== undefined) {
+    headers.set("retry-after", failure.retryAfter);
+  }
+  return new Response(anthropicErrorBody(mapped.type, mapped.message, requestId), {
+    status: mapped.status,
+    headers,
+  });
+}
+
+function mapAnthropicFailure(failure: Readonly<GatewayFailure>): {
+  readonly status: number;
+  readonly type: AnthropicErrorType;
+  readonly message: string;
+} {
+  if (failure.kind === "upstream_http") {
+    return {
+      status: failure.status,
+      type: upstreamAnthropicErrorType(failure.status),
+      message: "upstream request failed",
+    };
+  }
+  if (failure.kind === "body_too_large") {
+    return { status: 413, type: "request_too_large", message: "request body too large" };
+  }
+  if (failure.kind === "unsupported_media_type") {
+    return { status: 415, type: "invalid_request_error", message: "unsupported media type" };
+  }
+  if (failure.kind === "unsupported_semantics") {
+    return { status: 400, type: "invalid_request_error", message: "unsupported semantics" };
+  }
+  if (failure.kind === "authentication") {
+    return { status: 401, type: "authentication_error", message: "authentication failed" };
+  }
+  if (failure.kind === "permission") {
+    return { status: 403, type: "permission_error", message: "permission denied" };
+  }
+  if (failure.kind === "model_not_found") {
+    return { status: 404, type: "not_found_error", message: "model not found" };
+  }
+  if (failure.kind === "queue_full" || failure.kind === "queue_timeout") {
+    return { status: 529, type: "overloaded_error", message: "server overloaded" };
+  }
+  if (failure.kind === "upstream_timeout") {
+    return { status: 504, type: "timeout_error", message: "upstream timeout" };
+  }
+  if (failure.kind === "upstream_network") {
+    return { status: 502, type: "api_error", message: "upstream request failed" };
+  }
+  if (failure.kind === "invalid_upstream_response") {
+    return { status: 502, type: "api_error", message: "invalid upstream response" };
+  }
+  if (failure.kind === "internal") {
+    return { status: 500, type: "api_error", message: "internal error" };
+  }
+  return { status: 400, type: "invalid_request_error", message: "invalid request" };
+}
+
+function upstreamAnthropicErrorType(status: number): AnthropicErrorType {
+  if (status === 400 || status === 415 || status === 422) {
+    return "invalid_request_error";
+  }
+  if (status === 401) {
+    return "authentication_error";
+  }
+  if (status === 402) {
+    return "billing_error";
+  }
+  if (status === 403) {
+    return "permission_error";
+  }
+  if (status === 404) {
+    return "not_found_error";
+  }
+  if (status === 413) {
+    return "request_too_large";
+  }
+  if (status === 429) {
+    return "rate_limit_error";
+  }
+  if (status === 504) {
+    return "timeout_error";
+  }
+  if (status === 529) {
+    return "overloaded_error";
+  }
+  return "api_error";
+}
+
+function assertAnthropicVersion(headers: Headers): void {
+  const value = headers.get("anthropic-version");
+  if (value === null || value.includes(",") || value.trim() !== "2023-06-01") {
+    throw new GatewayFailureError({ kind: "invalid_request" });
+  }
+}
+
+function readRequestedModel(body: WireJsonObject): { readonly value: string | undefined } {
+  const values = memberValues(body, "model");
+  if (values.length === 0) {
+    return { value: undefined };
+  }
+  const value = values[0];
+  if (typeof value !== "string") {
+    throw new GatewayFailureError({ kind: "invalid_request" });
+  }
+  return { value };
+}
+
+async function bindAccount(
+  dependencies: AnthropicMessagesRouteDependencies,
+  signal: AbortSignal,
+) {
+  try {
+    return await dependencies.directory.bindDefault(signal);
+  } catch (error: unknown) {
+    if (error instanceof AccountDirectoryError && (error.code === "no_default" || error.code === "not_found")) {
+      throw new GatewayFailureError({ kind: "authentication" });
+    }
+    throw error;
+  }
+}
+
+async function loadCatalog(
+  dependencies: AnthropicMessagesRouteDependencies,
+  accountId: string,
+  signal: AbortSignal,
+) {
+  try {
+    const catalog = await dependencies.catalog.get(accountId, signal);
+    dependencies.preferences.markInvalidIfMissing(
+      accountId,
+      new Set(catalog.models.map((model) => model.id)),
+      catalog.generation,
+    );
+    return catalog;
+  } catch (error: unknown) {
+    if (error instanceof CapiFetchError) {
+      if (error.failureKind === "upstream_timeout") {
+        throw new GatewayFailureError({ kind: "upstream_timeout", cause: error });
+      }
+      if (error.failureKind === "upstream_network") {
+        throw new GatewayFailureError({ kind: "upstream_network", cause: error });
+      }
+      if (error.failureKind === "invalid_upstream_response") {
+        throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+      }
+      throw new GatewayFailureError({
+        kind: "upstream_http",
+        status: error.status,
+        ...(error.retryAfter === undefined ? {} : { retryAfter: error.retryAfter }),
+      });
+    }
+    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+  }
+}
+
+function throwIfUpstreamHttp(response: { readonly status: number; readonly headers: Headers }): void {
+  if (response.status < 400) {
+    return;
+  }
+  const retryAfter = retryAfterHeader(response.status, response.headers);
+  throw new GatewayFailureError({
+    kind: "upstream_http",
+    status: response.status,
+    ...(retryAfter === undefined ? {} : { retryAfter }),
+  });
+}
+
+function retryAfterHeader(status: number, headers: Headers): string | undefined {
+  if (status !== 429) {
+    return undefined;
+  }
+  const value = headers.get("retry-after");
+  if (value === null || value.length === 0) {
+    return undefined;
+  }
+  if (/^\d+$/u.test(value)) {
+    return value;
+  }
+  if (value.includes(",") && !/^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT$/u.test(value)) {
+    return undefined;
+  }
+  return Number.isNaN(Date.parse(value)) ? undefined : value;
+}
+
+function hasVisionInput(messages: unknown[]): boolean {
+  return JSON.stringify(messages).includes("\"image_url\"");
+}

--- a/src/protocols/anthropic_messages/request.ts
+++ b/src/protocols/anthropic_messages/request.ts
@@ -1,0 +1,557 @@
+import { GatewayFailureError } from "../../gateway/failures.js";
+import { canonicalizeWireJson } from "../../serialization/canonical_json.js";
+import {
+  isWireJsonArray,
+  isWireJsonObject,
+  parseWireJson,
+  type WireJson,
+  type WireJsonArray,
+  type WireJsonObject,
+} from "../../serialization/wire_json.js";
+import { asRecord, emptyWireObject, firstMember, isTextPart, unsignedInteger, wireToJson } from "./common.js";
+export interface ChatRequestBody {
+  [key: string]: unknown;
+  model: string;
+  messages: unknown[];
+  max_tokens?: unknown;
+  max_completion_tokens?: unknown;
+  temperature?: unknown;
+  top_p?: unknown;
+  stop?: unknown;
+  stream?: unknown;
+  stream_options?: { include_usage: true };
+  tools?: unknown[];
+  tool_choice?: unknown;
+  reasoning_effort?: string;
+}
+
+export function convertAnthropicRequest(
+  request: WireJsonObject,
+  resolvedModel: string,
+  rawModel: string | undefined,
+): ChatRequestBody {
+  const messagesValue = firstMember(request, "messages");
+  if (!isWireJsonArray(messagesValue)) {
+    throw new GatewayFailureError({ kind: "invalid_request" });
+  }
+  const result: ChatRequestBody = {
+    model: resolvedModel,
+    messages: convertMessages(request, messagesValue, rawModel ?? resolvedModel),
+  };
+  copyMaxTokens(request, result, rawModel);
+  copyIfPresent(request, "temperature", result, "temperature");
+  copyIfPresent(request, "top_p", result, "top_p");
+  copyIfPresent(request, "stop_sequences", result, "stop");
+  copyIfPresent(request, "stream", result, "stream");
+  if (result.stream === true) {
+    result.stream_options = { include_usage: true };
+  }
+  const tools = convertTools(firstMember(request, "tools"));
+  if (tools.length > 0) {
+    result.tools = tools;
+  }
+  const toolChoice = convertToolChoice(firstMember(request, "tool_choice"));
+  if (toolChoice !== undefined) {
+    result.tool_choice = toolChoice;
+  }
+  const reasoning = convertReasoning(request, rawModel ?? resolvedModel);
+  if (reasoning !== undefined) {
+    result.reasoning_effort = reasoning;
+  }
+  return result;
+}
+
+function copyIfPresent(
+  source: WireJsonObject,
+  sourceKey: string,
+  target: Record<string, unknown>,
+  targetKey: string,
+): void {
+  const value = firstMember(source, sourceKey);
+  if (value !== undefined) {
+    target[targetKey] = wireToJson(value);
+  }
+}
+
+function copyMaxTokens(source: WireJsonObject, target: ChatRequestBody, rawModel: string | undefined): void {
+  const value = firstMember(source, "max_tokens");
+  if (value === undefined) {
+    return;
+  }
+  if (rawModel !== undefined && /^o[0-9]/u.test(rawModel)) {
+    target.max_completion_tokens = wireToJson(value);
+    return;
+  }
+  target.max_tokens = wireToJson(value);
+}
+
+function convertMessages(
+  request: WireJsonObject,
+  messages: WireJsonArray,
+  model: string,
+): unknown[] {
+  const converted: unknown[] = [];
+  const systemMessages = systemChatMessages(firstMember(request, "system"));
+  for (const item of messages.items) {
+    converted.push(...convertMessage(item, model));
+  }
+  if (systemMessages.length === 1) {
+    return [systemMessages[0], ...converted];
+  }
+  if (systemMessages.length > 1) {
+    const content = systemMessages
+      .map((message) => typeof message.content === "string" ? message.content : "")
+      .filter((text) => text.length > 0)
+      .join("\n");
+    if (content.length > 0) {
+      return [{ role: "system", content }, ...converted];
+    }
+  }
+  return converted;
+}
+
+function systemChatMessages(system: WireJson | undefined): Array<{ role: "system"; content: unknown }> {
+  if (typeof system === "string") {
+    const text = stripBillingHeader(system);
+    return text.length === 0 ? [] : [{ role: "system", content: text }];
+  }
+  if (!isWireJsonArray(system)) {
+    return [];
+  }
+  const messages: Array<{ role: "system"; content: unknown }> = [];
+  for (const item of system.items) {
+    if (!isWireJsonObject(item)) {
+      continue;
+    }
+    const text = firstMember(item, "text");
+    if (typeof text !== "string") {
+      continue;
+    }
+    const stripped = stripBillingHeader(text);
+    if (stripped.length > 0) {
+      messages.push({ role: "system", content: stripped });
+    }
+  }
+  return messages;
+}
+
+function stripBillingHeader(text: string): string {
+  const prefix = "x-anthropic-billing-header:";
+  if (!text.startsWith(prefix)) {
+    return text;
+  }
+  let rest = text.slice(prefix.length);
+  const firstLineBreak = rest.match(/\r\n|\n|\r/u);
+  if (firstLineBreak === null || firstLineBreak.index === undefined) {
+    return "";
+  }
+  rest = rest.slice(firstLineBreak.index + firstLineBreak[0].length);
+  if (rest.startsWith("\r\n")) {
+    return rest.slice(2);
+  }
+  if (rest.startsWith("\n") || rest.startsWith("\r")) {
+    return rest.slice(1);
+  }
+  return rest;
+}
+
+function convertMessage(value: WireJson, model: string): unknown[] {
+  if (!isWireJsonObject(value)) {
+    return [];
+  }
+  const role = typeof firstMember(value, "role") === "string" ? firstMember(value, "role") as string : "user";
+  const content = firstMember(value, "content");
+  if (content === undefined) {
+    return [{ role, content: null }];
+  }
+  if (typeof content === "string") {
+    return [{ role, content }];
+  }
+  if (!isWireJsonArray(content)) {
+    return [{ role, content: wireToJson(content) }];
+  }
+
+  const toolMessages: unknown[] = [];
+  const parts: unknown[] = [];
+  const toolCalls: unknown[] = [];
+  const thinking: string[] = [];
+  for (const block of content.items) {
+    if (!isWireJsonObject(block)) {
+      continue;
+    }
+    const type = firstMember(block, "type");
+    if (type === "text") {
+      const text = firstMember(block, "text");
+      if (typeof text === "string") {
+        parts.push({ type: "text", text });
+      }
+      continue;
+    }
+    if (type === "image") {
+      const image = convertImage(block);
+      if (image !== undefined) {
+        parts.push(image);
+      }
+      continue;
+    }
+    if (type === "tool_use") {
+      toolCalls.push(convertToolUse(block));
+      continue;
+    }
+    if (type === "tool_result") {
+      toolMessages.push(convertToolResult(block));
+      continue;
+    }
+    if (type === "thinking") {
+      const text = firstMember(block, "thinking");
+      if (typeof text === "string" && text.length > 0) {
+        thinking.push(text);
+      }
+      continue;
+    }
+    if (type === "redacted_thinking") {
+      thinking.push("[redacted thinking]");
+    }
+  }
+  const output: unknown[] = [...toolMessages];
+  const mediaMessage = mediaUserMessage(toolMessages);
+  if (mediaMessage !== undefined) {
+    output.push(mediaMessage);
+  }
+  if (parts.length > 0 || toolCalls.length > 0) {
+    const message: Record<string, unknown> = {
+      role,
+      content: parts.length === 1 && isTextPart(parts[0])
+        ? parts[0].text
+        : parts.length === 0
+          ? null
+          : parts,
+    };
+    if (toolCalls.length > 0) {
+      message.tool_calls = toolCalls;
+      if (role === "assistant" && preservesThinkingHistory(model)) {
+        message.reasoning_content = thinking.length > 0 ? thinking.join("\n") : "tool call";
+      }
+    }
+    output.push(message);
+  }
+  return output;
+}
+
+function convertImage(block: WireJsonObject): unknown | undefined {
+  const source = firstMember(block, "source");
+  if (!isWireJsonObject(source)) {
+    return undefined;
+  }
+  const sourceType = firstMember(source, "type");
+  if (sourceType === "base64") {
+    const mediaType = firstMember(source, "media_type");
+    const data = firstMember(source, "data");
+    if (typeof mediaType === "string" && typeof data === "string") {
+      return { type: "image_url", image_url: { url: `data:${mediaType};base64,${data}` } };
+    }
+  }
+  if (sourceType === "url") {
+    const url = firstMember(source, "url");
+    if (typeof url === "string") {
+      return { type: "image_url", image_url: { url } };
+    }
+  }
+  return undefined;
+}
+
+function convertToolUse(block: WireJsonObject): unknown {
+  const id = firstMember(block, "id");
+  const name = firstMember(block, "name");
+  const input = firstMember(block, "input") ?? emptyWireObject();
+  return {
+    id: typeof id === "string" ? id : "",
+    type: "function",
+    function: {
+      name: typeof name === "string" ? name : "",
+      arguments: new TextDecoder().decode(canonicalizeWireJson(input)),
+    },
+  };
+}
+
+function convertToolResult(block: WireJsonObject): unknown {
+  const id = firstMember(block, "tool_use_id");
+  const content = firstMember(block, "content");
+  const callId = typeof id === "string" ? id : "";
+  let text = "";
+  let media: unknown[] = [];
+  if (typeof content === "string") {
+    const extracted = extractMediaFromString(content);
+    text = extracted.text;
+    media = extracted.media;
+  } else if (content !== undefined) {
+    const extracted = extractToolResultMedia(content);
+    text = new TextDecoder().decode(canonicalizeWireJson(extracted.value));
+    media = extracted.media;
+  }
+  return {
+    role: "tool",
+    tool_call_id: callId,
+    content: text,
+    ...(media.length === 0 ? {} : { __anthropicMedia: { callId, media } }),
+  };
+}
+
+function mediaUserMessage(toolMessages: unknown[]): unknown | undefined {
+  const content: unknown[] = [];
+  for (const message of toolMessages) {
+    const record = asRecord(message);
+    const mediaRecord = asRecord(record?.__anthropicMedia);
+    if (mediaRecord === undefined || !Array.isArray(mediaRecord.media)) {
+      continue;
+    }
+    content.push({
+      type: "text",
+      text: `[cc-switch: media output of tool call ${String(mediaRecord.callId ?? "")}]`,
+    });
+    content.push(...mediaRecord.media);
+    delete record?.__anthropicMedia;
+  }
+  return content.length === 0 ? undefined : { role: "user", content };
+}
+
+function extractMediaFromString(content: string): { readonly text: string; readonly media: unknown[] } {
+  const trimmed = content.trim();
+  if (trimmed.startsWith("data:image/") && trimmed.length >= 8192) {
+    return {
+      text: "[cc-switch: tool result media moved to the following user message]",
+      media: [{ type: "image_url", image_url: { url: trimmed } }],
+    };
+  }
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = parseWireJson(new TextEncoder().encode(trimmed), { maxBytes: trimmed.length, maxDepth: 32 });
+      const extracted = extractToolResultMedia(parsed);
+      if (extracted.media.length > 0) {
+        return { text: new TextDecoder().decode(canonicalizeWireJson(extracted.value)), media: extracted.media };
+      }
+    } catch (_error: unknown) {
+      return { text: content, media: [] };
+    }
+  }
+  return { text: content, media: [] };
+}
+
+function extractToolResultMedia(value: WireJson, depth = 0): { readonly value: WireJson; readonly media: unknown[] } {
+  if (depth > 32) {
+    return { value, media: [] };
+  }
+  const media = mediaPartFromWire(value);
+  if (media !== undefined) {
+    return {
+      value: "[cc-switch: tool result media moved to the following user message]",
+      media: [media],
+    };
+  }
+  if (isWireJsonArray(value)) {
+    const items: WireJson[] = [];
+    const mediaParts: unknown[] = [];
+    for (const item of value.items) {
+      const extracted = extractToolResultMedia(item, depth + 1);
+      items.push(extracted.value);
+      mediaParts.push(...extracted.media);
+    }
+    return { value: { kind: "array", items }, media: mediaParts };
+  }
+  if (isWireJsonObject(value)) {
+    const members: Array<{ key: string; value: WireJson }> = [];
+    const mediaParts: unknown[] = [];
+    for (const member of value.members) {
+      const extracted = extractToolResultMedia(member.value, depth + 1);
+      members.push({ key: member.key, value: extracted.value });
+      mediaParts.push(...extracted.media);
+    }
+    return { value: { kind: "object", members }, media: mediaParts };
+  }
+  return { value, media: [] };
+}
+
+function mediaPartFromWire(value: WireJson): unknown | undefined {
+  if (!isWireJsonObject(value)) {
+    return undefined;
+  }
+  const type = firstMember(value, "type");
+  if (type === "image") {
+    const source = firstMember(value, "source");
+    if (isWireJsonObject(source)) {
+      const mediaType = firstMember(source, "media_type") ?? firstMember(source, "mimeType");
+      const data = firstMember(source, "data");
+      const url = firstMember(source, "url");
+      if (typeof url === "string") {
+        return { type: "image_url", image_url: { url } };
+      }
+      if (typeof mediaType === "string" && typeof data === "string") {
+        return { type: "image_url", image_url: { url: `data:${mediaType};base64,${data}` } };
+      }
+    }
+    const mimeType = firstMember(value, "mimeType");
+    const data = firstMember(value, "data");
+    if (typeof mimeType === "string" && typeof data === "string") {
+      return { type: "image_url", image_url: { url: `data:${mimeType};base64,${data}` } };
+    }
+  }
+  if (type === "image_url") {
+    const imageUrl = firstMember(value, "image_url");
+    return { type: "image_url", image_url: wireToJson(imageUrl ?? emptyWireObject()) };
+  }
+  if (type === "input_file" && (firstMember(value, "file_id") !== undefined || firstMember(value, "file_data") !== undefined)) {
+    const file: Record<string, unknown> = {};
+    copyMediaField(value, file, "file_id");
+    copyMediaField(value, file, "file_data");
+    copyMediaField(value, file, "filename");
+    return { type: "file", file };
+  }
+  if (type === "input_audio") {
+    const inputAudio = firstMember(value, "input_audio");
+    if (inputAudio !== undefined) {
+      return { type: "input_audio", input_audio: wireToJson(inputAudio) };
+    }
+  }
+  return undefined;
+}
+
+function copyMediaField(source: WireJsonObject, target: Record<string, unknown>, key: string): void {
+  const value = firstMember(source, key);
+  if (value !== undefined) {
+    target[key] = wireToJson(value);
+  }
+}
+
+function convertTools(value: WireJson | undefined): unknown[] {
+  if (!isWireJsonArray(value)) {
+    return [];
+  }
+  const tools: unknown[] = [];
+  for (const item of value.items) {
+    if (!isWireJsonObject(item) || firstMember(item, "type") === "BatchTool") {
+      continue;
+    }
+    const name = firstMember(item, "name");
+    const description = firstMember(item, "description");
+    const inputSchema = firstMember(item, "input_schema") ?? emptyWireObject();
+    tools.push({
+      type: "function",
+      function: {
+        name: typeof name === "string" ? name : "",
+        description: description === undefined ? null : wireToJson(description),
+        parameters: cleanupSchema(wireToJson(inputSchema)),
+      },
+    });
+  }
+  return tools;
+}
+
+function cleanupSchema(value: unknown): unknown {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  if (!("type" in record)) {
+    record.type = "object";
+    if (!("properties" in record)) {
+      record.properties = {};
+    }
+  }
+  if (record.format === "uri") {
+    delete record.format;
+  }
+  if (record.properties !== null && typeof record.properties === "object" && !Array.isArray(record.properties)) {
+    for (const child of Object.values(record.properties as Record<string, unknown>)) {
+      cleanupSchema(child);
+    }
+  }
+  cleanupSchema(record.items);
+  return record;
+}
+
+function convertToolChoice(value: WireJson | undefined): unknown | undefined {
+  if (typeof value === "string") {
+    if (value === "auto") {
+      return "auto";
+    }
+    if (value === "any") {
+      return "required";
+    }
+    if (value === "none") {
+      return "none";
+    }
+    return value;
+  }
+  if (!isWireJsonObject(value)) {
+    return value === undefined ? undefined : wireToJson(value);
+  }
+  const type = firstMember(value, "type");
+  if (type === "auto") {
+    return "auto";
+  }
+  if (type === "any") {
+    return "required";
+  }
+  if (type === "none") {
+    return "none";
+  }
+  if (type === "tool") {
+    const name = firstMember(value, "name");
+    return { type: "function", function: { name: typeof name === "string" ? name : "" } };
+  }
+  return wireToJson(value);
+}
+
+function convertReasoning(request: WireJsonObject, model: string): string | undefined {
+  if (!supportsReasoning(model)) {
+    return undefined;
+  }
+  const outputConfig = firstMember(request, "output_config");
+  if (isWireJsonObject(outputConfig)) {
+    const effort = firstMember(outputConfig, "effort");
+    if (typeof effort === "string") {
+      if (effort === "low" || effort === "medium" || effort === "high") {
+        return effort;
+      }
+      if (effort === "max") {
+        return "xhigh";
+      }
+      return undefined;
+    }
+  }
+  const thinking = firstMember(request, "thinking");
+  if (!isWireJsonObject(thinking)) {
+    return undefined;
+  }
+  if (firstMember(thinking, "type") === "adaptive") {
+    return "xhigh";
+  }
+  if (firstMember(thinking, "type") !== "enabled") {
+    return undefined;
+  }
+  const budget = unsignedInteger(firstMember(thinking, "budget_tokens"));
+  if (budget === undefined) {
+    return "high";
+  }
+  if (budget < 4000) {
+    return "low";
+  }
+  if (budget < 16000) {
+    return "medium";
+  }
+  return "high";
+}
+
+function supportsReasoning(model: string): boolean {
+  const lower = model.toLowerCase();
+  return /^o[0-9]/u.test(lower)
+    || /^gpt-[5-9]/u.test(lower)
+    || lower === "grok-4.5"
+    || lower.startsWith("grok-4.5-")
+    || lower.startsWith("grok-build-");
+}
+
+function preservesThinkingHistory(model: string): boolean {
+  const lower = model.toLowerCase();
+  return lower.includes("deepseek") || lower.includes("mimo") || lower.includes("xiaomimimo");
+}

--- a/src/protocols/anthropic_messages/stream.ts
+++ b/src/protocols/anthropic_messages/stream.ts
@@ -1,0 +1,328 @@
+import { iterateChatFrames } from "../../copilot/backend.js";
+import { GatewayFailureError } from "../../gateway/failures.js";
+import type { RequestScope } from "../../gateway/request_scope.js";
+import { createStreamResponseWriter } from "../../gateway/stream_response.js";
+import type { UpstreamByteStream } from "../chat_completions/types.js";
+import { anthropicStopReason, anthropicUsage } from "./bridge.js";
+import { asRecord, normalizeToolId, wireToJson } from "./common.js";
+import { encodeAnthropicSse, type AnthropicEvent } from "./wire.js";
+
+const STREAM_HEADERS = {
+  "Content-Type": "text/event-stream; charset=utf-8",
+  "Cache-Control": "no-store",
+} as const;
+
+export function createAnthropicStreamResponse(input: {
+  readonly upstream: UpstreamByteStream;
+  readonly model: string;
+  readonly createUuid: () => string;
+  readonly scope: Readonly<RequestScope>;
+}): Response {
+  const converter = new AnthropicStreamConverter(input.model, input.createUuid);
+  const writer = createStreamResponseWriter({
+    signal: input.scope.signal,
+    headers: { ...STREAM_HEADERS, "request-id": input.scope.requestId },
+  });
+  void (async () => {
+    try {
+      for (const event of converter.start()) {
+        if (!await writer.enqueue(encodeAnthropicSse(event))) {
+          return;
+        }
+      }
+      for await (const frame of iterateChatFrames(input.upstream)) {
+        if (input.scope.signal.aborted) {
+          writer.abort();
+          return;
+        }
+        if (frame.kind === "chunk") {
+          for (const event of converter.consume(wireToJson(frame.chunk.payload))) {
+            if (!await writer.enqueue(encodeAnthropicSse(event))) {
+              return;
+            }
+          }
+          continue;
+        }
+        if (frame.kind === "done") {
+          for (const event of converter.finish()) {
+            if (!await writer.enqueue(encodeAnthropicSse(event))) {
+              return;
+            }
+          }
+          writer.close();
+          return;
+        }
+        writer.close();
+        return;
+      }
+      for (const event of converter.finish()) {
+        if (!await writer.enqueue(encodeAnthropicSse(event))) {
+          return;
+        }
+      }
+      writer.close();
+    } catch (_error: unknown) {
+      writer.abort();
+    }
+  })();
+  return writer.response;
+}
+class AnthropicStreamConverter {
+  private active: { type: "text" | "thinking" | "tool"; index: number; name?: string } | undefined;
+  private nextIndex = 0;
+  private pendingFinish: { stopReason: "end_turn" | "max_tokens" | "tool_use"; usage: Record<string, unknown> } | undefined;
+  private stopped = false;
+
+  constructor(
+    private readonly model: string,
+    private readonly createUuid: () => string,
+  ) {}
+
+  start(): AnthropicEvent[] {
+    return [{
+      type: "message_start",
+      message: {
+        id: `msg_${this.createUuid()}`,
+        type: "message",
+        role: "assistant",
+        content: [],
+        model: this.model,
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    }];
+  }
+
+  consume(chunk: unknown): AnthropicEvent[] {
+    if (this.stopped) {
+      return [];
+    }
+    const object = asRecord(chunk);
+    if (object === undefined) {
+      throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+    }
+    const usage = anthropicUsage(object.usage);
+    const choices = Array.isArray(object.choices) ? object.choices : [];
+    if (choices.length === 0) {
+      if (object.usage !== undefined && this.pendingFinish !== undefined) {
+        this.pendingFinish = { ...this.pendingFinish, usage };
+        return this.flushFinish();
+      }
+      return [];
+    }
+
+    const events: AnthropicEvent[] = [];
+    let lastToolDelta: Record<string, unknown> | undefined;
+    for (const choiceValue of choices) {
+      const choice = asRecord(choiceValue);
+      if (choice === undefined) {
+        continue;
+      }
+      const delta = asRecord(choice.delta);
+      if (delta !== undefined) {
+        const toolCalls = Array.isArray(delta.tool_calls) ? delta.tool_calls : undefined;
+        if (toolCalls === undefined) {
+          events.push(...this.consumeDelta(delta));
+        } else {
+          const withoutToolCalls = { ...delta };
+          delete withoutToolCalls.tool_calls;
+          events.push(...this.consumeDelta(withoutToolCalls));
+          lastToolDelta = { tool_calls: toolCalls };
+        }
+      }
+      if (choice.finish_reason !== undefined && choice.finish_reason !== null) {
+        this.pendingFinish = {
+          stopReason: anthropicStopReason(choice.finish_reason),
+          usage: object.usage === undefined ? { input_tokens: 0, output_tokens: 0 } : usage,
+        };
+      }
+    }
+    if (lastToolDelta !== undefined) {
+      events.push(...this.consumeDelta(lastToolDelta));
+    }
+    return events;
+  }
+
+  finish(): AnthropicEvent[] {
+    if (this.stopped) {
+      return [];
+    }
+    if (this.pendingFinish !== undefined) {
+      return this.flushFinish();
+    }
+    const events = this.closeActive();
+    events.push({ type: "message_stop" });
+    this.stopped = true;
+    return events;
+  }
+
+  private consumeDelta(delta: Record<string, unknown>): AnthropicEvent[] {
+    const events: AnthropicEvent[] = [];
+    events.push(...this.consumeThinkingBlocks(delta.thinking_blocks));
+    const thinking = typeof delta.reasoning_content === "string" ? delta.reasoning_content : "";
+    if (thinking.length > 0) {
+      events.push(...this.openBlock("thinking"));
+      events.push({ type: "content_block_delta", index: this.activeIndex(), delta: { type: "thinking_delta", thinking } });
+    }
+    const content = typeof delta.content === "string" ? delta.content : "";
+    if (content.length > 0) {
+      events.push(...this.openBlock("text"));
+      events.push({ type: "content_block_delta", index: this.activeIndex(), delta: { type: "text_delta", text: content } });
+    }
+    if (Array.isArray(delta.tool_calls)) {
+      for (const callValue of delta.tool_calls) {
+        const call = asRecord(callValue);
+        if (call === undefined) {
+          continue;
+        }
+        const fn = asRecord(call.function);
+        const rawName = typeof fn?.name === "string" ? fn.name : undefined;
+        if (rawName !== undefined) {
+          const rawId = typeof call.id === "string" ? call.id : this.createUuid();
+          events.push(...this.openToolBlock(rawName, rawId));
+        }
+        const args = typeof fn?.arguments === "string" ? fn.arguments : "";
+        if (args.length > 0) {
+          if (this.active?.type !== "tool") {
+            events.push(...this.openToolBlock("", this.createUuid()));
+          }
+          events.push({
+            type: "content_block_delta",
+            index: this.activeIndex(),
+            delta: { type: "input_json_delta", partial_json: args },
+          });
+        }
+      }
+    }
+    return events;
+  }
+
+  private consumeThinkingBlocks(value: unknown): AnthropicEvent[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    const events: AnthropicEvent[] = [];
+    for (const item of value) {
+      const block = asRecord(item);
+      if (block?.type !== "thinking") {
+        continue;
+      }
+      const thinking = typeof block.thinking === "string" ? block.thinking : "";
+      const signature = typeof block.signature === "string" ? block.signature : "";
+      if (thinking.length === 0 && signature.length === 0) {
+        continue;
+      }
+      events.push(...this.openThinkingBlock(thinking, signature));
+      if (signature.length > 0) {
+        events.push({
+          type: "content_block_delta",
+          index: this.activeIndex(),
+          delta: { type: "signature_delta", signature },
+        });
+        continue;
+      }
+      if (thinking.length > 0) {
+        events.push({
+          type: "content_block_delta",
+          index: this.activeIndex(),
+          delta: { type: "thinking_delta", thinking },
+        });
+      }
+    }
+    return events;
+  }
+
+  private openBlock(type: "text" | "thinking"): AnthropicEvent[] {
+    if (this.active?.type === type) {
+      return [];
+    }
+    const events = this.closeActive();
+    const index = this.nextIndex;
+    this.nextIndex += 1;
+    this.active = { type, index };
+    events.push({
+      type: "content_block_start",
+      index,
+      content_block: type === "text"
+        ? { type: "text", text: "" }
+        : { type: "thinking", thinking: "", signature: "" },
+    });
+    return events;
+  }
+
+  private openThinkingBlock(thinking: string, signature: string): AnthropicEvent[] {
+    const events = this.closeActive();
+    const index = this.nextIndex;
+    this.nextIndex += 1;
+    this.active = { type: "thinking", index };
+    events.push({
+      type: "content_block_start",
+      index,
+      content_block: { type: "thinking", thinking, signature },
+    });
+    return events;
+  }
+
+  private openToolBlock(name: string, rawId: string): AnthropicEvent[] {
+    if (this.active?.type === "tool" && this.active.name === name) {
+      return [];
+    }
+    const events = this.closeActive();
+    const index = this.nextIndex;
+    this.nextIndex += 1;
+    const normalized = normalizeToolId(rawId);
+    const block: Record<string, unknown> = {
+      type: "tool_use",
+      id: normalized.id,
+      name,
+      input: {},
+    };
+    if (normalized.signature !== undefined) {
+      block.provider_specific_fields = { signature: normalized.signature };
+    }
+    this.active = { type: "tool", index, name };
+    events.push({ type: "content_block_start", index, content_block: block });
+    return events;
+  }
+
+  private closeActive(): AnthropicEvent[] {
+    if (this.active === undefined) {
+      return [];
+    }
+    const event = { type: "content_block_stop", index: this.active.index };
+    this.active = undefined;
+    return [event];
+  }
+
+  private flushFinish(): AnthropicEvent[] {
+    if (this.pendingFinish === undefined) {
+      return [];
+    }
+    const events: AnthropicEvent[] = [];
+    if (this.active === undefined && this.nextIndex === 0) {
+      events.push(...this.openBlock("text"));
+    }
+    events.push(...this.closeActive());
+    events.push({
+      type: "message_delta",
+      delta: { stop_reason: this.pendingFinish.stopReason },
+      usage: this.pendingFinish.usage,
+    });
+    events.push({ type: "message_stop" });
+    this.stopped = true;
+    return events;
+  }
+
+  private activeIndex(): number {
+    if (this.active === undefined) {
+      throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+    }
+    return this.active.index;
+  }
+}

--- a/src/protocols/anthropic_messages/wire.ts
+++ b/src/protocols/anthropic_messages/wire.ts
@@ -1,0 +1,69 @@
+export type AnthropicErrorType =
+  | "invalid_request_error"
+  | "request_too_large"
+  | "authentication_error"
+  | "permission_error"
+  | "not_found_error"
+  | "overloaded_error"
+  | "api_error"
+  | "timeout_error"
+  | "billing_error"
+  | "rate_limit_error";
+
+export interface AnthropicEvent {
+  readonly type: string;
+  readonly [key: string]: unknown;
+}
+
+export function anthropicErrorBody(type: AnthropicErrorType, message: string, requestId: string): string {
+  return JSON.stringify({
+    type: "error",
+    error: { type, message },
+    request_id: requestId,
+  });
+}
+
+export function encodeAnthropicSse(event: AnthropicEvent): Uint8Array {
+  return new TextEncoder().encode(`event: ${event.type}\ndata: ${pythonJsonDumps(event)}\n\n`);
+}
+
+export function pythonJsonDumps(value: unknown): string {
+  return ensureAscii(writePythonJson(value));
+}
+
+function writePythonJson(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? JSON.stringify(value) : "null";
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => writePythonJson(item)).join(", ")}]`;
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter((entry): entry is [string, unknown] => entry[1] !== undefined);
+    return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}: ${writePythonJson(entryValue)}`).join(", ")}}`;
+  }
+  return "null";
+}
+
+function ensureAscii(value: string): string {
+  let escaped = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code > 0x7f) {
+      escaped += `\\u${code.toString(16).padStart(4, "0")}`;
+    } else {
+      escaped += value[index];
+    }
+  }
+  return escaped;
+}

--- a/tests/refactor/contract/anthropic_harness.ts
+++ b/tests/refactor/contract/anthropic_harness.ts
@@ -1,0 +1,138 @@
+import { AccountDirectory } from "../../../src/accounts/account_directory.js";
+import { MemoryCredentialStore } from "../../../src/accounts/credential_store.js";
+import { ScriptedCopilotBackend } from "../../../src/copilot/backend.js";
+import { CopilotModelCatalog, type CapiModelsResponse } from "../../../src/copilot/model_catalog.js";
+import { defaultRuntimeConfigSnapshot } from "../../../src/config/schema.js";
+import { parseStartupConfig } from "../../../src/config/startup_config.js";
+import { createGateway, type Gateway, type GatewayDependencies } from "../../../src/gateway/create_gateway.js";
+import { closeDatabase, openDatabase } from "../../../src/persistence/database.js";
+import { embedMigration } from "../../../src/persistence/migrations.js";
+import { migration as runtimeConfigMigration } from "../../../src/persistence/migrations/001_runtime_config.js";
+import { migration as accountsMigration } from "../../../src/persistence/migrations/010_accounts.js";
+import { createAnthropicMessagesRoute } from "../../../src/protocols/anthropic_messages/endpoint.js";
+import type { RuntimeConfigSnapshot } from "../../../src/config/schema.js";
+import type { ChatRequest } from "../../../src/protocols/chat_completions/types.js";
+
+export const ACCOUNT_ID = "github.com/1";
+
+const nowMs = (): number => 1_700_000_000_000;
+
+export interface AnthropicGatewayFixture {
+  readonly gw: Gateway;
+  readonly backend: ScriptedCopilotBackend;
+  readonly capturedRequests: ChatRequest[];
+  close(): Promise<void>;
+}
+
+export async function anthropicGateway(options: {
+  readonly backend?: ScriptedCopilotBackend;
+  readonly runtime?: RuntimeConfigSnapshot;
+  readonly gatewayDependencies?: Readonly<GatewayDependencies>;
+  readonly preferredModel?: string;
+  readonly createUuid?: () => string;
+  readonly catalogFetch?: () => Promise<CapiModelsResponse> | CapiModelsResponse;
+} = {}): Promise<AnthropicGatewayFixture> {
+  const database = openDatabase({
+    path: ":memory:",
+    migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+    nowMs,
+  });
+  const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+  await accounts.upsertAuthenticated({
+    host: "github.com",
+    userId: "1",
+    secret: { generation: 0, githubToken: "t" },
+  });
+
+  const catalog = new CopilotModelCatalog({
+    async fetch() {
+      return options.catalogFetch?.() ?? {
+        data: [
+          { id: "gpt", name: "GPT", vendor: "github", model_picker_enabled: true },
+          { id: "o1", name: "O1", vendor: "github", model_picker_enabled: true },
+          { id: "gpt-5", name: "GPT 5", vendor: "github", model_picker_enabled: true },
+          { id: "deepseek-reasoner", name: "DeepSeek", vendor: "github", model_picker_enabled: true },
+        ],
+      };
+    },
+  }, () => new Date("2026-01-02T03:04:05.000Z"));
+
+  if (options.preferredModel !== undefined) {
+    accounts.preferences.set(ACCOUNT_ID, { modelId: options.preferredModel, catalogGeneration: 0 }, 0);
+  }
+
+  const capturedRequests: ChatRequest[] = [];
+  const backend = options.backend ?? new ScriptedCopilotBackend({
+    chat(request) {
+      capturedRequests.push(request);
+      return {
+        status: 200,
+        headers: new Headers(),
+        body: new TextEncoder().encode(JSON.stringify({
+          id: "chatcmpl_1",
+          model: "gpt",
+          choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+        })),
+      };
+    },
+    chatStream: [new TextEncoder().encode("data: [DONE]\n\n")],
+  });
+
+  const gw = await createGateway({
+    startup: parseStartupConfig([], {}, { homedir: "Q:\\ghcp-ollama-worktrees\\rm-11\\.test-home" }),
+    runtime: options.runtime ?? defaultRuntimeConfigSnapshot(),
+  }, [createAnthropicMessagesRoute({
+    directory: accounts,
+    catalog,
+    preferences: accounts.preferences,
+    copilot: backend,
+    createUuid: options.createUuid ?? (() => "00000000-0000-4000-8000-000000000001"),
+  })], {
+    createRequestId: () => "req_test_1",
+    ...options.gatewayDependencies,
+  });
+
+  return {
+    gw,
+    backend,
+    capturedRequests,
+    async close() {
+      await gw.close();
+      closeDatabase(database);
+    },
+  };
+}
+
+export function anthropicRequest(body: unknown, headers: HeadersInit = {}): Request {
+  return new Request("http://127.0.0.1:31400/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "anthropic-version": "2023-06-01",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export function decodeChatBody(request: ChatRequest): Record<string, unknown> {
+  return JSON.parse(new TextDecoder().decode(request.body)) as Record<string, unknown>;
+}
+
+export function sse(data: unknown): Uint8Array {
+  return new TextEncoder().encode(`data: ${asciiJson(data)}\n\n`);
+}
+
+function asciiJson(value: unknown): string {
+  const json = JSON.stringify(value);
+  let escaped = "";
+  for (let index = 0; index < json.length; index += 1) {
+    const code = json.charCodeAt(index);
+    if (code > 0x7f) {
+      escaped += `\\u${code.toString(16).padStart(4, "0")}`;
+    } else {
+      escaped += json[index];
+    }
+  }
+  return escaped;
+}

--- a/tests/refactor/contract/anthropic_nonstream.test.ts
+++ b/tests/refactor/contract/anthropic_nonstream.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { ScriptedCopilotBackend } from "../../../src/copilot/backend.js";
+import { anthropicGateway, anthropicRequest } from "./anthropic_harness.js";
+
+describe("RM-11 Anthropic non-stream response", () => {
+  it("maps all choices, thinking blocks, repaired tools, stop reason, usage aliases, and request ID", async () => {
+    const backend = new ScriptedCopilotBackend({
+      chat: {
+        status: 200,
+        headers: new Headers(),
+        body: new TextEncoder().encode(JSON.stringify({
+          id: "chatcmpl_42",
+          model: "gpt",
+          choices: [
+            {
+              finish_reason: "tool_calls",
+              message: {
+                reasoning_content: "fallback thought",
+                content: "answer",
+                tool_calls: [{
+                  id: "call.bad__thought__sig",
+                  type: "function",
+                  function: { name: "lookup", arguments: "{\"city\":\"Zürich\"," },
+                  thought_signature: "signed",
+                }],
+              },
+            },
+            {
+              finish_reason: "stop",
+              message: {
+                thinking_blocks: [
+                  { type: "thinking", thinking: "   ", signature: "drop" },
+                  { type: "redacted_thinking", data: "" },
+                  { type: "thinking", thinking: "second thought", signature: "sig2" },
+                ],
+                content: "",
+              },
+            },
+          ],
+          usage: {
+            prompt_tokens: 30,
+            completion_tokens: 7,
+            _cache_read_input_tokens: 5,
+            prompt_tokens_details: {
+              cache_write_tokens: 3,
+              web_search_requests: 2,
+            },
+          },
+        })),
+      },
+    });
+    const { gw, close } = await anthropicGateway({ backend });
+    try {
+      const response = await gw.fetch(anthropicRequest({ model: "gpt", max_tokens: 16, messages: [{ role: "user", content: "hi" }], stream: false }));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("request-id")).toBe("req_test_1");
+      expect(JSON.parse(await response.text())).toEqual({
+        id: "chatcmpl_42",
+        type: "message",
+        role: "assistant",
+        model: "gpt",
+        content: [
+          { type: "thinking", thinking: "fallback thought", signature: null },
+          { type: "text", text: "answer" },
+          {
+            type: "tool_use",
+            id: "call_bad",
+            name: "lookup",
+            input: { city: "Zürich" },
+            provider_specific_fields: { signature: "signed" },
+          },
+          { type: "redacted_thinking", data: "" },
+          { type: "thinking", thinking: "second thought", signature: "sig2" },
+          { type: "text", text: "" },
+        ],
+        stop_reason: "tool_use",
+        stop_sequence: null,
+        usage: {
+          input_tokens: 22,
+          output_tokens: 7,
+          cache_read_input_tokens: 5,
+          cache_creation_input_tokens: 3,
+          server_tool_use: { web_search_requests: 2 },
+        },
+      });
+    } finally {
+      await close();
+    }
+  });
+
+  it("rebuilds upstream HTTP errors with Anthropic's native error shape", async () => {
+    const backend = new ScriptedCopilotBackend({
+      chat: {
+        status: 429,
+        headers: new Headers({ "retry-after": "120" }),
+        body: new TextEncoder().encode("{\"leak\":\"upstream\"}"),
+      },
+    });
+    const { gw, close } = await anthropicGateway({ backend });
+    try {
+      const response = await gw.fetch(anthropicRequest({ model: "gpt", max_tokens: 1, messages: [{ role: "user", content: "hi" }], stream: false }));
+      expect(response.status).toBe(429);
+      expect(response.headers.get("retry-after")).toBe("120");
+      expect(response.headers.get("request-id")).toBe("req_test_1");
+      expect(await response.text()).toBe("{\"type\":\"error\",\"error\":{\"type\":\"rate_limit_error\",\"message\":\"upstream request failed\"},\"request_id\":\"req_test_1\"}");
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/refactor/contract/anthropic_request.test.ts
+++ b/tests/refactor/contract/anthropic_request.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import { anthropicGateway, anthropicRequest, decodeChatBody } from "./anthropic_harness.js";
+import { ScriptedCopilotBackend } from "../../../src/copilot/backend.js";
+import { CapiFetchError } from "../../../src/copilot/models_source.js";
+import type { ChatRequest } from "../../../src/protocols/chat_completions/types.js";
+
+describe("RM-11 Anthropic request route", () => {
+  it("requires the exact Messages version header and never forwards it to Chat", async () => {
+    const { gw, capturedRequests, close } = await anthropicGateway();
+    try {
+      for (const [name, headers] of [
+        ["missing", { "anthropic-version": undefined }],
+        ["empty", { "anthropic-version": "" }],
+        ["wrong", { "anthropic-version": "2024-01-01" }],
+        ["merged", { "anthropic-version": "2023-06-01, 2023-06-01" }],
+      ] as const) {
+        const actualHeaders: Record<string, string> = { "content-type": "application/json" };
+        if (headers["anthropic-version"] !== undefined) {
+          actualHeaders["anthropic-version"] = headers["anthropic-version"];
+        }
+        const response = await gw.fetch(new Request("http://127.0.0.1:31400/v1/messages", {
+          method: "POST",
+          headers: actualHeaders,
+          body: JSON.stringify({ model: "gpt", max_tokens: 1, messages: [{ role: "user", content: "hi" }] }),
+        }));
+        expect(response.status, name).toBe(400);
+        expect(response.headers.get("request-id")).toBe("req_test_1");
+        expect(await response.text()).toBe("{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"invalid request\"},\"request_id\":\"req_test_1\"}");
+      }
+
+      const ok = await gw.fetch(anthropicRequest({ model: "gpt", max_tokens: 1, messages: [{ role: "user", content: "hi" }], stream: false }));
+      expect(ok.status).toBe(200);
+      expect(capturedRequests).toHaveLength(1);
+      expect(new TextDecoder().decode(capturedRequests[0]?.body)).not.toContain("anthropic-version");
+    } finally {
+      await close();
+    }
+  });
+
+  it("resolves missing model only through a valid visible preference and rejects explicit unknown models", async () => {
+    const { gw, capturedRequests, close } = await anthropicGateway({ preferredModel: "gpt" });
+    try {
+      const preferred = await gw.fetch(anthropicRequest({ max_tokens: 1, messages: [{ role: "user", content: "hi" }], stream: false }));
+      expect(preferred.status).toBe(200);
+      expect(decodeChatBody(capturedRequests[0] as ChatRequest).model).toBe("gpt");
+
+      const unknown = await gw.fetch(anthropicRequest({ model: "no-such-model", max_tokens: 1, messages: [{ role: "user", content: "hi" }], stream: false }));
+      expect(unknown.status).toBe(404);
+      expect(await unknown.text()).toBe("{\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",\"message\":\"model not found\"},\"request_id\":\"req_test_1\"}");
+      expect(capturedRequests).toHaveLength(1);
+    } finally {
+      await close();
+    }
+  });
+
+  it("preserves model catalog timeout, network, and invalid-response failure categories", async () => {
+    for (const [failureKind, expected] of [
+      ["upstream_timeout", { status: 504, type: "timeout_error", message: "upstream timeout" }],
+      ["upstream_network", { status: 502, type: "api_error", message: "upstream request failed" }],
+      ["invalid_upstream_response", { status: 502, type: "api_error", message: "invalid upstream response" }],
+    ] as const) {
+      const { gw, close } = await anthropicGateway({
+        catalogFetch() {
+          throw new CapiFetchError(502, undefined, failureKind);
+        },
+      });
+      try {
+        const response = await gw.fetch(anthropicRequest({ model: "gpt", max_tokens: 1, messages: [{ role: "user", content: "hi" }], stream: false }));
+        expect(response.status).toBe(expected.status);
+        expect(await response.text()).toBe(JSON.stringify({
+          type: "error",
+          error: { type: expected.type, message: expected.message },
+          request_id: "req_test_1",
+        }));
+      } finally {
+        await close();
+      }
+    }
+  });
+
+  it("converts system, media, tool history, schema cleanup, tool choice, and reasoning rules", async () => {
+    const captured: ChatRequest[] = [];
+    const backend = new ScriptedCopilotBackend({
+      chatStream(request) {
+        captured.push(request);
+        return [new TextEncoder().encode("data: [DONE]\n\n")];
+      },
+    });
+    const { gw, close } = await anthropicGateway({ backend });
+    try {
+      const response = await gw.fetch(anthropicRequest({
+        model: "gpt-5",
+        max_tokens: 64,
+        temperature: 0.2,
+        top_p: 0.9,
+        stop_sequences: ["END"],
+        stream: true,
+        system: [
+          { type: "text", text: "x-anthropic-billing-header:\n\nbill me elsewhere" },
+          { type: "text", text: "second" },
+        ],
+        metadata: { dropped: true },
+        context_management: { dropped: true },
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" }, cache_control: { type: "ephemeral" } },
+              { type: "document", source: { type: "text", data: "drop" } },
+            ],
+          },
+          {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "hidden" },
+              { type: "tool_use", id: "call_1", name: "lookup", input: { z: 1, a: [true, null] } },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "call_1", content: { b: 2, a: 1 }, is_error: true },
+              { type: "text", text: "continue" },
+            ],
+          },
+        ],
+        tools: [
+          { type: "BatchTool", name: "ignored" },
+          {
+            name: "lookup",
+            description: "Lookup",
+            input_schema: {
+              properties: {
+                url: { type: "string", format: "uri" },
+                nested: { items: { properties: { link: { type: "string", format: "uri" } } } },
+                untouched: { oneOf: [{ type: "string", format: "uri" }] },
+              },
+            },
+            strict: true,
+          },
+        ],
+        tool_choice: { type: "tool", name: "lookup", disable_parallel_tool_use: true },
+        output_config: { effort: "max", format: { type: "json_schema" } },
+      }));
+
+      expect(response.status).toBe(200);
+      expect(captured).toHaveLength(1);
+      const body = decodeChatBody(captured[0] as ChatRequest);
+      expect(body).toEqual({
+        model: "gpt-5",
+        messages: [
+          { role: "system", content: "bill me elsewhere\nsecond" },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+            ],
+          },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [{
+              id: "call_1",
+              type: "function",
+              function: { name: "lookup", arguments: "{\"a\":[true,null],\"z\":1}" },
+            }],
+          },
+          { role: "tool", tool_call_id: "call_1", content: "{\"a\":1,\"b\":2}" },
+          { role: "user", content: "continue" },
+        ],
+        max_tokens: 64,
+        temperature: 0.2,
+        top_p: 0.9,
+        stop: ["END"],
+        stream: true,
+        stream_options: { include_usage: true },
+        tools: [{
+          type: "function",
+          function: {
+            name: "lookup",
+            description: "Lookup",
+            parameters: {
+              type: "object",
+              properties: {
+                url: { type: "string" },
+                nested: { type: "object", properties: {}, items: { type: "object", properties: { link: { type: "string" } } } },
+                untouched: { type: "object", properties: {}, oneOf: [{ type: "string", format: "uri" }] },
+              },
+            },
+          },
+        }],
+        tool_choice: { type: "function", function: { name: "lookup" } },
+        reasoning_effort: "xhigh",
+      });
+    } finally {
+      await close();
+    }
+  });
+
+  it("keeps parallel tool_result messages adjacent and moves media into the following user message", async () => {
+    const captured: ChatRequest[] = [];
+    const backend = new ScriptedCopilotBackend({
+      chat(request) {
+        captured.push(request);
+        return {
+          status: 200,
+          headers: new Headers(),
+          body: new TextEncoder().encode(JSON.stringify({
+            id: "chatcmpl_1",
+            model: "gpt",
+            choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+          })),
+        };
+      },
+    });
+    const { gw, close } = await anthropicGateway({ backend });
+    try {
+      const response = await gw.fetch(anthropicRequest({
+        model: "gpt",
+        max_tokens: 1,
+        stream: false,
+        messages: [{
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_1",
+              content: [{ type: "image", source: { media_type: "image/png", data: "abc" } }],
+            },
+            { type: "tool_result", tool_use_id: "call_2", content: "plain" },
+            { type: "text", text: "after tools" },
+          ],
+        }],
+      }));
+
+      expect(response.status).toBe(200);
+      expect(decodeChatBody(captured[0] as ChatRequest).messages).toEqual([
+        {
+          role: "tool",
+          tool_call_id: "call_1",
+          content: "[\"[cc-switch: tool result media moved to the following user message]\"]",
+        },
+        { role: "tool", tool_call_id: "call_2", content: "plain" },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "[cc-switch: media output of tool call call_1]" },
+            { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+          ],
+        },
+        { role: "user", content: "after tools" },
+      ]);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/refactor/contract/anthropic_stream.test.ts
+++ b/tests/refactor/contract/anthropic_stream.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { ScriptedCopilotBackend } from "../../../src/copilot/backend.js";
+import { anthropicGateway, anthropicRequest, sse } from "./anthropic_harness.js";
+
+const decoder = new TextDecoder();
+
+describe("RM-11 Anthropic stream lifecycle", () => {
+  it("emits signed thinking blocks with Python-compatible SSE text", async () => {
+    const backend = new ScriptedCopilotBackend({
+      chatStream: [
+        sse({
+          id: "chunk_1",
+          choices: [{
+            delta: { thinking_blocks: [{ type: "thinking", thinking: "signed plan", signature: "sigT" }] },
+            finish_reason: "stop",
+          }],
+        }),
+        new TextEncoder().encode("data: [DONE]\n\n"),
+      ],
+    });
+    const { gw, close } = await anthropicGateway({ backend });
+    try {
+      const response = await gw.fetch(anthropicRequest({ model: "gpt", max_tokens: 16, messages: [{ role: "user", content: "hi" }], stream: true }));
+      expect(await response.text()).toBe([
+        "event: message_start\ndata: {\"type\": \"message_start\", \"message\": {\"id\": \"msg_00000000-0000-4000-8000-000000000001\", \"type\": \"message\", \"role\": \"assistant\", \"content\": [], \"model\": \"gpt\", \"stop_reason\": null, \"stop_sequence\": null, \"usage\": {\"input_tokens\": 0, \"output_tokens\": 0, \"cache_creation_input_tokens\": 0, \"cache_read_input_tokens\": 0}}}\n\n",
+        "event: content_block_start\ndata: {\"type\": \"content_block_start\", \"index\": 0, \"content_block\": {\"type\": \"thinking\", \"thinking\": \"signed plan\", \"signature\": \"sigT\"}}\n\n",
+        "event: content_block_delta\ndata: {\"type\": \"content_block_delta\", \"index\": 0, \"delta\": {\"type\": \"signature_delta\", \"signature\": \"sigT\"}}\n\n",
+        "event: content_block_stop\ndata: {\"type\": \"content_block_stop\", \"index\": 0}\n\n",
+        "event: message_delta\ndata: {\"type\": \"message_delta\", \"delta\": {\"stop_reason\": \"end_turn\"}, \"usage\": {\"input_tokens\": 0, \"output_tokens\": 0}}\n\n",
+        "event: message_stop\ndata: {\"type\": \"message_stop\"}\n\n",
+      ].join(""));
+    } finally {
+      await close();
+    }
+  });
+
+  it("uses only the last tool-bearing choice while preserving text from all choices", async () => {
+    const backend = new ScriptedCopilotBackend({
+      chatStream: [
+        sse({
+          id: "chunk_1",
+          choices: [
+            {
+              delta: {
+                content: "A",
+                tool_calls: [{ id: "call_first", type: "function", function: { name: "first", arguments: "{\"x\":1}" } }],
+              },
+            },
+            {
+              delta: {
+                content: "B",
+                tool_calls: [{ id: "call_second", type: "function", function: { name: "second", arguments: "{\"y\":2}" } }],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+        }),
+        new TextEncoder().encode("data: [DONE]\n\n"),
+      ],
+    });
+    const { gw, close } = await anthropicGateway({ backend });
+    try {
+      const response = await gw.fetch(anthropicRequest({ model: "gpt", max_tokens: 16, messages: [{ role: "user", content: "hi" }], stream: true }));
+      const text = await response.text();
+      expect(text).toContain("\"text\": \"A\"");
+      expect(text).toContain("\"text\": \"B\"");
+      expect(text).toContain("\"id\": \"call_second\"");
+      expect(text).toContain("\"name\": \"second\"");
+      expect(text).toContain("\"partial_json\": \"{\\\"y\\\":2}\"");
+      expect(text).not.toContain("call_first");
+      expect(text).not.toContain("\"name\": \"first\"");
+      expect(text).not.toContain("\"partial_json\": \"{\\\"x\\\":1}\"");
+    } finally {
+      await close();
+    }
+  });
+
+  it("emits Python-compatible SSE for block switches, signed thinking, delayed usage, and message_stop", async () => {
+    const backend = new ScriptedCopilotBackend({
+      chatStream: [
+        sse({ id: "chunk_1", choices: [{ delta: { reasoning_content: "plan" } }] }),
+        sse({ id: "chunk_2", choices: [{ delta: { content: "hé" } }] }),
+        sse({ id: "chunk_3", choices: [{ delta: { tool_calls: [{ id: "call.1__thought__sigA", type: "function", function: { name: "lookup", arguments: "{\"a\":" } }] } }] }),
+        sse({ id: "chunk_4", choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: "1}" } }] }, finish_reason: "tool_calls" }], usage: { prompt_tokens: 8, completion_tokens: 3 } }),
+        sse({ id: "chunk_5", choices: [], usage: { prompt_tokens: 10, completion_tokens: 4, cache_read_input_tokens: 2 } }),
+        new TextEncoder().encode("data: [DONE]\n\n"),
+      ],
+    });
+    const { gw, close } = await anthropicGateway({
+      backend,
+      createUuid: (() => {
+        const values = ["00000000-0000-4000-8000-0000000000aa"];
+        return () => values.shift() ?? "00000000-0000-4000-8000-0000000000ff";
+      })(),
+    });
+    try {
+      const response = await gw.fetch(anthropicRequest({ model: "gpt", max_tokens: 16, messages: [{ role: "user", content: "hi" }], stream: true }));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+      expect(response.headers.get("request-id")).toBe("req_test_1");
+      expect(await response.text()).toBe([
+        "event: message_start\ndata: {\"type\": \"message_start\", \"message\": {\"id\": \"msg_00000000-0000-4000-8000-0000000000aa\", \"type\": \"message\", \"role\": \"assistant\", \"content\": [], \"model\": \"gpt\", \"stop_reason\": null, \"stop_sequence\": null, \"usage\": {\"input_tokens\": 0, \"output_tokens\": 0, \"cache_creation_input_tokens\": 0, \"cache_read_input_tokens\": 0}}}\n\n",
+        "event: content_block_start\ndata: {\"type\": \"content_block_start\", \"index\": 0, \"content_block\": {\"type\": \"thinking\", \"thinking\": \"\", \"signature\": \"\"}}\n\n",
+        "event: content_block_delta\ndata: {\"type\": \"content_block_delta\", \"index\": 0, \"delta\": {\"type\": \"thinking_delta\", \"thinking\": \"plan\"}}\n\n",
+        "event: content_block_stop\ndata: {\"type\": \"content_block_stop\", \"index\": 0}\n\n",
+        "event: content_block_start\ndata: {\"type\": \"content_block_start\", \"index\": 1, \"content_block\": {\"type\": \"text\", \"text\": \"\"}}\n\n",
+        "event: content_block_delta\ndata: {\"type\": \"content_block_delta\", \"index\": 1, \"delta\": {\"type\": \"text_delta\", \"text\": \"h\\u00e9\"}}\n\n",
+        "event: content_block_stop\ndata: {\"type\": \"content_block_stop\", \"index\": 1}\n\n",
+        "event: content_block_start\ndata: {\"type\": \"content_block_start\", \"index\": 2, \"content_block\": {\"type\": \"tool_use\", \"id\": \"call_1\", \"name\": \"lookup\", \"input\": {}, \"provider_specific_fields\": {\"signature\": \"sigA\"}}}\n\n",
+        "event: content_block_delta\ndata: {\"type\": \"content_block_delta\", \"index\": 2, \"delta\": {\"type\": \"input_json_delta\", \"partial_json\": \"{\\\"a\\\":\"}}\n\n",
+        "event: content_block_delta\ndata: {\"type\": \"content_block_delta\", \"index\": 2, \"delta\": {\"type\": \"input_json_delta\", \"partial_json\": \"1}\"}}\n\n",
+        "event: content_block_stop\ndata: {\"type\": \"content_block_stop\", \"index\": 2}\n\n",
+        "event: message_delta\ndata: {\"type\": \"message_delta\", \"delta\": {\"stop_reason\": \"tool_use\"}, \"usage\": {\"input_tokens\": 8, \"output_tokens\": 4, \"cache_read_input_tokens\": 2}}\n\n",
+        "event: message_stop\ndata: {\"type\": \"message_stop\"}\n\n",
+      ].join(""));
+    } finally {
+      await close();
+    }
+  });
+
+  it("closes natural exhaustion with message_stop and propagates post-commit exceptions without synthetic success", async () => {
+    async function* brokenStream(): AsyncIterable<Uint8Array> {
+      yield sse({ id: "chunk_1", choices: [{ delta: { content: "partial" } }] });
+      throw new Error("boom");
+    }
+    const backend = new ScriptedCopilotBackend({ chatStream: brokenStream() });
+    const { gw, close } = await anthropicGateway({ backend });
+    try {
+      const response = await gw.fetch(anthropicRequest({ model: "gpt", max_tokens: 16, messages: [{ role: "user", content: "hi" }], stream: true }));
+      const reader = response.body?.getReader();
+      if (reader === undefined) {
+        throw new Error("expected stream body");
+      }
+      let text = "";
+      await expect((async () => {
+        for (;;) {
+          const next = await reader.read();
+          if (next.done) {
+            return;
+          }
+          text += decoder.decode(next.value, { stream: true });
+        }
+      })()).rejects.toThrow();
+      expect(text).toContain("event: content_block_delta");
+      expect(text).not.toContain("event: message_stop");
+      expect(text).not.toContain("event: error");
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/refactor/contract/anthropic_wire.test.ts
+++ b/tests/refactor/contract/anthropic_wire.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { anthropicErrorBody, encodeAnthropicSse } from "../../../src/protocols/anthropic_messages/wire.js";
+
+describe("RM-11 Anthropic wire helpers", () => {
+  it("uses native compact error JSON with request ID equality", () => {
+    expect(anthropicErrorBody("invalid_request_error", "invalid request", "req_1")).toBe("{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"invalid request\"},\"request_id\":\"req_1\"}");
+  });
+
+  it("uses Python default json.dumps spacing and ASCII escaping for SSE", () => {
+    expect(new TextDecoder().decode(encodeAnthropicSse({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "hé" },
+    }))).toBe("event: content_block_delta\ndata: {\"type\": \"content_block_delta\", \"index\": 0, \"delta\": {\"type\": \"text_delta\", \"text\": \"h\\u00e9\"}}\n\n");
+  });
+});

--- a/tests/refactor/sdk/anthropic.sdk.test.ts
+++ b/tests/refactor/sdk/anthropic.sdk.test.ts
@@ -1,0 +1,34 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { describe, expect, it } from "vitest";
+
+const enabled = process.env.GHC_GATEWAY_SDK_TESTS === "1";
+
+describe.runIf(enabled)("RM-11 Anthropic SDK compatibility", () => {
+  it("can list models and call Messages non-stream and stream through the gateway", async () => {
+    const client = new Anthropic({
+      apiKey: "gateway-local",
+      baseURL: process.env.GHC_GATEWAY_BASE_URL ?? "http://127.0.0.1:31400",
+    });
+
+    const models = await client.models.list();
+    expect(models.data.length).toBeGreaterThanOrEqual(0);
+
+    const message = await client.messages.create({
+      model: process.env.GHC_GATEWAY_SDK_MODEL ?? "gpt",
+      max_tokens: 8,
+      messages: [{ role: "user", content: "Say ok." }],
+    });
+    expect(message.type).toBe("message");
+
+    const stream = await client.messages.create({
+      model: process.env.GHC_GATEWAY_SDK_MODEL ?? "gpt",
+      max_tokens: 8,
+      stream: true,
+      messages: [{ role: "user", content: "Say ok." }],
+    });
+    for await (const event of stream) {
+      expect(event.type.length).toBeGreaterThan(0);
+      break;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the RM-11 Anthropic Messages endpoint for `/v1/messages` with strict `anthropic-version` validation, model resolution, native Anthropic errors, and request-ID handling.
- Implements protocol-local request conversion, non-stream response conversion, stream lifecycle conversion, and Python-compatible SSE text in separate Anthropic modules.
- Covers system/message/media/tool/schema/tool-choice/reasoning request mapping, non-stream thinking/tool/usage conversion, stream signed thinking, multi-choice tool selection, delayed usage, natural exhaustion, and post-commit failure behavior.
- Adds manual-only official Anthropic SDK compatibility coverage behind `GHC_GATEWAY_SDK_TESTS`.

Closes #20

## Validation
- `npm run typecheck:refactor`
- `npm run test:refactor -- tests/refactor/contract/anthropic_stream.test.ts tests/refactor/contract/anthropic_request.test.ts tests/refactor/contract/anthropic_nonstream.test.ts tests/refactor/contract/anthropic_wire.test.ts`
- `npm run lint:refactor`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check`

## Code review
- Standards review: no blockers. One mild stream converter structure smell was judged not unsafe to merge because Anthropic state/terminal ownership is protocol-local and bounded inside `stream.ts`.
- Spec review: no blockers after fixing multi-choice stream tool selection and post-commit exception propagation.