### PR TITLE
Implement RM-15 Responses bridge non-stream conversion

### DIFF
--- a/src/protocols/responses/bridge_nonstream.ts
+++ b/src/protocols/responses/bridge_nonstream.ts
@@ -1,0 +1,462 @@
+import {
+  isWireJsonArray,
+  isWireJsonNumber,
+  isWireJsonObject,
+  memberValues,
+  parseWireJson,
+  serializeWireJson,
+  type WireJson,
+  type WireJsonArray,
+  type WireJsonObject,
+} from "../../serialization/wire_json.js";
+import type { ResponsesHistoryRecord } from "./history.js";
+import type { RequestToolContext, ToolBinding } from "./tool_context.js";
+import type { ResponsesRequest } from "./dto.js";
+
+export interface ResponsesBridgeResponseContext {
+  readonly originalRequest: ResponsesRequest;
+  readonly toolContext: RequestToolContext;
+  readonly customLlmProvider?: string;
+  readonly modelId?: string;
+  readonly createUuid: () => string;
+}
+
+export interface ResponsesBridgeNonstreamResult {
+  readonly response: WireJsonObject;
+  readonly historyRecord: ResponsesHistoryRecord;
+}
+
+export function convertChatResponseToResponses(
+  chat: WireJsonObject,
+  context: Readonly<ResponsesBridgeResponseContext>,
+): ResponsesBridgeNonstreamResult {
+  const choices = arrayMember(chat, "choices")?.items ?? [];
+  const firstChoice = choices.find(isWireJsonObject);
+  const status = responseStatus(firstChoice);
+  const output = responseOutput(choices, context);
+  const rawResponseId = stringMember(chat, "id") ?? "";
+  const responseId = managedResponseId(rawResponseId, context.customLlmProvider, context.modelId);
+  const response = object([
+    ["id", responseId],
+    ["object", "response"],
+    ["created_at", memberValues(chat, "created")[0] ?? number(0)],
+    ["status", status],
+    ["error", memberValues(chat, "error")[0] ?? null],
+    ["incomplete_details", memberValues(chat, "incomplete_details")[0] ?? null],
+    ["instructions", memberValues(chat, "instructions")[0] ?? null],
+    ["metadata", memberValues(chat, "metadata")[0] ?? object([])],
+    ["model", memberValues(chat, "model")[0] ?? ""],
+    ["output", array(output)],
+    ["parallel_tool_calls", memberValues(chat, "parallel_tool_calls")[0] ?? false],
+    ["temperature", memberValues(chat, "temperature")[0] ?? number(0)],
+    ["tool_choice", memberValues(chat, "tool_choice")[0] ?? "auto"],
+    ["tools", memberValues(chat, "tools")[0] ?? array([])],
+    ["top_p", memberValues(chat, "top_p")[0] ?? null],
+    ["max_output_tokens", memberValues(chat, "max_output_tokens")[0] ?? null],
+    ["previous_response_id", memberValues(chat, "previous_response_id")[0] ?? null],
+    ["reasoning", null],
+    ["text", object([])],
+    ["truncation", memberValues(chat, "truncation")[0] ?? null],
+    ["user", memberValues(chat, "user")[0] ?? null],
+    ["usage", usage(memberValues(chat, "usage")[0])],
+    ...providerFields(chat),
+  ]);
+  return {
+    response,
+    historyRecord: { responseId, output },
+  };
+}
+
+export function managedResponseId(
+  id: string,
+  customLlmProvider: string | undefined,
+  modelId: string | undefined,
+): string {
+  if (id.length === 0 || isManagedResponseId(id)) {
+    return id;
+  }
+  const provider = customLlmProvider ?? "None";
+  const model = modelId ?? "None";
+  const encoded = Buffer.from(`litellm:custom_llm_provider:${provider};model_id:${model};response_id:${id}`, "utf8").toString("base64");
+  return `resp_${encoded}`;
+}
+
+function responseOutput(
+  choices: readonly WireJson[],
+  context: Readonly<ResponsesBridgeResponseContext>,
+): WireJsonObject[] {
+  const output: WireJsonObject[] = [];
+  const reasoning = reasoningItem(choices, context);
+  if (reasoning !== undefined) {
+    output.push(reasoning);
+  }
+  for (const choice of choices) {
+    if (!isWireJsonObject(choice)) {
+      continue;
+    }
+    output.push(...messageOrImages(choice, context));
+  }
+  for (const choice of choices) {
+    if (!isWireJsonObject(choice)) {
+      continue;
+    }
+    output.push(...toolCalls(choice, context));
+  }
+  return output;
+}
+
+function reasoningItem(
+  choices: readonly WireJson[],
+  context: Readonly<ResponsesBridgeResponseContext>,
+): WireJsonObject | undefined {
+  for (const choice of choices) {
+    if (!isWireJsonObject(choice)) {
+      continue;
+    }
+    const message = objectMember(choice, "message");
+    if (message === undefined) {
+      continue;
+    }
+    const text = stringMember(message, "reasoning_content");
+    const encrypted = encryptedThinkingContent(message);
+    if ((text === undefined || text.length === 0) && encrypted === undefined) {
+      continue;
+    }
+    return object([
+      ["type", "reasoning"],
+      ["id", `rs_${context.createUuid()}`],
+      ["status", itemStatus(choice)],
+      ["content", text === undefined || text.length === 0 ? array([]) : array([object([["type", "reasoning_text"], ["text", text]])])],
+      ["summary", array([])],
+      ...(encrypted === undefined ? [] : [["encrypted_content", encrypted] as const]),
+    ]);
+  }
+  return undefined;
+}
+
+function encryptedThinkingContent(message: WireJsonObject): string | undefined {
+  const blocks = arrayMember(message, "thinking_blocks");
+  if (blocks === undefined) {
+    return undefined;
+  }
+  const keep = blocks.items.filter((item) => {
+    if (!isWireJsonObject(item)) {
+      return false;
+    }
+    return memberValues(item, "signature")[0] !== undefined || memberValues(item, "data")[0] !== undefined;
+  });
+  return keep.length === 0 ? undefined : new TextDecoder().decode(serializeWireJson(array(keep)));
+}
+
+function messageOrImages(
+  choice: WireJsonObject,
+  context: Readonly<ResponsesBridgeResponseContext>,
+): WireJsonObject[] {
+  const message = objectMember(choice, "message");
+  if (message === undefined) {
+    return [];
+  }
+  const images = arrayMember(message, "images");
+  if (images !== undefined) {
+    return images.items.map((image) => imageCall(image, choice, context)).filter((item): item is WireJsonObject => item !== undefined);
+  }
+  return [object([
+    ["type", "message"],
+    ["id", `msg_${context.createUuid()}`],
+    ["status", itemStatus(choice)],
+    ["role", stringMember(message, "role") ?? "assistant"],
+    ["content", array([object([
+      ["type", "output_text"],
+      ["text", messageText(message)],
+      ["annotations", array(annotations(message))],
+    ])])],
+  ])];
+}
+
+function imageCall(
+  image: WireJson,
+  choice: WireJsonObject,
+  context: Readonly<ResponsesBridgeResponseContext>,
+): WireJsonObject | undefined {
+  if (typeof image !== "string" || image.length === 0) {
+    return undefined;
+  }
+  const comma = image.startsWith("data:") ? image.indexOf(",") : -1;
+  if (image.startsWith("data:") && comma === -1) {
+    return undefined;
+  }
+  return object([
+    ["type", "image_generation_call"],
+    ["id", `ig_${context.createUuid()}`],
+    ["status", imageStatus(choice)],
+    ["result", comma === -1 ? image : image.slice(comma + 1)],
+  ]);
+}
+
+function toolCalls(
+  choice: WireJsonObject,
+  context: Readonly<ResponsesBridgeResponseContext>,
+): WireJsonObject[] {
+  const calls = arrayMember(objectMember(choice, "message"), "tool_calls");
+  if (calls === undefined) {
+    return [];
+  }
+  return calls.items.map((call) => toolCall(call, context)).filter((call): call is WireJsonObject => call !== undefined);
+}
+
+function toolCall(value: WireJson, context: Readonly<ResponsesBridgeResponseContext>): WireJsonObject | undefined {
+  if (!isWireJsonObject(value)) {
+    return undefined;
+  }
+  const fn = objectMember(value, "function");
+  if (fn === undefined) {
+    return undefined;
+  }
+  const chatName = stringMember(fn, "name") ?? "";
+  const id = stringMember(value, "id") ?? "";
+  const args = stringMember(fn, "arguments") ?? "";
+  const binding = context.toolContext.chatNameToBinding.get(chatName);
+  const status = stringMember(fn, "status") ?? "completed";
+  if (binding?.kind === "custom") {
+    return object([
+      ["type", "custom_tool_call"],
+      ["id", id],
+      ["call_id", id],
+      ["name", binding.originalName],
+      ["status", status],
+      ["input", customInput(args)],
+    ]);
+  }
+  if (binding?.kind === "tool_search") {
+    return object([
+      ["type", "tool_search_call"],
+      ["call_id", id],
+      ["status", status],
+      ["execution", "client"],
+      ["arguments", toolSearchArguments(args)],
+    ]);
+  }
+  const normal = object([
+    ["type", "function_call"],
+    ["id", id],
+    ["call_id", id],
+    ["name", binding?.kind === "namespace" ? binding.originalName : chatName],
+    ...(binding?.kind === "namespace" && binding.namespace !== undefined ? [["namespace", binding.namespace] as const] : []),
+    ["arguments", args],
+    ["status", status],
+    ...providerSpecificFields(value, fn, binding),
+  ]);
+  return normal;
+}
+
+function customInput(argumentsText: string): string {
+  if (argumentsText.trim().length === 0) {
+    return "";
+  }
+  const parsed = parseJsonString(argumentsText);
+  if (isWireJsonObject(parsed)) {
+    const input = memberValues(parsed, "input")[0];
+    if (typeof input === "string") {
+      return input;
+    }
+  }
+  return argumentsText;
+}
+
+function toolSearchArguments(argumentsText: string): WireJsonObject {
+  if (argumentsText.trim().length === 0) {
+    return object([]);
+  }
+  const parsed = parseJsonString(argumentsText);
+  if (isWireJsonObject(parsed)) {
+    return parsed;
+  }
+  return object([["query", argumentsText]]);
+}
+
+function usage(value: WireJson | undefined): WireJsonObject {
+  const input = isWireJsonObject(value) ? value : object([]);
+  const prompt = memberValues(input, "prompt_tokens")[0] ?? number(0);
+  const completion = memberValues(input, "completion_tokens")[0] ?? number(0);
+  const total = memberValues(input, "total_tokens")[0] ?? number(0);
+  const members: Array<readonly [string, WireJson]> = [
+    ["input_tokens", prompt],
+    ["output_tokens", completion],
+    ["total_tokens", total],
+  ];
+  const promptDetails = objectMember(input, "prompt_tokens_details");
+  if (promptDetails !== undefined) {
+    const cacheWriteTokens = memberValues(promptDetails, "cache_write_tokens")[0];
+    members.push(["input_tokens_details", object([
+      ["cached_tokens", memberValues(promptDetails, "cached_tokens")[0] ?? number(0)],
+      ...optionalMember(promptDetails, "text_tokens"),
+      ...optionalMember(promptDetails, "audio_tokens"),
+      ["cache_creation_tokens", isTruthyWireJson(cacheWriteTokens) ? cacheWriteTokens : memberValues(promptDetails, "cache_creation_tokens")[0] ?? number(0)],
+    ])]);
+  }
+  const completionDetails = objectMember(input, "completion_tokens_details");
+  if (completionDetails !== undefined) {
+    members.push(["output_tokens_details", object([
+      ["reasoning_tokens", memberValues(completionDetails, "reasoning_tokens")[0] ?? number(0)],
+      ...optionalMember(completionDetails, "audio_tokens"),
+      ...optionalMember(completionDetails, "text_tokens"),
+      ...optionalMember(completionDetails, "image_tokens"),
+    ])]);
+  }
+  const cost = memberValues(input, "cost")[0];
+  if (cost !== undefined) {
+    members.push(["cost", cost]);
+  }
+  return object(members);
+}
+
+function providerFields(chat: WireJsonObject): Array<readonly [string, WireJson]> {
+  const hidden = objectMember(chat, "_hidden_params");
+  if (hidden === undefined) {
+    return [];
+  }
+  const fields: Array<readonly [string, WireJson]> = [["_hidden_params", hidden]];
+  const provider = objectMember(hidden, "provider_specific_fields");
+  if (provider !== undefined) {
+    for (const member of provider.members) {
+      fields.push([member.key, member.value]);
+    }
+  }
+  return fields;
+}
+
+function providerSpecificFields(
+  outer: WireJsonObject,
+  fn: WireJsonObject,
+  binding: ToolBinding | undefined,
+): Array<readonly [string, WireJson]> {
+  if (binding?.kind === "custom") {
+    return [];
+  }
+  const source = truthyObject(outer) ?? truthyObject(fn);
+  if (source === undefined) {
+    return [];
+  }
+  const provider = objectMember(source, "provider_specific_fields");
+  return provider === undefined ? [] : [["provider_specific_fields", provider]];
+}
+
+function truthyObject(value: WireJsonObject): WireJsonObject | undefined {
+  return value.members.length === 0 ? undefined : value;
+}
+
+function responseStatus(choice: WireJsonObject | undefined): string {
+  const finish = choice === undefined ? undefined : memberValues(choice, "finish_reason")[0];
+  return finish === "length" || finish === "content_filter" || finish === "refusal" ? "incomplete" : "completed";
+}
+
+function itemStatus(choice: WireJsonObject): string {
+  return responseStatus(choice);
+}
+
+function imageStatus(choice: WireJsonObject): string {
+  const finish = memberValues(choice, "finish_reason")[0];
+  if (finish === "length") {
+    return "incomplete";
+  }
+  if (finish === "content_filter" || finish === "error") {
+    return "failed";
+  }
+  return "completed";
+}
+
+function messageText(message: WireJsonObject): string {
+  const content = memberValues(message, "content")[0];
+  return typeof content === "string" ? content : "";
+}
+
+function annotations(message: WireJsonObject): WireJsonObject[] {
+  const values = arrayMember(message, "annotations");
+  if (values === undefined) {
+    return [];
+  }
+  return values.items.filter(isWireJsonObject).filter((item) => memberValues(item, "type")[0] === "url_citation").map((item) => {
+    const members: Array<readonly [string, WireJson]> = [["type", "url_citation"]];
+    for (const key of ["start_index", "end_index", "url", "title"]) {
+      const value = memberValues(item, key)[0];
+      if (value !== undefined) {
+        members.push([key, value]);
+      }
+    }
+    return object(members);
+  });
+}
+
+function parseJsonString(value: string): WireJson | undefined {
+  try {
+    const bytes = new TextEncoder().encode(value);
+    return parseWireJson(bytes, { maxBytes: Math.max(bytes.byteLength, 1), maxDepth: 64 });
+  } catch (_error: unknown) {
+    return undefined;
+  }
+}
+
+function isManagedResponseId(id: string): boolean {
+  if (!id.startsWith("resp_")) {
+    return false;
+  }
+  try {
+    return Buffer.from(id.slice("resp_".length), "base64").toString("utf8").startsWith("litellm:custom_llm_provider:");
+  } catch (_error: unknown) {
+    return false;
+  }
+}
+
+function optionalMember(objectValue: WireJsonObject, key: string): Array<readonly [string, WireJson]> {
+  const value = memberValues(objectValue, key)[0];
+  return value === undefined ? [] : [[key, value]];
+}
+
+function objectMember(value: WireJson | undefined, key: string): WireJsonObject | undefined {
+  if (!isWireJsonObject(value)) {
+    return undefined;
+  }
+  const member = memberValues(value, key)[0];
+  return isWireJsonObject(member) ? member : undefined;
+}
+
+function arrayMember(value: WireJson | undefined, key: string): WireJsonArray | undefined {
+  if (!isWireJsonObject(value)) {
+    return undefined;
+  }
+  const member = memberValues(value, key)[0];
+  return isWireJsonArray(member) ? member : undefined;
+}
+
+function stringMember(objectValue: WireJsonObject, key: string): string | undefined {
+  const value = memberValues(objectValue, key)[0];
+  return typeof value === "string" ? value : undefined;
+}
+
+function object(members: readonly (readonly [string, WireJson])[]): WireJsonObject {
+  return { kind: "object", members: members.map(([key, value]) => ({ key, value })) };
+}
+
+function array(items: readonly WireJson[]): WireJsonArray {
+  return { kind: "array", items };
+}
+
+function number(lexeme: number): WireJson {
+  return { kind: "number", lexeme: String(lexeme) };
+}
+
+function isTruthyWireJson(value: WireJson | undefined): value is WireJson {
+  if (value === undefined || value === null || value === false) {
+    return false;
+  }
+  if (isWireJsonNumber(value)) {
+    return Number(value.lexeme) !== 0;
+  }
+  if (isWireJsonArray(value)) {
+    return value.items.length > 0;
+  }
+  if (isWireJsonObject(value)) {
+    return value.members.length > 0;
+  }
+  return typeof value === "string" ? value.length > 0 : true;
+}

