### PR TITLE
Implement RM-13 Responses native planner

### DIFF
--- a/src/copilot/backend.ts
+++ b/src/copilot/backend.ts
@@ -32,8 +32,8 @@ export interface CopilotBackend {
 export interface ScriptedCopilotHandlers {
   chat?: ChatResponse | ((request: ChatRequest) => ChatResponse | Promise<ChatResponse>);
   chatStream?: Uint8Array[] | AsyncIterable<Uint8Array> | ((request: ChatRequest) => Uint8Array[] | AsyncIterable<Uint8Array>);
-  responses?: UpstreamByteResponse;
-  responsesStream?: Uint8Array[];
+  responses?: UpstreamByteResponse | ((request: NativeResponsesUpstreamRequest) => UpstreamByteResponse | Promise<UpstreamByteResponse>);
+  responsesStream?: Uint8Array[] | AsyncIterable<Uint8Array> | ((request: NativeResponsesUpstreamRequest) => Uint8Array[] | AsyncIterable<Uint8Array>);
 }
 
 export class ScriptedCopilotBackend implements CopilotBackend {
@@ -75,19 +75,26 @@ export class ScriptedCopilotBackend implements CopilotBackend {
           cancel: async () => undefined,
         };
       },
-      async completeResponses() {
+      async completeResponses(request) {
         captured.push({ accountId: account.accountId, kind: "responses" });
-        if (handlers.responses === undefined) {
+        const handler = handlers.responses;
+        if (typeof handler === "function") {
+          return handler(request);
+        }
+        if (handler === undefined) {
           throw new Error("scripted responses missing");
         }
-        return handlers.responses;
+        return handler;
       },
-      async openResponsesStream() {
+      async openResponsesStream(request) {
         captured.push({ accountId: account.accountId, kind: "responses-stream" });
+        const stream = typeof handlers.responsesStream === "function"
+          ? handlers.responsesStream(request)
+          : handlers.responsesStream;
         return {
           status: 200,
           headers: new Headers({ "content-type": "text/event-stream" }),
-          bytes: asAsync(handlers.responsesStream ?? []),
+          bytes: asAsync(stream ?? []),
           cancel: async () => undefined,
         };
       },

--- a/src/copilot/transport.ts
+++ b/src/copilot/transport.ts
@@ -45,8 +45,8 @@ export class HttpCopilotBackend implements CopilotBackend {
       target,
       completeChat: (request) => this.completeJson(`${target.endpoint}/chat/completions`, target.token, request.body, request.signal, fetchImpl, request.nonstreamBodyBytes, request.connectTimeoutMs, request.firstByteTimeoutMs, chatExtraHeaders(request.hasVisionInput)),
       openChatStream: (request) => this.openStream(`${target.endpoint}/chat/completions`, target.token, request.body, request.signal, fetchImpl, request.connectTimeoutMs, request.firstByteTimeoutMs, chatExtraHeaders(request.hasVisionInput)),
-      completeResponses: (request) => this.completeJson(`${target.endpoint}/responses`, target.token, request.body, request.signal, fetchImpl, undefined, undefined, undefined),
-      openResponsesStream: (request) => this.openStream(`${target.endpoint}/responses`, target.token, request.body, request.signal, fetchImpl, undefined, undefined),
+      completeResponses: (request) => this.completeJson(responsesUrl(target.endpoint), target.token, request.body, request.signal, fetchImpl, request.nonstreamBodyBytes, request.connectTimeoutMs, request.firstByteTimeoutMs, responsesExtraHeaders(request)),
+      openResponsesStream: (request) => this.openStream(responsesUrl(target.endpoint), target.token, request.body, request.signal, fetchImpl, request.connectTimeoutMs, request.firstByteTimeoutMs, responsesExtraHeaders(request)),
     };
   }
 
@@ -287,6 +287,28 @@ function chatExtraHeaders(hasVisionInput: boolean): Headers {
     headers.set("copilot-vision-request", "true");
   }
   return headers;
+}
+
+function responsesExtraHeaders(request: {
+  readonly hasVisionInput: boolean;
+  readonly initiator: "user" | "agent";
+  readonly requestId: string;
+}): Headers {
+  const headers = new Headers({
+    "content-type": "application/json",
+    "openai-intent": "conversation-panel",
+    "x-request-id": request.requestId,
+    "x-vscode-user-agent-library-version": "electron-fetch",
+    "x-initiator": request.initiator,
+  });
+  if (request.hasVisionInput) {
+    headers.set("copilot-vision-request", "true");
+  }
+  return headers;
+}
+
+function responsesUrl(endpoint: string): string {
+  return `${endpoint.replace(/\/+$/u, "")}/responses`;
 }
 
 async function* empty(): AsyncIterable<Uint8Array> {}

--- a/src/protocols/chat_completions/types.ts
+++ b/src/protocols/chat_completions/types.ts
@@ -30,6 +30,10 @@ export interface NativeResponsesUpstreamRequest {
   readonly body: Uint8Array;
   readonly hasVisionInput: boolean;
   readonly initiator: "user" | "agent";
+  readonly requestId: string;
+  readonly nonstreamBodyBytes: number;
+  readonly connectTimeoutMs: number;
+  readonly firstByteTimeoutMs: number;
   readonly signal: AbortSignal;
 }
 

--- a/src/protocols/responses/native.ts
+++ b/src/protocols/responses/native.ts
@@ -1,0 +1,324 @@
+import { ChatSseError } from "../../copilot/chat_sse.js";
+import type { BoundCopilot } from "../../copilot/backend.js";
+import { GatewayFailureError } from "../../gateway/failures.js";
+import {
+  isWireJsonArray,
+  isWireJsonNumber,
+  isWireJsonObject,
+  memberValues,
+  parseWireJson,
+  serializeWireJson,
+  type WireJson,
+  type WireJsonObject,
+} from "../../serialization/wire_json.js";
+import type { NativeResponsesUpstreamRequest, UpstreamByteResponse, UpstreamByteStream } from "../chat_completions/types.js";
+import type { NativeResponsesPlan } from "./planner.js";
+
+export interface NativeResponsesRequestOptions {
+  readonly requestId: string;
+  readonly nonstreamBodyBytes: number;
+  readonly connectTimeoutMs: number;
+  readonly firstByteTimeoutMs: number;
+  readonly signal: AbortSignal;
+}
+
+interface ParsedSseEvent {
+  readonly eventName?: string;
+  readonly data: string;
+}
+
+const TERMINAL_EVENTS = new Set(["response.completed", "response.failed", "response.incomplete", "error"]);
+
+export function nativeResponsesUpstreamRequest(
+  plan: Readonly<NativeResponsesPlan>,
+  options: Readonly<NativeResponsesRequestOptions>,
+): NativeResponsesUpstreamRequest {
+  return {
+    body: serializeNativeResponsesRequest(plan),
+    hasVisionInput: hasNativeVisionInput(plan.originalRequest.input),
+    initiator: nativeInitiator(plan.originalRequest.input),
+    requestId: options.requestId,
+    nonstreamBodyBytes: options.nonstreamBodyBytes,
+    connectTimeoutMs: options.connectTimeoutMs,
+    firstByteTimeoutMs: options.firstByteTimeoutMs,
+    signal: options.signal,
+  };
+}
+
+export async function completeNativeResponses(
+  bound: BoundCopilot,
+  plan: Readonly<NativeResponsesPlan>,
+  options: Readonly<NativeResponsesRequestOptions>,
+): Promise<UpstreamByteResponse> {
+  const response = await bound.completeResponses(nativeResponsesUpstreamRequest(plan, options));
+  return {
+    status: response.status,
+    headers: response.headers,
+    body: validatedNativeResponsesBody(response, options.nonstreamBodyBytes),
+  };
+}
+
+export async function openNativeResponsesStream(
+  bound: BoundCopilot,
+  plan: Readonly<NativeResponsesPlan>,
+  options: Readonly<NativeResponsesRequestOptions>,
+): Promise<UpstreamByteStream> {
+  const upstream = await bound.openResponsesStream(nativeResponsesUpstreamRequest(plan, options));
+  if (upstream.status >= 200 && upstream.status < 300 && !isEventStream(upstream.headers)) {
+    await upstream.cancel();
+    throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+  }
+  return upstream;
+}
+
+export function serializeNativeResponsesRequest(plan: Readonly<NativeResponsesPlan>): Uint8Array {
+  let replaced = false;
+  const members = plan.originalRequest.body.members.map((member) => {
+    if (member.key !== "model") {
+      return member;
+    }
+    replaced = true;
+    return { key: member.key, value: plan.resolvedModel.upstreamModel };
+  });
+  if (!replaced) {
+    members.push({ key: "model", value: plan.resolvedModel.upstreamModel });
+  }
+  return serializeWireJson({ kind: "object", members });
+}
+
+export function validatedNativeResponsesBody(
+  response: Readonly<UpstreamByteResponse>,
+  maxBytes: number,
+): Uint8Array {
+  if (response.status < 200 || response.status >= 300) {
+    return response.body;
+  }
+  try {
+    const parsed = parseWireJson(response.body, { maxBytes, maxDepth: 64 });
+    if (!isWireJsonObject(parsed)) {
+      throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+    }
+    return response.body;
+  } catch (error: unknown) {
+    if (error instanceof GatewayFailureError) {
+      throw error;
+    }
+    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+  }
+}
+
+export async function* normalizeNativeResponsesStream(
+  bytes: AsyncIterable<Uint8Array>,
+  eventLimitBytes: number,
+): AsyncIterable<Uint8Array> {
+  const stableIds = new Map<number, string>();
+  let terminal = false;
+  for await (const event of parseResponsesSse(bytes, eventLimitBytes)) {
+    const payload = parseResponsesEventData(event);
+    const type = stringMember(payload, "type");
+    if (type === undefined || type.length === 0 || (event.eventName !== undefined && event.eventName !== type)) {
+      throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+    }
+    const normalized = normalizeNativeResponsesEvent(payload, stableIds, type);
+    yield encodeResponsesSseEvent(normalized);
+    if (TERMINAL_EVENTS.has(type)) {
+      terminal = true;
+      return;
+    }
+  }
+  if (!terminal) {
+    throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+  }
+}
+
+export function encodeResponsesSseEvent(event: WireJsonObject): Uint8Array {
+  const type = stringMember(event, "type");
+  if (type === undefined || type.length === 0) {
+    throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+  }
+  return new TextEncoder().encode(`event: ${type}\ndata: ${new TextDecoder().decode(serializeWireJson(event))}\n\n`);
+}
+
+function normalizeNativeResponsesEvent(
+  event: WireJsonObject,
+  stableIds: Map<number, string>,
+  type: string,
+): WireJsonObject {
+  const outputIndex = integerMember(event, "output_index");
+  if (type === "response.output_item.added" && outputIndex !== undefined) {
+    const item = objectMember(event, "item");
+    const id = item === undefined ? undefined : stringMember(item, "id");
+    if (id !== undefined) {
+      stableIds.set(outputIndex, id);
+    }
+  }
+  const stableId = outputIndex === undefined ? undefined : stableIds.get(outputIndex);
+  if (stableId === undefined) {
+    return event;
+  }
+  let next = replaceExistingStringMember(event, "item_id", stableId);
+  if (type === "response.output_item.done") {
+    const item = objectMember(next, "item");
+    if (item !== undefined) {
+      next = replaceMember(next, "item", replaceExistingStringMember(item, "id", stableId));
+    }
+  }
+  return next;
+}
+
+async function* parseResponsesSse(
+  bytes: AsyncIterable<Uint8Array>,
+  eventLimitBytes: number,
+): AsyncIterable<ParsedSseEvent> {
+  let pending = "";
+  const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+  try {
+    for await (const chunk of bytes) {
+      pending += decoder.decode(chunk, { stream: true });
+      for (;;) {
+        const normalized = pending.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n");
+        const boundary = normalized.indexOf("\n\n");
+        if (boundary === -1) {
+          if (new TextEncoder().encode(normalized).byteLength > eventLimitBytes) {
+            throw new ChatSseError("event_too_large", "SSE event exceeds limit");
+          }
+          pending = normalized;
+          break;
+        }
+        const raw = normalized.slice(0, boundary);
+        if (new TextEncoder().encode(`${raw}\n\n`).byteLength > eventLimitBytes) {
+          throw new ChatSseError("event_too_large", "SSE event exceeds limit");
+        }
+        pending = normalized.slice(boundary + 2);
+        const parsed = parseSseRecord(raw);
+        if (parsed !== undefined) {
+          yield parsed;
+        }
+      }
+    }
+    pending += decoder.decode();
+  } catch (error: unknown) {
+    if (error instanceof GatewayFailureError) {
+      throw error;
+    }
+    if (error instanceof ChatSseError) {
+      throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+    }
+    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+  }
+  if (pending.length > 0) {
+    throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+  }
+}
+
+function parseSseRecord(raw: string): ParsedSseEvent | undefined {
+  let eventName: string | undefined;
+  const data: string[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.length === 0 || line.startsWith(":")) {
+      continue;
+    }
+    const separator = line.indexOf(":");
+    const name = separator === -1 ? line : line.slice(0, separator);
+    const value = separator === -1 ? "" : line.slice(separator + 1).replace(/^ /u, "");
+    if (name === "event") {
+      eventName = value;
+    } else if (name === "data") {
+      data.push(value);
+    }
+  }
+  if (data.length === 0) {
+    return undefined;
+  }
+  const joined = data.join("\n");
+  if (joined === "[DONE]") {
+    throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+  }
+  return eventName === undefined ? { data: joined } : { eventName, data: joined };
+}
+
+function parseResponsesEventData(event: ParsedSseEvent): WireJsonObject {
+  try {
+    const data = new TextEncoder().encode(event.data);
+    const parsed = parseWireJson(data, { maxBytes: Math.max(data.byteLength, 1), maxDepth: 64 });
+    if (!isWireJsonObject(parsed)) {
+      throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+    }
+    return parsed;
+  } catch (error: unknown) {
+    if (error instanceof GatewayFailureError) {
+      throw error;
+    }
+    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+  }
+}
+
+function hasNativeVisionInput(value: WireJson | undefined): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  if (isWireJsonObject(value)) {
+    if (memberValues(value, "type")[0] === "input_image") {
+      return true;
+    }
+    return value.members.some((member) => hasNativeVisionInput(member.value));
+  }
+  if (isWireJsonArray(value)) {
+    return value.items.some((item) => hasNativeVisionInput(item));
+  }
+  return false;
+}
+
+function nativeInitiator(value: WireJson | undefined): "user" | "agent" {
+  if (isWireJsonObject(value) && memberValues(value, "role")[0] === "assistant") {
+    return "agent";
+  }
+  return "user";
+}
+
+function stringMember(object: WireJsonObject, key: string): string | undefined {
+  const value = memberValues(object, key)[0];
+  return typeof value === "string" ? value : undefined;
+}
+
+function integerMember(object: WireJsonObject, key: string): number | undefined {
+  const value = memberValues(object, key)[0];
+  if (!isWireJsonNumber(value)) {
+    return undefined;
+  }
+  const parsed = Number(value.lexeme);
+  return Number.isInteger(parsed) ? parsed : undefined;
+}
+
+function objectMember(object: WireJsonObject, key: string): WireJsonObject | undefined {
+  const value = memberValues(object, key)[0];
+  return isWireJsonObject(value) ? value : undefined;
+}
+
+function replaceMember(object: WireJsonObject, key: string, value: WireJson): WireJsonObject {
+  let replaced = false;
+  const members = object.members.map((member) => {
+    if (member.key !== key) {
+      return member;
+    }
+    replaced = true;
+    return { key, value };
+  });
+  if (!replaced) {
+    members.push({ key, value });
+  }
+  return { kind: "object", members };
+}
+
+function replaceExistingStringMember(object: WireJsonObject, key: string, value: string): WireJsonObject {
+  return {
+    kind: "object",
+    members: object.members.map((member) => member.key === key && typeof member.value === "string"
+      ? { key, value }
+      : member),
+  };
+}
+
+function isEventStream(headers: Headers): boolean {
+  return headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase() === "text/event-stream";
+}

