### PR TITLE
Implement RM-14 Responses bridge request conversion

### DIFF
--- a/src/protocols/responses/bridge_request.ts
+++ b/src/protocols/responses/bridge_request.ts
@@ -1,0 +1,733 @@
+import { canonicalizeWireJson } from "../../serialization/canonical_json.js";
+import {
+  isWireJsonArray,
+  isWireJsonObject,
+  memberValues,
+  parseWireJson,
+  type WireJson,
+  type WireJsonArray,
+  type WireJsonObject,
+} from "../../serialization/wire_json.js";
+import type { ResponsesHistory } from "./history.js";
+import type { ChatBridgePlan } from "./planner.js";
+import { buildRequestToolContext, chatNameForSource, type RequestToolContext } from "./tool_context.js";
+import type { ResponsesRequest } from "./dto.js";
+
+export interface ReasoningConfig {
+  readonly supportsThinking?: boolean;
+  readonly supportsEffort?: boolean;
+  readonly thinkingParam?: "thinking" | "enable_thinking" | "reasoning_split" | "none";
+  readonly effortParam?: "reasoning_effort" | "reasoning.effort" | "none";
+  readonly effortValueMode?: "passthrough" | "deepseek" | "low_high" | "openrouter" | "zen";
+  readonly effortLevels?: readonly string[];
+}
+
+export interface ResponsesBridgeRequestContext {
+  readonly resolvedModel: string;
+  readonly toolContext: RequestToolContext;
+  readonly reasoningConfig: ReasoningConfig | null;
+  readonly upstreamHost?: string;
+  readonly upstreamPath?: string;
+  readonly promptCacheRouting?: "enabled" | "disabled" | "auto";
+  readonly clientSessionId?: string;
+}
+
+export async function buildChatBridgeRequest(
+  plan: Readonly<ChatBridgePlan>,
+  history: ResponsesHistory,
+  options: Omit<ResponsesBridgeRequestContext, "resolvedModel" | "toolContext">,
+  signal: AbortSignal,
+): Promise<WireJsonObject> {
+  const explicitPromptCacheKey = stringMember(plan.originalRequest.body, "prompt_cache_key");
+  const enriched = await history.enrich(plan.originalRequest, signal);
+  const modeled = applyResolvedModel(enriched, plan.resolvedModel.upstreamModel);
+  const toolContext = buildRequestToolContext(modeled);
+  return convertResponsesRequest(modeled, {
+    ...options,
+    resolvedModel: plan.resolvedModel.upstreamModel,
+    toolContext,
+    ...(options.clientSessionId === undefined ? {} : { clientSessionId: options.clientSessionId }),
+  }, explicitPromptCacheKey);
+}
+
+export function convertResponsesRequest(
+  request: Readonly<ResponsesRequest>,
+  context: Readonly<ResponsesBridgeRequestContext>,
+  explicitPromptCacheKey = stringMember(request.body, "prompt_cache_key"),
+): WireJsonObject {
+  const messages = convertMessages(request, context.toolContext);
+  const members: Array<readonly [string, WireJson]> = [
+    ["model", context.resolvedModel],
+    ["messages", array(messages)],
+  ];
+  copyTopLevel(request.body, members);
+  applyReasoning(request.body, context.reasoningConfig, members);
+  if (context.toolContext.chatTools.length > 0) {
+    members.push(["tools", array(context.toolContext.chatTools)]);
+    const choice = convertToolChoice(memberValues(request.body, "tool_choice")[0], context.toolContext);
+    if (choice !== undefined) {
+      members.push(["tool_choice", choice]);
+    }
+  } else {
+    removeMembers(members, "parallel_tool_calls");
+  }
+  const promptCacheKey = promptCacheKeyFor(context, explicitPromptCacheKey);
+  if (promptCacheKey !== undefined) {
+    members.push(["prompt_cache_key", promptCacheKey]);
+  }
+
+  function removeMembers(members: Array<readonly [string, WireJson]>, key: string): void {
+    for (let index = members.length - 1; index >= 0; index -= 1) {
+      if (members[index]?.[0] === key) {
+        members.splice(index, 1);
+      }
+    }
+  }
+  return object(members);
+}
+
+function applyResolvedModel(request: Readonly<ResponsesRequest>, model: string): ResponsesRequest {
+  let replaced = false;
+  const members = request.body.members.map((member) => {
+    if (member.key !== "model") {
+      return member;
+    }
+    replaced = true;
+    return { key: "model", value: model };
+  });
+  if (!replaced) {
+    members.push({ key: "model", value: model });
+  }
+  return {
+    body: { kind: "object", members },
+    model,
+    stream: request.stream,
+    ...(request.store === undefined ? {} : { store: request.store }),
+    ...(request.input === undefined ? {} : { input: request.input }),
+    ...(request.previousResponseId === undefined ? {} : { previousResponseId: request.previousResponseId }),
+  };
+}
+
+const DIRECT_COPY_FIELDS = new Set([
+  "frequency_penalty",
+  "logit_bias",
+  "logprobs",
+  "metadata",
+  "n",
+  "parallel_tool_calls",
+  "presence_penalty",
+  "response_format",
+  "seed",
+  "service_tier",
+  "stop",
+  "temperature",
+  "top_logprobs",
+  "top_p",
+  "user",
+]);
+
+function copyTopLevel(source: WireJsonObject, members: Array<readonly [string, WireJson]>): void {
+  const model = stringMember(source, "model") ?? "";
+  const maxOutputTokens = memberValues(source, "max_output_tokens")[0];
+  if (maxOutputTokens !== undefined) {
+    members.push([/^o[0-9]/u.test(model) ? "max_completion_tokens" : "max_tokens", maxOutputTokens]);
+  }
+  for (const member of source.members) {
+    if (member.key === "max_tokens" || member.key === "max_completion_tokens" || DIRECT_COPY_FIELDS.has(member.key)) {
+      members.push([member.key, member.value]);
+    }
+    if (member.key === "stream") {
+      members.push(["stream", member.value]);
+    }
+  }
+  if (memberValues(source, "stream")[0] === true) {
+    const streamOptions = memberValues(source, "stream_options")[0];
+    const existing = isWireJsonObject(streamOptions)
+      ? streamOptions.members.filter((member) => member.key !== "include_usage")
+      : [];
+    members.push(["stream_options", { kind: "object", members: [...existing, { key: "include_usage", value: true }] }]);
+  } else {
+    const streamOptions = memberValues(source, "stream_options")[0];
+    if (streamOptions !== undefined) {
+      members.push(["stream_options", streamOptions]);
+    }
+  }
+}
+
+function convertMessages(request: Readonly<ResponsesRequest>, toolContext: RequestToolContext): WireJsonObject[] {
+  const state: MessageState = { output: [], pendingReasoning: [] };
+  for (const system of instructionMessages(memberValues(request.body, "instructions")[0])) {
+    state.output.push(system);
+  }
+  const input = request.input;
+  if (typeof input === "string") {
+    flushBeforeUserBoundary(state);
+    state.output.push(chatMessage("user", input));
+  } else if (isWireJsonArray(input)) {
+    convertInputItems(input.items, state, toolContext);
+  } else if (isWireJsonObject(input)) {
+    convertInputItems([input], state, toolContext);
+  }
+  flushPendingReasoning(state);
+  return mergeSystemMessages(state.output);
+}
+
+interface MessageState {
+  readonly output: WireJsonObject[];
+  readonly pendingReasoning: string[];
+}
+
+function convertInputItems(items: readonly WireJson[], state: MessageState, toolContext: RequestToolContext): void {
+  let calls: WireJsonObject[] = [];
+  const flushCalls = (): void => {
+    if (calls.length === 0) {
+      return;
+    }
+    const reasoning = consumeReasoning(state);
+    const members: Array<readonly [string, WireJson]> = [
+      ["role", "assistant"],
+      ["content", null],
+      ["tool_calls", array(calls)],
+    ];
+    if (reasoning.length > 0) {
+      members.push(["reasoning_content", reasoning]);
+    } else {
+      members.push(["reasoning_content", "tool call"]);
+    }
+    state.output.push(object(members));
+    calls = [];
+  };
+
+  for (const item of items) {
+    if (!isWireJsonObject(item)) {
+      flushCalls();
+      continue;
+    }
+    const type = stringMember(item, "type");
+    if (type === "reasoning") {
+      appendReasoning(state.pendingReasoning, reasoningFromItem(item));
+      continue;
+    }
+    const call = callTool(item, toolContext);
+    if (call !== undefined) {
+      appendReasoning(state.pendingReasoning, reasoningFromItem(item));
+      calls.push(call);
+      continue;
+    }
+    flushCalls();
+    if (type === "function_call_output") {
+      state.output.push(toolMessage(callId(item), functionOutputContent(item)));
+      continue;
+    }
+    if (type === "custom_tool_call_output" || type === "tool_search_output") {
+      const extracted = extractMediaFromToolOutput(item);
+      state.output.push(toolMessage(callId(item), canonicalString(extracted.value)));
+      if (extracted.media.length > 0) {
+        state.output.push(mediaMessage(callId(item), extracted.media));
+      }
+      continue;
+    }
+    const message = messageFromItem(item);
+    if (message !== undefined) {
+      if (chatRole(item) !== "assistant") {
+        flushBeforeUserBoundary(state);
+      } else {
+        appendReasoning(state.pendingReasoning, reasoningFromItem(item));
+      }
+      state.output.push(message);
+    }
+  }
+  flushCalls();
+}
+
+function instructionMessages(value: WireJson | undefined): WireJsonObject[] {
+  if (typeof value === "string") {
+    return value.length === 0 ? [] : [chatMessage("system", value)];
+  }
+  if (!isWireJsonArray(value)) {
+    return [];
+  }
+  const text = value.items.map((item) => {
+    if (typeof item === "string") {
+      return item;
+    }
+    return isWireJsonObject(item) ? stringMember(item, "text") ?? "" : "";
+  }).filter((item) => item.length > 0).join("\n\n");
+  return text.length === 0 ? [] : [chatMessage("system", text)];
+}
+
+function mergeSystemMessages(messages: readonly WireJsonObject[]): WireJsonObject[] {
+  const systemText: string[] = [];
+  const rest: WireJsonObject[] = [];
+  for (const message of messages) {
+    if (memberValues(message, "role")[0] === "system") {
+      const content = memberValues(message, "content")[0];
+      if (typeof content === "string" && content.length > 0) {
+        systemText.push(content);
+      }
+    } else {
+      rest.push(message);
+    }
+  }
+  return systemText.length === 0 ? rest : [chatMessage("system", systemText.join("\n\n")), ...rest];
+}
+
+function messageFromItem(item: WireJsonObject): WireJsonObject | undefined {
+  const type = stringMember(item, "type");
+  const role = chatRole(item);
+  if (type !== undefined && !["message", "input_text", "input_image", "input_file", "input_audio"].includes(type)
+    && memberValues(item, "role").length === 0 && memberValues(item, "content").length === 0) {
+    return undefined;
+  }
+  if (type === "input_text" || type === "input_image" || type === "input_file" || type === "input_audio") {
+    const part = convertContentPart(item);
+    if (part === undefined) {
+      return undefined;
+    }
+    return chatMessage(role, contentFromParts([part]));
+  }
+  const content = memberValues(item, "content")[0];
+  if (isWireJsonArray(content)) {
+    const parts = content.items.map(convertContentPart).filter((part): part is WireJsonObject => part !== undefined);
+    return chatMessage(role, contentFromParts(parts));
+  }
+  return chatMessage(role, content === undefined ? null : content);
+}
+
+function convertContentPart(value: WireJson): WireJsonObject | undefined {
+  if (!isWireJsonObject(value)) {
+    return undefined;
+  }
+  const type = stringMember(value, "type");
+  if (type === "input_text" || type === "output_text" || type === "text") {
+    const text = stringMember(value, "text");
+    return text === undefined || text.length === 0 ? undefined : object([["type", "text"], ["text", text]]);
+  }
+  if (type === "refusal") {
+    const text = stringMember(value, "refusal");
+    return text === undefined || text.length === 0 ? undefined : object([["type", "text"], ["text", text]]);
+  }
+  if (type === "input_image") {
+    const image = memberValues(value, "image_url")[0];
+    return object([["type", "image_url"], ["image_url", isWireJsonObject(image) ? image : object([["url", typeof image === "string" ? image : ""]])]]);
+  }
+  if (type === "input_file") {
+    const fields = ["file_id", "file_data", "filename"]
+      .map((key): readonly [string, WireJson] | undefined => {
+        const member = memberValues(value, key)[0];
+        return member === undefined ? undefined : [key, member];
+      })
+      .filter((field): field is readonly [string, WireJson] => field !== undefined);
+    if (!fields.some(([key]) => key === "file_id" || key === "file_data")) {
+      return undefined;
+    }
+    return object([["type", "file"], ["file", object(fields)]]);
+  }
+  if (type === "input_audio") {
+    const audio = memberValues(value, "input_audio")[0];
+    return audio === undefined ? undefined : object([["type", "input_audio"], ["input_audio", audio]]);
+  }
+  return undefined;
+}
+
+function contentFromParts(parts: readonly WireJsonObject[]): WireJson {
+  const nonText = parts.some((part) => memberValues(part, "type")[0] !== "text");
+  if (!nonText) {
+    return parts.map((part) => stringMember(part, "text") ?? "").join("\n");
+  }
+  return array(parts);
+}
+
+function callTool(item: WireJsonObject, toolContext: RequestToolContext): WireJsonObject | undefined {
+  const type = stringMember(item, "type");
+  if (type === "function_call") {
+    const originalName = stringMember(item, "name") ?? "";
+    const chatName = chatNameForSource(toolContext, stringMember(item, "namespace"), originalName) ?? originalName;
+    return chatToolCall(callId(item), chatName, normalizedArguments(memberValues(item, "arguments")[0]));
+  }
+  if (type === "custom_tool_call") {
+    return chatToolCall(callId(item), stringMember(item, "name") ?? "", canonicalString(object([["input", memberValues(item, "input")[0] ?? ""]])));
+  }
+  if (type === "tool_search_call") {
+    return chatToolCall(callId(item), "tool_search", canonicalString(memberValues(item, "arguments")[0] ?? object([])));
+  }
+  return undefined;
+}
+
+function chatToolCall(id: string, name: string, args: string): WireJsonObject {
+  return object([
+    ["id", id],
+    ["type", "function"],
+    ["function", object([
+      ["name", name],
+      ["arguments", args],
+    ])],
+  ]);
+}
+
+function functionOutputContent(item: WireJsonObject): string {
+  const value = memberValues(item, "output")[0];
+  if (typeof value === "string") {
+    const parsed = parseJsonString(value);
+    return parsed === undefined ? value : canonicalString(parsed);
+  }
+  return value === undefined ? "" : canonicalString(value);
+}
+
+function normalizedArguments(value: WireJson | undefined): string {
+  if (value === undefined) {
+    return "{}";
+  }
+  if (typeof value === "string") {
+    if (value.trim().length === 0) {
+      return "{}";
+    }
+    const parsed = parseJsonString(value);
+    return parsed === undefined ? value : canonicalString(parsed);
+  }
+  return canonicalString(value);
+}
+
+function reasoningFromItem(item: WireJsonObject): string | undefined {
+  for (const key of ["reasoning_content", "reasoning"]) {
+    const value = memberValues(item, key)[0];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+    if (isWireJsonObject(value)) {
+      const nested = stringMember(value, "content") ?? stringMember(value, "text") ?? stringMember(value, "summary");
+      if (nested !== undefined && nested.length > 0) {
+        return nested;
+      }
+    }
+  }
+  const details = memberValues(item, "reasoning_details")[0];
+  if (typeof details === "string" && details.length > 0) {
+    return details;
+  }
+  if (isWireJsonArray(details)) {
+    const text = details.items.map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      return isWireJsonObject(part) ? stringMember(part, "text") ?? stringMember(part, "content") ?? "" : "";
+    }).filter((part) => part.length > 0).join("\n\n");
+    return text.length === 0 ? undefined : text;
+  }
+  const summary = memberValues(item, "summary")[0];
+  if (typeof summary === "string" && summary.length > 0) {
+    return summary;
+  }
+  if (isWireJsonArray(summary)) {
+    const text = summary.items.map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      return isWireJsonObject(part) ? stringMember(part, "text") ?? stringMember(part, "content") ?? "" : "";
+    }).filter((part) => part.length > 0).join("\n\n");
+    return text.length === 0 ? undefined : text;
+  }
+  return undefined;
+}
+
+function consumeReasoning(state: MessageState): string {
+  const text = state.pendingReasoning.join("\n\n");
+  state.pendingReasoning.length = 0;
+  return text;
+}
+
+function appendReasoning(target: string[], value: string | undefined): void {
+  if (value !== undefined && value.length > 0 && !target.includes(value)) {
+    target.push(value);
+  }
+}
+
+function flushBeforeUserBoundary(state: MessageState): void {
+  flushPendingReasoning(state);
+}
+
+function flushPendingReasoning(state: MessageState): void {
+  if (state.pendingReasoning.length === 0) {
+    return;
+  }
+  const previousIndex = state.output.findLastIndex((message) => memberValues(message, "role")[0] === "assistant");
+  const previous = state.output[previousIndex];
+  if (previous !== undefined && memberValues(previous, "reasoning_content").length === 0) {
+    state.output[previousIndex] = {
+      kind: "object",
+      members: [...previous.members, { key: "reasoning_content", value: state.pendingReasoning.join("\n\n") }],
+    };
+  }
+  state.pendingReasoning.length = 0;
+}
+
+function applyReasoning(
+  body: WireJsonObject,
+  config: ReasoningConfig | null,
+  members: Array<readonly [string, WireJson]>,
+): void {
+  const requested = requestedReasoning(body);
+  if (config === null) {
+    const effort = requested.effort;
+    if (requested.enabled === true && effort !== undefined && ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"].includes(effort)) {
+      members.push(["reasoning_effort", effort]);
+    }
+    return;
+  }
+  const supportsEffort = config.supportsEffort === true;
+  const supportsThinking = supportsEffort || config.supportsThinking === true;
+  if (requested.enabled !== undefined && supportsThinking) {
+    const thinkingParam = config.thinkingParam ?? "thinking";
+    if (thinkingParam === "thinking") {
+      members.push(["thinking", object([["type", requested.enabled ? "enabled" : "disabled"]])]);
+    } else if (thinkingParam === "enable_thinking" || thinkingParam === "reasoning_split") {
+      members.push([thinkingParam, requested.enabled]);
+    }
+  }
+  if (requested.enabled === true && supportsEffort) {
+    const effort = mappedEffort(requested.effort, config);
+    const effortParam = config.effortParam ?? "reasoning_effort";
+    if (effort !== undefined && effortParam === "reasoning_effort") {
+      members.push(["reasoning_effort", effort]);
+    } else if (effort !== undefined && effortParam === "reasoning.effort") {
+      members.push(["reasoning", object([["effort", effort]])]);
+    }
+  } else if (requested.enabled === false && config.effortParam === "reasoning.effort") {
+    members.push(["reasoning", object([["effort", "none"]])]);
+  }
+}
+
+function requestedReasoning(body: WireJsonObject): { readonly enabled?: boolean; readonly effort?: string } {
+  const reasoning = memberValues(body, "reasoning")[0];
+  if (isWireJsonObject(reasoning)) {
+    const effort = stringMember(reasoning, "effort")?.trim().toLowerCase();
+    if (effort !== undefined) {
+      if (["none", "off", "disabled"].includes(effort)) {
+        return { enabled: false, effort };
+      }
+      return { enabled: true, effort };
+    }
+    return { enabled: true };
+  }
+  if (reasoning === null) {
+    return { enabled: false };
+  }
+  if (reasoning !== undefined) {
+    return { enabled: true };
+  }
+  return {};
+}
+
+function mappedEffort(effort: string | undefined, config: ReasoningConfig): string | undefined {
+  if (effort === undefined) {
+    return undefined;
+  }
+  const mode = config.effortValueMode ?? "passthrough";
+  if (mode === "deepseek") {
+    return ["max", "xhigh", "ultra"].includes(effort) ? "max" : "high";
+  }
+  if (mode === "low_high") {
+    return ["minimal", "low"].includes(effort) ? "low" : "high";
+  }
+  if (mode === "openrouter") {
+    return ["max", "xhigh", "ultra"].includes(effort) ? "xhigh" : ["high", "medium", "low", "minimal"].includes(effort) ? effort : undefined;
+  }
+  if (mode === "zen") {
+    return zenEffort(effort, config.effortLevels ?? []);
+  }
+  return ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"].includes(effort) ? effort : undefined;
+}
+
+function zenEffort(effort: string, levels: readonly string[]): string | undefined {
+  const order = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+  const requested = order.indexOf(effort);
+  if (requested === -1 || levels.length === 0) {
+    return undefined;
+  }
+  return levels.find((level) => order.indexOf(level) >= requested) ?? levels.at(-1);
+}
+
+function convertToolChoice(value: WireJson | undefined, context: RequestToolContext): WireJson | undefined {
+  if (isWireJsonObject(value)) {
+    const type = stringMember(value, "type");
+    if (type === "function") {
+      const originalName = stringMember(value, "name") ?? "";
+      const chatName = chatNameForSource(context, stringMember(value, "namespace"), originalName) ?? originalName;
+      return object([["type", "function"], ["function", object([["name", chatName]])]]);
+    }
+    if (type === "tool_search") {
+      return object([["type", "function"], ["function", object([["name", "tool_search"]])]]);
+    }
+    if (type === "custom") {
+      const name = stringMember(value, "name") ?? "";
+      return object([["type", "function"], ["function", object([["name", name]])]]);
+    }
+  }
+  return value;
+}
+
+interface ExtractedMedia {
+  readonly value: WireJson;
+  readonly media: readonly WireJsonObject[];
+}
+
+function extractMediaFromToolOutput(value: WireJson, depth = 0): ExtractedMedia {
+  if (depth > 32) {
+    return { value, media: [] };
+  }
+  if (typeof value === "string") {
+    const parsed = parseJsonString(value.trim());
+    if (parsed !== undefined) {
+      const extracted = extractMediaFromToolOutput(parsed, depth + 1);
+      if (extracted.media.length > 0) {
+        return { value: canonicalString(omitLongResidualStrings(extracted.value)), media: extracted.media };
+      }
+    }
+  }
+  const media = mediaPart(value);
+  if (media !== undefined) {
+    return { value: "[cc-switch: tool result media moved to the following user message]", media: [media] };
+  }
+  if (isWireJsonArray(value)) {
+    const items: WireJson[] = [];
+    const mediaItems: WireJsonObject[] = [];
+    for (const item of value.items) {
+      const extracted = extractMediaFromToolOutput(item, depth + 1);
+      items.push(extracted.value);
+      mediaItems.push(...extracted.media);
+    }
+    return { value: array(items), media: mediaItems };
+  }
+  if (isWireJsonObject(value)) {
+    const members: Array<readonly [string, WireJson]> = [];
+    const mediaItems: WireJsonObject[] = [];
+    for (const member of value.members) {
+      const extracted = extractMediaFromToolOutput(member.value, depth + 1);
+      members.push([member.key, extracted.value]);
+      mediaItems.push(...extracted.media);
+    }
+    return { value: object(members), media: mediaItems };
+  }
+  return { value, media: [] };
+}
+
+function mediaPart(value: WireJson): WireJsonObject | undefined {
+  if (typeof value === "string" && value.trim().startsWith("data:image/") && new TextEncoder().encode(value.trim()).byteLength >= 8192) {
+    return object([["type", "image_url"], ["image_url", object([["url", value.trim()]])]]);
+  }
+  if (!isWireJsonObject(value)) {
+    return undefined;
+  }
+  const type = stringMember(value, "type");
+  if (type === "input_image" || type === "image_url") {
+    const image = memberValues(value, "image_url")[0] ?? memberValues(value, "source")[0];
+    return object([["type", "image_url"], ["image_url", isWireJsonObject(image) ? image : object([["url", typeof image === "string" ? image : ""]])]]);
+  }
+  if (type === "input_file" && (memberValues(value, "file_id")[0] !== undefined || memberValues(value, "file_data")[0] !== undefined)) {
+    return convertContentPart(value);
+  }
+  if (type === "input_audio") {
+    return convertContentPart(value);
+  }
+  return undefined;
+}
+
+function omitLongResidualStrings(value: WireJson): WireJson {
+  if (typeof value === "string") {
+    const bytes = new TextEncoder().encode(value).byteLength;
+    if (bytes >= 8192 && value !== "[cc-switch: tool result media moved to the following user message]") {
+      return `[cc-switch: omitted ${bytes} bytes]`;
+    }
+    return value;
+  }
+  if (isWireJsonArray(value)) {
+    return { kind: "array", items: value.items.map(omitLongResidualStrings) };
+  }
+  if (isWireJsonObject(value)) {
+    return {
+      kind: "object",
+      members: value.members.map((member) => ({ key: member.key, value: omitLongResidualStrings(member.value) })),
+    };
+  }
+  return value;
+}
+
+function mediaMessage(callIdValue: string, media: readonly WireJsonObject[]): WireJsonObject {
+  return chatMessage("user", array([
+    object([["type", "text"], ["text", `[cc-switch: media output of tool call ${callIdValue}]`]]),
+    ...media,
+  ]));
+}
+
+function promptCacheKeyFor(
+  context: Readonly<ResponsesBridgeRequestContext>,
+  explicit: string | undefined,
+): string | undefined {
+  if (context.promptCacheRouting === "disabled") {
+    return undefined;
+  }
+  const allowed = context.promptCacheRouting === "enabled" || defaultPromptCacheAllowed(context);
+  if (!allowed) {
+    return undefined;
+  }
+  const key = explicit?.trim() || context.clientSessionId?.trim();
+  return key === undefined || key.length === 0 ? undefined : key;
+}
+
+function defaultPromptCacheAllowed(context: Readonly<ResponsesBridgeRequestContext>): boolean {
+  if (context.promptCacheRouting !== undefined && context.promptCacheRouting !== "auto") {
+    return false;
+  }
+  if (context.upstreamHost === "api.openai.com") {
+    return true;
+  }
+  return context.upstreamHost === "api.kimi.com" && (context.upstreamPath === "/coding" || context.upstreamPath?.startsWith("/coding/") === true);
+}
+
+function chatRole(item: WireJsonObject): string {
+  const role = stringMember(item, "role");
+  if (role === "system" || role === "developer") {
+    return "system";
+  }
+  if (role === "assistant" || role === "tool") {
+    return role;
+  }
+  return "user";
+}
+
+function chatMessage(role: string, content: WireJson): WireJsonObject {
+  return object([["role", role], ["content", content]]);
+}
+
+function toolMessage(id: string, content: string): WireJsonObject {
+  return object([["role", "tool"], ["tool_call_id", id], ["content", content]]);
+}
+
+function callId(item: WireJsonObject): string {
+  return stringMember(item, "call_id")?.trim() || stringMember(item, "id")?.trim() || "";
+}
+
+function canonicalString(value: WireJson): string {
+  return new TextDecoder().decode(canonicalizeWireJson(value));
+}
+
+function parseJsonString(value: string): WireJson | undefined {
+  try {
+    return parseWireJson(new TextEncoder().encode(value), { maxBytes: Math.max(1, new TextEncoder().encode(value).byteLength), maxDepth: 64 });
+  } catch (_error: unknown) {
+    return undefined;
+  }
+}
+
+function stringMember(object: WireJsonObject, key: string): string | undefined {
+  const value = memberValues(object, key)[0];
+  return typeof value === "string" ? value : undefined;
+}
+
+function object(members: readonly (readonly [string, WireJson])[]): WireJsonObject {
+  return { kind: "object", members: members.map(([key, value]) => ({ key, value })) };
+}
+
+function array(items: readonly WireJson[]): WireJsonArray {
+  return { kind: "array", items };
+}