--- a/tests/refactor/contract/responses_bridge_nonstream.test.ts
+++ b/tests/refactor/contract/responses_bridge_nonstream.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import { convertChatResponseToResponses, managedResponseId } from "../../../src/protocols/responses/bridge_nonstream.js";
+import { decodeResponsesRequest } from "../../../src/protocols/responses/decoder.js";
+import { buildRequestToolContext } from "../../../src/protocols/responses/tool_context.js";
+import { isWireJsonArray, isWireJsonObject, parseWireJson, serializeWireJson, type WireJsonObject } from "../../../src/serialization/wire_json.js";
+
+const LIMITS = { maxBytes: 65_536, maxDepth: 64 } as const;
+
+describe("RM-15 Responses bridge non-stream conversion", () => {
+  it("builds envelope defaults, ordered output, managed ID, usage, provider fields, and history record", () => {
+    const request = requestFromJson(JSON.stringify({
+      model: "gpt",
+      tools: [
+        { type: "function", name: "lookup", parameters: {} },
+        { type: "namespace", name: "ns", tools: [{ type: "function", name: "child", parameters: {} }] },
+        { type: "custom", name: "render" },
+        { type: "tool_search" },
+      ],
+    }));
+    let uuid = 0;
+    const result = convertChatResponseToResponses(wireObject(JSON.stringify({
+      id: "chatcmpl_1",
+      created: 1700000000,
+      model: "gpt",
+      choices: [
+        {
+          finish_reason: "tool_calls",
+          message: {
+            role: "assistant",
+            reasoning_content: "plan",
+            thinking_blocks: [{ type: "thinking", thinking: "hidden", signature: "sig" }],
+            content: "answer",
+            annotations: [
+              { type: "url_citation", start_index: 0, end_index: 4, url: "https://example.test", title: "Example" },
+              { type: "other", drop: true },
+            ],
+            tool_calls: [
+              { id: "call_fn", function: { name: "lookup", arguments: "{\"raw\":true}", status: "in_progress" }, provider_specific_fields: { a: 1 } },
+              { id: "call_ns", function: { name: "ns__child", arguments: "{}" } },
+              { id: "call_custom", function: { name: "render", arguments: "{\"input\":\"card\"}" } },
+              { id: "call_search", function: { name: "tool_search", arguments: "{\"query\":\"docs\"}" } },
+            ],
+          },
+        },
+      ],
+      usage: {
+        prompt_tokens: 5,
+        completion_tokens: 7,
+        total_tokens: 12,
+        cost: 0.5,
+        prompt_tokens_details: { cached_tokens: 1, text_tokens: 4, cache_creation_tokens: 2 },
+        completion_tokens_details: { reasoning_tokens: 3, image_tokens: 1 },
+      },
+      _hidden_params: { provider_specific_fields: { vendor: "x" } },
+    })), {
+      originalRequest: request,
+      toolContext: buildRequestToolContext(request),
+      customLlmProvider: "github_copilot",
+      modelId: "gpt",
+      createUuid: () => `00000000-0000-4000-8000-${(++uuid).toString().padStart(12, "0")}`,
+    });
+
+    expect(json(result.response)).toEqual({
+      id: managedResponseId("chatcmpl_1", "github_copilot", "gpt"),
+      object: "response",
+      created_at: 1700000000,
+      status: "completed",
+      error: null,
+      incomplete_details: null,
+      instructions: null,
+      metadata: {},
+      model: "gpt",
+      output: [
+        {
+          type: "reasoning",
+          id: "rs_00000000-0000-4000-8000-000000000001",
+          status: "completed",
+          content: [{ type: "reasoning_text", text: "plan" }],
+          summary: [],
+          encrypted_content: "[{\"type\":\"thinking\",\"thinking\":\"hidden\",\"signature\":\"sig\"}]",
+        },
+        {
+          type: "message",
+          id: "msg_00000000-0000-4000-8000-000000000002",
+          status: "completed",
+          role: "assistant",
+          content: [{
+            type: "output_text",
+            text: "answer",
+            annotations: [{ type: "url_citation", start_index: 0, end_index: 4, url: "https://example.test", title: "Example" }],
+          }],
+        },
+        { type: "function_call", id: "call_fn", call_id: "call_fn", name: "lookup", arguments: "{\"raw\":true}", status: "in_progress", provider_specific_fields: { a: 1 } },
+        { type: "function_call", id: "call_ns", call_id: "call_ns", name: "child", namespace: "ns", arguments: "{}", status: "completed" },
+        { type: "custom_tool_call", id: "call_custom", call_id: "call_custom", name: "render", status: "completed", input: "card" },
+        { type: "tool_search_call", call_id: "call_search", status: "completed", execution: "client", arguments: { query: "docs" } },
+      ],
+      parallel_tool_calls: false,
+      temperature: 0,
+      tool_choice: "auto",
+      tools: [],
+      top_p: null,
+      max_output_tokens: null,
+      previous_response_id: null,
+      reasoning: null,
+      text: {},
+      truncation: null,
+      user: null,
+      usage: {
+        input_tokens: 5,
+        output_tokens: 7,
+        total_tokens: 12,
+        input_tokens_details: { cached_tokens: 1, text_tokens: 4, cache_creation_tokens: 2 },
+        output_tokens_details: { reasoning_tokens: 3, image_tokens: 1 },
+        cost: 0.5,
+      },
+      _hidden_params: { provider_specific_fields: { vendor: "x" } },
+      vendor: "x",
+    });
+    const outputValue = result.response.members.find((member) => member.key === "output")?.value;
+    expect(isWireJsonArray(outputValue)).toBe(true);
+    expect(result.historyRecord).toEqual({
+      responseId: json(result.response).id,
+      output: isWireJsonArray(outputValue) ? outputValue.items : [],
+    });
+  });
+
+  it("handles empty choices, incomplete status, images, idempotent managed IDs, and malformed custom/search args", () => {
+    const request = requestFromJson(JSON.stringify({ model: "gpt", tools: [{ type: "custom", name: "render" }, { type: "tool_search" }] }));
+    const managed = managedResponseId("chatcmpl_2", undefined, undefined);
+    const empty = convertChatResponseToResponses(wireObject(JSON.stringify({ id: managed, model: "gpt", choices: [] })), {
+      originalRequest: request,
+      toolContext: buildRequestToolContext(request),
+      createUuid: () => "00000000-0000-4000-8000-000000000099",
+    });
+    expect(json(empty.response)).toMatchObject({ id: managed, status: "completed", output: [] });
+
+    let uuid = 0;
+    const result = convertChatResponseToResponses(wireObject(JSON.stringify({
+      id: "chatcmpl_3",
+      model: "gpt",
+      choices: [{
+        finish_reason: "length",
+        message: {
+          images: ["data:image/png;base64,abc", "rawbase64"],
+          tool_calls: [
+            { id: "call_custom", function: { name: "render", arguments: "not-json" } },
+            { id: "call_search", function: { name: "tool_search", arguments: "plain query" } },
+          ],
+        },
+      }],
+    })), {
+      originalRequest: request,
+      toolContext: buildRequestToolContext(request),
+      createUuid: () => `00000000-0000-4000-8000-${(++uuid).toString().padStart(12, "0")}`,
+    });
+    expect(json(result.response)).toMatchObject({
+      status: "incomplete",
+      output: [
+        { type: "image_generation_call", id: "ig_00000000-0000-4000-8000-000000000001", status: "incomplete", result: "abc" },
+        { type: "image_generation_call", id: "ig_00000000-0000-4000-8000-000000000002", status: "incomplete", result: "rawbase64" },
+        { type: "custom_tool_call", input: "not-json" },
+        { type: "tool_search_call", arguments: { query: "plain query" } },
+      ],
+      usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+    });
+  });
+
+  it("falls back from zero cache_write_tokens to cache_creation_tokens", () => {
+    const request = requestFromJson(JSON.stringify({ model: "gpt" }));
+    const result = convertChatResponseToResponses(wireObject(JSON.stringify({
+      id: "chatcmpl_4",
+      model: "gpt",
+      choices: [],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 1,
+        total_tokens: 11,
+        prompt_tokens_details: {
+          cached_tokens: 0,
+          cache_write_tokens: 0,
+          cache_creation_tokens: 4,
+        },
+      },
+    })), {
+      originalRequest: request,
+      toolContext: buildRequestToolContext(request),
+      createUuid: () => "00000000-0000-4000-8000-000000000001",
+    });
+    expect(json(result.response).usage).toEqual({
+      input_tokens: 10,
+      output_tokens: 1,
+      total_tokens: 11,
+      input_tokens_details: {
+        cached_tokens: 0,
+        cache_creation_tokens: 4,
+      },
+    });
+  });
+
+  function requestFromJson(source: string) {
+    return decodeResponsesRequest(wireObject(source));
+  }
+
+  function wireObject(source: string): WireJsonObject {
+    const parsed = parseWireJson(new TextEncoder().encode(source), LIMITS);
+    expect(isWireJsonObject(parsed)).toBe(true);
+    return parsed as WireJsonObject;
+  }
+
+  function json(value: WireJsonObject): Record<string, unknown> {
+    return JSON.parse(new TextDecoder().decode(serializeWireJson(value))) as Record<string, unknown>;
+  }
+});


### PR DESCRIPTION
## Summary
- Adds RM-15 pure Chat response -> Responses non-stream conversion for ChatBridgePlan.
- Implements Responses envelope/defaults, first-choice status, ordered reasoning/message/image/tool output, managed response IDs, usage/provider fields, and minimal history record materialization.
- Restores function/custom/namespace/tool-search calls only through RequestToolContext and preserves documented argument losses.

Closes #23

## Validation
- `npm run typecheck:refactor`
- `npm run test:refactor -- tests/refactor/contract/responses_bridge_nonstream.test.ts tests/refactor/contract/responses_bridge_request.test.ts`
- `npm run lint:refactor`
- `npm run test:refactor`
- `npm run build:refactor`
- `npm run fixtures:verify`
- `git --no-pager diff --check`

## Code review
- Standards review: no blockers.
- Spec review: no blockers after fixing `cache_write_tokens: 0` fallback to `cache_creation_tokens`.