--- a/src/protocols/responses/planner.ts
+++ b/src/protocols/responses/planner.ts
@@ -1,0 +1,50 @@
+import type { CopilotTarget } from "../../copilot/backend.js";
+import type { ResolvedModel } from "../model_catalog/resolver.js";
+import type { ResponsesRequest } from "./dto.js";
+
+export type ResponsesExecutionPlan = NativeResponsesPlan | ChatBridgePlan;
+
+export interface NativeResponsesPlan {
+  readonly kind: "native_responses";
+  readonly originalRequest: ResponsesRequest;
+  readonly resolvedModel: ResolvedModel;
+  readonly upstreamUrl: string;
+  readonly stream: boolean;
+}
+
+export interface ChatBridgePlan {
+  readonly kind: "chat_bridge";
+  readonly originalRequest: ResponsesRequest;
+  readonly resolvedModel: ResolvedModel;
+}
+
+export function planResponsesExecution(
+  request: ResponsesRequest,
+  resolvedModel: ResolvedModel,
+  target: Readonly<CopilotTarget>,
+): ResponsesExecutionPlan {
+  if (!usesNativeResponses(resolvedModel.routing)) {
+    return { kind: "chat_bridge", originalRequest: request, resolvedModel };
+  }
+  return {
+    kind: "native_responses",
+    originalRequest: request,
+    resolvedModel,
+    upstreamUrl: responsesUpstreamUrl(target.endpoint),
+    stream: request.stream,
+  };
+}
+
+export function responsesUpstreamUrl(endpoint: string): string {
+  return `${endpoint.replace(/\/+$/u, "")}/responses`;
+}
+
+function usesNativeResponses(routing: ResolvedModel["routing"]): boolean {
+  if (routing.mode === "responses") {
+    return true;
+  }
+  if (routing.mode === "chat") {
+    return false;
+  }
+  return routing.supportedEndpoints?.includes("/v1/responses") === true;
+}