--- a/src/protocols/responses/tool_context.ts
+++ b/src/protocols/responses/tool_context.ts
@@ -1,0 +1,300 @@
+import { createHash } from "node:crypto";
+import { canonicalizeWireJson } from "../../serialization/canonical_json.js";
+import {
+  isWireJsonArray,
+  isWireJsonObject,
+  memberValues,
+  type WireJson,
+  type WireJsonArray,
+  type WireJsonObject,
+} from "../../serialization/wire_json.js";
+import type { ResponsesRequest } from "./dto.js";
+
+export type ToolBindingKind = "function" | "namespace" | "custom" | "tool_search";
+
+export interface ToolBinding {
+  readonly kind: ToolBindingKind;
+  readonly originalName: string;
+  readonly namespace?: string;
+}
+
+export interface RequestToolContext {
+  readonly chatTools: readonly WireJsonObject[];
+  readonly seenChatNames: ReadonlySet<string>;
+  readonly chatNameToBinding: ReadonlyMap<string, ToolBinding>;
+  readonly sourceNameToChatName: ReadonlyMap<string, string>;
+}
+
+interface MutableToolContext {
+  readonly chatTools: WireJsonObject[];
+  readonly seenChatNames: Set<string>;
+  readonly chatNameToBinding: Map<string, ToolBinding>;
+  readonly sourceNameToChatName: Map<string, string>;
+}
+
+const CUSTOM_INPUT_SCHEMA: WireJsonObject = object([
+  ["type", "object"],
+  ["properties", object([
+    ["input", object([
+      ["type", "string"],
+      ["description", "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description."],
+    ])],
+  ])],
+  ["required", array(["input"])],
+]);
+
+const TOOL_SEARCH_SCHEMA: WireJsonObject = object([
+  ["type", "object"],
+  ["properties", object([
+    ["query", object([
+      ["type", "string"],
+      ["description", "Search query for tools or connectors to load."],
+    ])],
+    ["limit", object([
+      ["type", "integer"],
+      ["description", "Maximum number of tool groups to return."],
+    ])],
+  ])],
+  ["required", array(["query"])],
+]);
+
+const TOOL_SEARCH_DESCRIPTION = "Search and load Codex tools, plugins, connectors, and MCP namespaces for the current task.";
+
+export function buildRequestToolContext(request: Readonly<ResponsesRequest>): RequestToolContext {
+  const context: MutableToolContext = {
+    chatTools: [],
+    seenChatNames: new Set<string>(),
+    chatNameToBinding: new Map<string, ToolBinding>(),
+    sourceNameToChatName: new Map<string, string>(),
+  };
+
+  const tools = memberValues(request.body, "tools")[0];
+  if (isWireJsonArray(tools)) {
+    for (const tool of tools.items) {
+      addToolDeclaration(context, tool);
+    }
+  }
+  collectToolSearchDeclarations(context, request.input);
+
+  return {
+    chatTools: context.chatTools,
+    seenChatNames: context.seenChatNames,
+    chatNameToBinding: context.chatNameToBinding,
+    sourceNameToChatName: context.sourceNameToChatName,
+  };
+}
+
+export function sourceToolKey(namespace: string | undefined, name: string): string {
+  return `${namespace ?? ""}\u0000${name}`;
+}
+
+export function chatNameForSource(
+  context: RequestToolContext,
+  namespace: string | undefined,
+  name: string,
+): string | undefined {
+  return context.sourceNameToChatName.get(sourceToolKey(namespace, name));
+}
+
+function addToolDeclaration(context: MutableToolContext, value: WireJson): void {
+  if (typeof value === "string") {
+    addCustomTool(context, value, value);
+    return;
+  }
+  if (!isWireJsonObject(value)) {
+    return;
+  }
+  const type = memberValues(value, "type")[0];
+  if (type === "function" || (type === undefined && functionShape(value) !== undefined)) {
+    addFunctionTool(context, value, undefined);
+    return;
+  }
+  if (type === "namespace") {
+    addNamespaceTool(context, value);
+    return;
+  }
+  if (type === "custom") {
+    const name = stringMember(value, "name")?.trim() ?? "";
+    addCustomTool(context, name, value);
+    return;
+  }
+  if (type === "tool_search") {
+    addToolSearch(context);
+  }
+}
+
+function addFunctionTool(context: MutableToolContext, tool: WireJsonObject, namespace: string | undefined): void {
+  const shape = functionShape(tool);
+  if (shape === undefined) {
+    return;
+  }
+  const originalName = stringMember(shape, "name")?.trim() ?? "";
+  if (originalName.length === 0) {
+    return;
+  }
+  const chatName = namespace === undefined ? originalName : hashedNamespaceName(namespace, originalName);
+  const parameters = cleanupFunctionParameters(memberValues(shape, "parameters")[0]);
+  const description = memberValues(shape, "description")[0] ?? null;
+  const nestedStrict = memberValues(shape, "strict")[0];
+  const strict = nestedStrict === undefined ? memberValues(tool, "strict")[0] : nestedStrict;
+  const functionMembers: Array<readonly [string, WireJson]> = [
+    ["name", chatName],
+    ["description", description],
+    ["parameters", parameters],
+  ];
+  if (strict === true || strict === false) {
+    functionMembers.push(["strict", strict]);
+  }
+  addChatTool(context, chatName, {
+    kind: namespace === undefined ? "function" : "namespace",
+    originalName,
+    ...(namespace === undefined ? {} : { namespace }),
+  }, object([
+    ["type", "function"],
+    ["function", object(functionMembers)],
+  ]));
+  context.sourceNameToChatName.set(sourceToolKey(namespace, originalName), chatName);
+}
+
+function addNamespaceTool(context: MutableToolContext, tool: WireJsonObject): void {
+  const namespace = stringMember(tool, "name") ?? "";
+  const children = arrayMember(tool, "tools") ?? arrayMember(tool, "children");
+  if (children === undefined) {
+    return;
+  }
+  for (const child of children.items) {
+    if (isWireJsonObject(child) && memberValues(child, "type")[0] === "function") {
+      addFunctionTool(context, child, namespace);
+    }
+  }
+}
+
+function addCustomTool(context: MutableToolContext, name: string, original: WireJson): void {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    return;
+  }
+  addChatTool(context, trimmed, { kind: "custom", originalName: trimmed }, object([
+    ["type", "function"],
+    ["function", object([
+      ["name", trimmed],
+      ["description", `Original tool definition:\n\`\`\`json\n${canonicalString(original)}\n\`\`\``],
+      ["parameters", CUSTOM_INPUT_SCHEMA],
+    ])],
+  ]));
+  context.sourceNameToChatName.set(sourceToolKey(undefined, trimmed), trimmed);
+}
+
+function addToolSearch(context: MutableToolContext): void {
+  addChatTool(context, "tool_search", { kind: "tool_search", originalName: "tool_search" }, object([
+    ["type", "function"],
+    ["function", object([
+      ["name", "tool_search"],
+      ["description", TOOL_SEARCH_DESCRIPTION],
+      ["parameters", TOOL_SEARCH_SCHEMA],
+    ])],
+  ]));
+  context.sourceNameToChatName.set(sourceToolKey(undefined, "tool_search"), "tool_search");
+}
+
+function addChatTool(
+  context: MutableToolContext,
+  chatName: string,
+  binding: ToolBinding,
+  tool: WireJsonObject,
+): void {
+  if (context.seenChatNames.has(chatName)) {
+    return;
+  }
+  context.seenChatNames.add(chatName);
+  context.chatNameToBinding.set(chatName, binding);
+  context.chatTools.push(tool);
+}
+
+function functionShape(tool: WireJsonObject): WireJsonObject | undefined {
+  const nested = memberValues(tool, "function")[0];
+  if (isWireJsonObject(nested)) {
+    return nested;
+  }
+  return tool;
+}
+
+function cleanupFunctionParameters(value: WireJson | undefined): WireJsonObject {
+  if (!isWireJsonObject(value)) {
+    return object([
+      ["type", "object"],
+      ["properties", object([])],
+    ]);
+  }
+  const members = value.members.filter((member) => member.key !== "type");
+  return {
+    kind: "object",
+    members: [{ key: "type", value: "object" }, ...members],
+  };
+}
+
+function collectToolSearchDeclarations(context: MutableToolContext, value: WireJson | undefined, depth = 0): void {
+  if (value === undefined || depth > 32) {
+    return;
+  }
+  if (isWireJsonArray(value)) {
+    for (const item of value.items) {
+      collectToolSearchDeclarations(context, item, depth + 1);
+    }
+    return;
+  }
+  if (!isWireJsonObject(value)) {
+    return;
+  }
+  if (memberValues(value, "type")[0] === "tool_search_output") {
+    const tools = arrayMember(value, "tools");
+    if (tools !== undefined) {
+      for (const tool of tools.items) {
+        addToolDeclaration(context, tool);
+      }
+    }
+  }
+  for (const member of value.members) {
+    collectToolSearchDeclarations(context, member.value, depth + 1);
+  }
+}
+
+function hashedNamespaceName(namespace: string, childName: string): string {
+  const full = `${namespace}__${childName}`;
+  if (new TextEncoder().encode(full).byteLength <= 64) {
+    return full;
+  }
+  const suffix = `__${createHash("sha256").update(full).digest("hex").slice(0, 16)}`;
+  const maxPrefixBytes = 64 - new TextEncoder().encode(suffix).byteLength;
+  let prefix = "";
+  for (const char of full) {
+    const next = `${prefix}${char}`;
+    if (new TextEncoder().encode(next).byteLength > maxPrefixBytes) {
+      break;
+    }
+    prefix = next;
+  }
+  return `${prefix}${suffix}`;
+}
+
+function canonicalString(value: WireJson): string {
+  return new TextDecoder().decode(canonicalizeWireJson(value));
+}
+
+function stringMember(object: WireJsonObject, key: string): string | undefined {
+  const value = memberValues(object, key)[0];
+  return typeof value === "string" ? value : undefined;
+}
+
+function arrayMember(object: WireJsonObject, key: string) {
+  const value = memberValues(object, key)[0];
+  return isWireJsonArray(value) ? value : undefined;
+}
+
+function object(members: readonly (readonly [string, WireJson])[]): WireJsonObject {
+  return { kind: "object", members: members.map(([key, value]) => ({ key, value })) };
+}
+
+function array(items: readonly WireJson[]): WireJsonArray {
+  return { kind: "array", items };
+}