--- a/tests/refactor/contract/responses_native.test.ts
+++ b/tests/refactor/contract/responses_native.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { ScriptedCopilotBackend } from "../../../src/copilot/backend.js";
+import type { BoundAccount } from "../../../src/accounts/account_directory.js";
+import type { BoundCopilot } from "../../../src/copilot/backend.js";
+import type { NativeResponsesUpstreamRequest, UpstreamByteStream } from "../../../src/protocols/chat_completions/types.js";
+import { decodeResponsesRequest } from "../../../src/protocols/responses/decoder.js";
+import {
+  completeNativeResponses,
+  nativeResponsesUpstreamRequest,
+  openNativeResponsesStream,
+  serializeNativeResponsesRequest,
+  validatedNativeResponsesBody,
+} from "../../../src/protocols/responses/native.js";
+import { planResponsesExecution, type NativeResponsesPlan } from "../../../src/protocols/responses/planner.js";
+import { isWireJsonObject, parseWireJson } from "../../../src/serialization/wire_json.js";
+import type { ResolvedModel } from "../../../src/protocols/model_catalog/resolver.js";
+
+describe("RM-13 native Responses execution", () => {
+  it("serializes only the resolved model change while preserving native fields and number lexemes", () => {
+    const plan = nativePlan("{\"previous_response_id\":\"resp_1\",\"model\":\"requested\",\"store\":false,\"temperature\":1.20,\"reasoning\":{\"encrypted_content\":\"abc\"}}");
+    expect(new TextDecoder().decode(serializeNativeResponsesRequest(plan))).toBe(
+      "{\"previous_response_id\":\"resp_1\",\"model\":\"resolved\",\"store\":false,\"temperature\":1.20,\"reasoning\":{\"encrypted_content\":\"abc\"}}",
+    );
+  });
+
+  it("builds upstream request metadata for native transport without invoking Chat", async () => {
+    let captured: NativeResponsesUpstreamRequest | undefined;
+    const backend = new ScriptedCopilotBackend({
+      responses(request) {
+        captured = request;
+        return {
+          status: 200,
+          headers: new Headers(),
+          body: new TextEncoder().encode("{\"id\":\"resp_1\",\"output\":[]}"),
+        };
+      },
+    });
+    const bound = await backend.bind({ accountId: "github.com/1" } as BoundAccount, new AbortController().signal);
+    const plan = nativePlan("{\"input\":[{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,abc\"}]}");
+    const request = nativeResponsesUpstreamRequest(plan, {
+      requestId: "req_native",
+      nonstreamBodyBytes: 1024,
+      connectTimeoutMs: 30,
+      firstByteTimeoutMs: 120,
+      signal: new AbortController().signal,
+    });
+    await completeNativeResponses(bound, plan, {
+      requestId: "req_native",
+      nonstreamBodyBytes: 1024,
+      connectTimeoutMs: 30,
+      firstByteTimeoutMs: 120,
+      signal: request.signal,
+    });
+    expect(backend.captured.map((entry) => entry.kind)).toEqual(["responses"]);
+    expect(captured).toMatchObject({
+      hasVisionInput: true,
+      initiator: "user",
+      requestId: "req_native",
+      nonstreamBodyBytes: 1024,
+      connectTimeoutMs: 30,
+      firstByteTimeoutMs: 120,
+    });
+  });
+
+  it("preserves valid native non-stream bodies and rejects malformed 2xx bodies", () => {
+    const body = new TextEncoder().encode("{\"id\":\"resp_1\",\"usage\":{\"input_tokens\":1}}");
+    expect(validatedNativeResponsesBody({ status: 200, headers: new Headers(), body }, 1024)).toBe(body);
+    expect(() => validatedNativeResponsesBody({
+      status: 200,
+      headers: new Headers(),
+      body: new TextEncoder().encode("[]"),
+    }, 1024)).toThrow(/GatewayFailureError|invalid/u);
+  });
+
+  it("rejects malformed native executor responses and non-SSE native streams", async () => {
+    const plan = nativePlan("{\"model\":\"requested\",\"input\":\"hi\",\"stream\":true}");
+    const signal = new AbortController().signal;
+    const invalidBody = await scriptedBound({
+      responses: {
+        status: 200,
+        headers: new Headers(),
+        body: new TextEncoder().encode("[]"),
+      },
+    });
+    await expect(completeNativeResponses(invalidBody, plan, {
+      requestId: "req_native",
+      nonstreamBodyBytes: 1024,
+      connectTimeoutMs: 30,
+      firstByteTimeoutMs: 120,
+      signal,
+    })).rejects.toThrow();
+
+    let canceled = 0;
+    const invalidStream = await scriptedBound({
+      stream: {
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        bytes: emptyStream(),
+        cancel: async () => { canceled += 1; },
+      },
+    });
+    await expect(openNativeResponsesStream(invalidStream, plan, {
+      requestId: "req_native",
+      nonstreamBodyBytes: 1024,
+      connectTimeoutMs: 30,
+      firstByteTimeoutMs: 120,
+      signal,
+    })).rejects.toThrow();
+    expect(canceled).toBe(1);
+  });
+
+  async function scriptedBound(options: {
+    readonly responses?: Awaited<ReturnType<BoundCopilot["completeResponses"]>>;
+    readonly stream?: UpstreamByteStream;
+  }): Promise<BoundCopilot> {
+    return {
+      accountId: "github.com/1",
+      target: { endpoint: "https://api.githubcopilot.com", token: "secret" },
+      completeChat: async () => { throw new Error("chat must not be called"); },
+      openChatStream: async () => { throw new Error("chat stream must not be called"); },
+      completeResponses: async () => {
+        if (options.responses === undefined) {
+          throw new Error("responses missing");
+        }
+        return options.responses;
+      },
+      openResponsesStream: async () => {
+        if (options.stream === undefined) {
+          throw new Error("stream missing");
+        }
+        return options.stream;
+      },
+    };
+  }
+
+  async function* emptyStream(): AsyncIterable<Uint8Array> {}
+
+  function nativePlan(json: string): NativeResponsesPlan {
+    const request = decode(json);
+    const resolvedModel: ResolvedModel = {
+      ...(request.model === undefined ? {} : { requestedModel: request.model }),
+      upstreamModel: "resolved",
+      source: "explicit",
+      routing: { mode: "responses" },
+    };
+    const plan = planResponsesExecution(request, resolvedModel, {
+      endpoint: "https://api.githubcopilot.com/",
+      token: "secret",
+    });
+    if (plan.kind !== "native_responses") {
+      throw new Error("expected native plan");
+    }
+    return plan;
+  }
+
+  function decode(json: string) {
+    const parsed = parseWireJson(new TextEncoder().encode(json), { maxBytes: 1024, maxDepth: 16 });
+    if (!isWireJsonObject(parsed)) {
+      throw new Error("expected object");
+    }
+    return decodeResponsesRequest(parsed);
+  }
+});