--- a/tests/refactor/contract/responses_bridge_request.test.ts
+++ b/tests/refactor/contract/responses_bridge_request.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+import type { ResolvedModel } from "../../../src/protocols/model_catalog/resolver.js";
+import { decodeResponsesRequest } from "../../../src/protocols/responses/decoder.js";
+import {
+  buildChatBridgeRequest,
+  convertResponsesRequest,
+} from "../../../src/protocols/responses/bridge_request.js";
+import type { ChatBridgePlan } from "../../../src/protocols/responses/planner.js";
+import { buildRequestToolContext } from "../../../src/protocols/responses/tool_context.js";
+import {
+  isWireJsonObject,
+  parseWireJson,
+  serializeWireJson,
+  type WireJsonObject,
+} from "../../../src/serialization/wire_json.js";
+
+const LIMITS = { maxBytes: 65_536, maxDepth: 64 } as const;
+
+describe("RM-14 Responses bridge request conversion", () => {
+  it("converts top-level fields, input parts, calls, tools, reasoning, and prompt cache", () => {
+    const request = requestFromJson(JSON.stringify({
+      model: "o1",
+      instructions: ["sys", { text: "dev" }, ""],
+      input: [
+        { role: "system", content: "later system" },
+        {
+          role: "user",
+          content: [
+            { type: "input_text", text: "hello" },
+            { type: "input_image", image_url: "https://example.test/a.png" },
+            { type: "input_file", file_id: "file_1", filename: "a.txt" },
+            { type: "input_audio", input_audio: { data: "abc", format: "wav" } },
+          ],
+        },
+        { type: "reasoning", summary: [{ text: "plan" }] },
+        { type: "function_call", call_id: "call_1", name: "lookup", arguments: "{\"z\":1,\"a\":2}" },
+        { type: "custom_tool_call", call_id: "call_2", name: "render", input: "card" },
+        { type: "tool_search_call", call_id: "call_3", arguments: { query: "docs" } },
+        { type: "function_call_output", call_id: "call_1", output: "{\"b\":2,\"a\":1}" },
+      ],
+      max_output_tokens: 9,
+      max_tokens: 7,
+      temperature: 0.2,
+      stream: true,
+      stream_options: { other: "keep", include_usage: false },
+      tools: [
+        { type: "function", name: "lookup", description: "Lookup", parameters: { type: "string", x: 1 }, strict: true },
+        { type: "namespace", name: "ns", tools: [{ type: "function", name: "child", parameters: {} }] },
+        { type: "custom", name: "render", input_format: "text" },
+        { type: "tool_search" },
+      ],
+      tool_choice: { type: "function", name: "child", namespace: "ns" },
+      parallel_tool_calls: true,
+      prompt_cache_key: "  cache-key  ",
+      previous_response_id: "drop",
+      store: true,
+      text: { format: "drop" },
+      reasoning: { effort: "max" },
+    }));
+    const toolContext = buildRequestToolContext(request);
+    const converted = convertResponsesRequest(request, {
+      resolvedModel: "o1",
+      toolContext,
+      reasoningConfig: { supportsEffort: true, effortValueMode: "openrouter" },
+      upstreamHost: "api.openai.com",
+      promptCacheRouting: "auto",
+    });
+
+    expect(json(converted)).toEqual({
+      model: "o1",
+      messages: [
+        { role: "system", content: "sys\n\ndev\n\nlater system" },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hello" },
+            { type: "image_url", image_url: { url: "https://example.test/a.png" } },
+            { type: "file", file: { file_id: "file_1", filename: "a.txt" } },
+            { type: "input_audio", input_audio: { data: "abc", format: "wav" } },
+          ],
+        },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            { id: "call_1", type: "function", function: { name: "lookup", arguments: "{\"a\":2,\"z\":1}" } },
+            { id: "call_2", type: "function", function: { name: "render", arguments: "{\"input\":\"card\"}" } },
+            { id: "call_3", type: "function", function: { name: "tool_search", arguments: "{\"query\":\"docs\"}" } },
+          ],
+          reasoning_content: "plan",
+        },
+        { role: "tool", tool_call_id: "call_1", content: "{\"a\":1,\"b\":2}" },
+      ],
+      max_completion_tokens: 9,
+      max_tokens: 7,
+      temperature: 0.2,
+      stream: true,
+      stream_options: { other: "keep", include_usage: true },
+      parallel_tool_calls: true,
+      thinking: { type: "enabled" },
+      reasoning_effort: "xhigh",
+      tools: [
+        { type: "function", function: { name: "lookup", description: "Lookup", parameters: { type: "object", x: 1 }, strict: true } },
+        { type: "function", function: { name: "ns__child", description: null, parameters: { type: "object" } } },
+        {
+          type: "function",
+          function: {
+            name: "render",
+            description: expect.stringContaining("Original tool definition:"),
+            parameters: {
+              type: "object",
+              properties: {
+                input: {
+                  type: "string",
+                  description: expect.stringContaining("Raw string input"),
+                },
+              },
+              required: ["input"],
+            },
+          },
+        },
+        {
+          type: "function",
+          function: {
+            name: "tool_search",
+            description: "Search and load Codex tools, plugins, connectors, and MCP namespaces for the current task.",
+            parameters: expect.objectContaining({ type: "object", required: ["query"] }),
+          },
+        },
+      ],
+      tool_choice: { type: "function", function: { name: "ns__child" } },
+      prompt_cache_key: "cache-key",
+    });
+    expect(JSON.stringify(json(converted))).not.toContain("previous_response_id");
+    expect(JSON.stringify(json(converted))).not.toContain("store");
+  });
+
+  it("uses history before ToolContext and removes tool_choice when no tools survive", async () => {
+    const events: string[] = [];
+    const request = requestFromJson(JSON.stringify({
+      model: "gpt",
+      input: [{ type: "function_call_output", call_id: "call_restored", output: "ok" }],
+      tool_choice: "none",
+      parallel_tool_calls: true,
+    }));
+    const plan: ChatBridgePlan = {
+      kind: "chat_bridge",
+      originalRequest: request,
+      resolvedModel: resolved("gpt"),
+    };
+    const converted = await buildChatBridgeRequest(plan, {
+      async enrich(_input) {
+        events.push("history");
+        return requestFromJson(JSON.stringify({
+          model: "gpt",
+          input: [
+            { type: "function_call", call_id: "call_restored", name: "late", arguments: "{}" },
+            { type: "function_call_output", call_id: "call_restored", output: "ok" },
+          ],
+          tools: [{ type: "function", name: "late", parameters: {} }],
+        }));
+      },
+      async record() {
+        throw new Error("record must not be called by RM-14 request conversion");
+      },
+    }, { reasoningConfig: null }, new AbortController().signal);
+    events.push("converted");
+
+    expect(events).toEqual(["history", "converted"]);
+    expect(json(converted)).toMatchObject({
+      model: "gpt",
+      messages: [
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [{ id: "call_restored", type: "function", function: { name: "late", arguments: "{}" } }],
+          reasoning_content: "tool call",
+        },
+        { role: "tool", tool_call_id: "call_restored", content: "ok" },
+      ],
+      tools: [{ type: "function", function: { name: "late", description: null, parameters: { type: "object" } } }],
+    });
+    expect(json(converted)).not.toHaveProperty("tool_choice");
+    expect(json(converted)).not.toHaveProperty("parallel_tool_calls");
+
+    const noTools = requestFromJson(JSON.stringify({
+      model: "gpt",
+      input: "hi",
+      tool_choice: "none",
+      parallel_tool_calls: true,
+    }));
+    const noToolsConverted = convertResponsesRequest(noTools, {
+      resolvedModel: "gpt",
+      toolContext: buildRequestToolContext(noTools),
+      reasoningConfig: null,
+    });
+    expect(json(noToolsConverted)).not.toHaveProperty("tool_choice");
+    expect(json(noToolsConverted)).not.toHaveProperty("parallel_tool_calls");
+  });
+
+  it("relocates tool-output media and supports reasoning effort modes", () => {
+    const dataUrl = `data:image/png;base64,${"a".repeat(8192)}`;
+    const residual = "b".repeat(8192);
+    const encodedOutput = JSON.stringify({
+      media: { type: "input_image", image_url: dataUrl },
+      residual,
+    });
+    const request = requestFromJson(JSON.stringify({
+      model: "gpt",
+      input: [
+        { type: "custom_tool_call_output", call_id: "call_media", output: [{ type: "input_image", image_url: dataUrl }] },
+        { type: "tool_search_output", call_id: "call_json_media", output: encodedOutput },
+      ],
+      reasoning: { effort: "low" },
+      tools: [{ type: "custom", name: "render" }],
+    }));
+    const converted = convertResponsesRequest(request, {
+      resolvedModel: "gpt",
+      toolContext: buildRequestToolContext(request),
+      reasoningConfig: { supportsEffort: true, effortParam: "reasoning.effort", effortValueMode: "low_high" },
+      promptCacheRouting: "disabled",
+      clientSessionId: "session",
+    });
+    expect(json(converted)).toMatchObject({
+      messages: [
+        {
+          role: "tool",
+          tool_call_id: "call_media",
+          content: "{\"call_id\":\"call_media\",\"output\":[\"[cc-switch: tool result media moved to the following user message]\"],\"type\":\"custom_tool_call_output\"}",
+        },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "[cc-switch: media output of tool call call_media]" },
+            { type: "image_url", image_url: { url: dataUrl } },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_json_media",
+          content: "{\"call_id\":\"call_json_media\",\"output\":\"{\\\"media\\\":\\\"[cc-switch: tool result media moved to the following user message]\\\",\\\"residual\\\":\\\"[cc-switch: omitted 8192 bytes]\\\"}\",\"type\":\"tool_search_output\"}",
+        },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "[cc-switch: media output of tool call call_json_media]" },
+            { type: "image_url", image_url: { url: dataUrl } },
+          ],
+        },
+      ],
+      thinking: { type: "enabled" },
+      reasoning: { effort: "low" },
+    });
+    expect(json(converted)).not.toHaveProperty("prompt_cache_key");
+  });
+
+  function requestFromJson(source: string) {
+    const parsed = parseWireJson(new TextEncoder().encode(source), LIMITS);
+    expect(isWireJsonObject(parsed)).toBe(true);
+    return decodeResponsesRequest(parsed as WireJsonObject);
+  }
+
+  function json(value: WireJsonObject): Record<string, unknown> {
+    return JSON.parse(new TextDecoder().decode(serializeWireJson(value))) as Record<string, unknown>;
+  }
+
+  function resolved(model: string): ResolvedModel {
+    return { upstreamModel: model, source: "explicit", requestedModel: model, routing: { mode: "chat" } };
+  }
+});


### PR DESCRIPTION
## Summary
- Adds RM-14 Responses ChatBridgePlan request orchestration: history enrichment, resolved model writeback, ToolContext construction, conversion, and prompt-cache injection.
- Implements pure Responses request -> Chat request conversion for top-level fields, instructions/system ordering, input content/media/files/audio, call batching, tool outputs, reasoning history, and reasoning config dialects.
- Adds authoritative request ToolContext construction for function, namespace, custom, tool-search, collision, hashing, and tool_choice mapping.
- Covers JSON-encoded tool-output media relocation and residual long-string omission.

Closes #21

## Validation
- `npm run typecheck:refactor`
- `npm run test:refactor -- tests/refactor/contract/responses_bridge_request.test.ts tests/refactor/unit/responses_history.test.ts tests/refactor/unit/responses_decoder.test.ts`
- `npm run lint:refactor`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check`

## Code review
- Standards review: no blockers.
- Spec review: no blockers after fixing JSON-encoded tool-output media extraction and residual long-string omission.