--- a/tests/refactor/contract/responses_native_stream.test.ts
+++ b/tests/refactor/contract/responses_native_stream.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { GatewayFailureError } from "../../../src/gateway/failures.js";
+import { normalizeNativeResponsesStream } from "../../../src/protocols/responses/native.js";
+
+describe("RM-13 native Responses stream", () => {
+  it("normalizes only item IDs by output index and preserves compact Responses SSE bytes", async () => {
+    const output = await collect(normalizeNativeResponsesStream(streamBytes([
+      "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"item_stable\",\"type\":\"message\"}}\n\n",
+      "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"item_id\":\"item_drift\",\"delta\":\"hi\"}\n\n",
+      "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"item_done\",\"type\":\"message\"}}\n\n",
+      "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"usage\":{\"input_tokens\":1}}}\n\n",
+    ]), 4096));
+    expect(output).toBe([
+      "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"item_stable\",\"type\":\"message\"}}\n\n",
+      "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"item_id\":\"item_stable\",\"delta\":\"hi\"}\n\n",
+      "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"item_stable\",\"type\":\"message\"}}\n\n",
+      "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"usage\":{\"input_tokens\":1}}}\n\n",
+    ].join(""));
+  });
+
+  it("rejects DONE markers, event type mismatches, and EOF before terminal", async () => {
+    await expect(collect(normalizeNativeResponsesStream(streamBytes(["data: [DONE]\n\n"]), 4096)))
+      .rejects.toBeInstanceOf(GatewayFailureError);
+    await expect(collect(normalizeNativeResponsesStream(streamBytes([
+      "event: wrong\ndata: {\"type\":\"response.completed\"}\n\n",
+    ]), 4096))).rejects.toBeInstanceOf(GatewayFailureError);
+    await expect(collect(normalizeNativeResponsesStream(streamBytes([
+      "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"item_stable\"}}\n\n",
+    ]), 4096))).rejects.toBeInstanceOf(GatewayFailureError);
+  });
+
+  it("applies the SSE byte limit per event rather than per network chunk", async () => {
+    const combined = [
+      "event: response.created\ndata: {\"type\":\"response.created\"}\n\n",
+      "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n",
+    ].join("");
+    await expect(collect(normalizeNativeResponsesStream(streamBytes([combined]), 80))).resolves.toBe(combined);
+  });
+
+  async function collect(source: AsyncIterable<Uint8Array>): Promise<string> {
+    let output = "";
+    for await (const chunk of source) {
+      output += new TextDecoder().decode(chunk);
+    }
+    return output;
+  }
+
+  async function* streamBytes(parts: readonly string[]): AsyncIterable<Uint8Array> {
+    const encoder = new TextEncoder();
+    for (const part of parts) {
+      yield encoder.encode(part);
+    }
+  }
+});

--- a/tests/refactor/contract/responses_planner.test.ts
+++ b/tests/refactor/contract/responses_planner.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { CatalogSnapshot } from "../../../src/copilot/model_catalog.js";
+import { decodeResponsesRequest } from "../../../src/protocols/responses/decoder.js";
+import { planResponsesExecution } from "../../../src/protocols/responses/planner.js";
+import { isWireJsonObject, parseWireJson } from "../../../src/serialization/wire_json.js";
+import { resolveModel } from "../../../src/protocols/model_catalog/resolver.js";
+
+describe("RM-13 Responses planner", () => {
+  it("selects native or bridge from resolved routing metadata without model-name inference", () => {
+    expect(plan("native", { mode: "responses", supportedEndpoints: [] }).kind).toBe("native_responses");
+    expect(plan("chat", { mode: "chat", supportedEndpoints: ["/v1/responses"] }).kind).toBe("chat_bridge");
+    expect(plan("endpoint", { supportedEndpoints: ["/v1/responses"] }).kind).toBe("native_responses");
+    expect(plan("unknown", { mode: "other", supportedEndpoints: ["/v1/chat/completions"] }).kind).toBe("chat_bridge");
+    expect(plan("gpt-looks-native", {}).kind).toBe("chat_bridge");
+  });
+
+  it("freezes the original request, resolved model, stream flag, and normalized native URL", () => {
+    const request = decode("{\"stream\":true,\"model\":\"native\",\"input\":\"hi\"}");
+    const resolved = resolvedFromCatalog("native", { mode: "responses" });
+    const plan = planResponsesExecution(request, resolved, {
+      endpoint: "https://api.githubcopilot.com/",
+      token: "secret",
+    });
+    expect(plan).toMatchObject({
+      kind: "native_responses",
+      originalRequest: request,
+      resolvedModel: resolved,
+      upstreamUrl: "https://api.githubcopilot.com/responses",
+      stream: true,
+    });
+  });
+
+  function plan(model: string, routing: CatalogSnapshot["models"][number]["routing"]) {
+    const request = decode(`{"model":"${model}"}`);
+    return planResponsesExecution(request, resolvedFromCatalog(model, routing), {
+      endpoint: "https://copilot.example.test",
+      token: "secret",
+    });
+  }
+
+  function resolvedFromCatalog(model: string, routing: CatalogSnapshot["models"][number]["routing"]) {
+    const catalog: CatalogSnapshot = {
+      accountId: "github.com/1",
+      fetchedAt: "2026-01-01T00:00:00Z",
+      generation: 1,
+      models: [{ id: model, name: model, vendor: "github", modelPickerEnabled: true, ...(routing === undefined ? {} : { routing }) }],
+    };
+    const resolved = resolveModel(catalog, model, null);
+    if ("kind" in resolved) {
+      throw new Error("expected resolved model");
+    }
+    return resolved;
+  }
+
+  function decode(json: string) {
+    const parsed = parseWireJson(new TextEncoder().encode(json), { maxBytes: 1024, maxDepth: 16 });
+    if (!isWireJsonObject(parsed)) {
+      throw new Error("expected object");
+    }
+    return decodeResponsesRequest(parsed);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds immutable Responses execution planning for native-vs-Chat bridge selection from resolved routing metadata only.
- Adds native Responses request serialization/execution helpers that preserve native fields/order/number lexemes and apply only resolved-model replacement.
- Adds native Responses SSE validation/encoding with text/event-stream validation, item-ID normalization by output_index, terminal ownership, no [DONE], and EOF truncation failure.
- Wires Responses-specific upstream request metadata through the Copilot backend/transport.

Closes #18

## Validation
- `npm run typecheck:refactor`
- `npm run test:refactor -- tests/refactor/contract/responses_planner.test.ts tests/refactor/contract/responses_native.test.ts tests/refactor/contract/responses_native_stream.test.ts`
- `npm run lint:refactor`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check`

## Code review
- Standards review: no real blockers. One reported `authorization` syntax issue was a secret-redaction artifact in tool output; actual source passed typecheck/build.
- Spec review: no blockers after adding executor-level 2xx body validation and native stream content-type validation.