### PR TITLE
Clarify Admin module architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,6 +183,8 @@ flowchart LR
     GitHub[GitHub.com or GHES]
     CAPI[GitHub Copilot CAPI]
     History[Responses history module]
+    Accounts[Accounts module]
+    Telemetry[Telemetry module]
     State[(SQLite state.db)]
     Admin[Admin module]
 
@@ -197,9 +199,12 @@ flowchart LR
     History --> State
     AdminBrowser --> Host
     Host --> Admin
+    Admin --> Accounts
     Admin --> Catalog
     Admin --> History
-    Admin --> State
+    Admin --> Telemetry
+    Accounts --> State
+    Telemetry --> State
 ```
 
 OpenAI Chat、Anthropic、Ollama 以及 Responses 的 bridge plan 调用 Chat Completions upstream；
@@ -225,6 +230,8 @@ flowchart TD
     History[Responses history module]
     Persistence[Persistence module]
     Admin[Admin module]
+    Accounts[Accounts module]
+    Telemetry[Telemetry module]
 
     Main --> Gateway
     Gateway --> Http
@@ -243,7 +250,12 @@ flowchart TD
     Models --> Copilot
     Copilot --> Stream
     History --> Persistence
-    Admin --> Persistence
+    Accounts --> Persistence
+    Telemetry --> Persistence
+    Admin --> Accounts
+    Admin --> Models
+    Admin --> History
+    Admin --> Telemetry
 ```
 
 依赖只能沿箭头方向。Protocol modules 不 import Hono、SQLite、`process.env` 或具体 HTTP client。
@@ -278,6 +290,43 @@ export async function createGateway(
 
 `close()` 幂等。它停止接收新请求、取消在途 upstream、等待有界 grace period，然后关闭 HTTP pool、
 SQLite 和日志资源。
+
+Gateway Foundation 通过 additive optional mount 接入管理面，而不修改协议 `RouteRegistration`：
+
+```ts
+export interface AdminRequestContext {
+  readonly requestId: string;
+  readonly signal: AbortSignal;
+  readonly requestBodyBytes: number;
+  readonly listenerOrigin: string;
+  readonly activity: GatewayActivity;
+}
+
+export interface AdminModule {
+  handle(request: Request, context: Readonly<AdminRequestContext>): Promise<Response>;
+  mintBootstrap(): AdminBootstrapResult;
+  close(): void;
+}
+
+export type AdminBootstrapResult =
+  | { readonly kind: "issued"; readonly token: string; readonly expiresAt: string }
+  | { readonly kind: "capacity" }
+  | { readonly kind: "closed" };
+
+export interface AdminStaticModule {
+  handle(request: Request, signal: AbortSignal): Promise<Response>;
+}
+```
+
+`GatewayDependencies` 可选接受 `admin?: AdminModule` 与 `adminStatic?: AdminStaticModule`。现有 callers 省略
+它们时行为不变；`RouteRegistration.body` 仍只有 `"none" | "wire-json-object"`，已实现 protocol factories
+与 wire behavior 不变。
+
+Host 在 protocol route matching 前把 exact `/admin/api/v1` 与 `/admin/api/v1/*` 交给
+`AdminModule.handle`。RM-21 的 `adminStatic` 只在 Admin API matching 后处理 `GET /admin` 和
+`GET /admin/*`；未匹配的 `/admin/api/v1/*` 永远不能变成 SPA HTML。Host 拥有 Admin request ID、caller/
+shutdown abort、captured body limit 和 active listener Origin；Admin module 拥有管理 JSON parsing、TypeBox
+validation、authentication、error envelope 与 SSE lifecycle。
 
 ### 7.2 Protocol endpoint modules
 
@@ -923,6 +972,42 @@ Semantic Checkpoint 同步等待 transaction commit。Usage Buckets 和 Operatio
 构建产物随 npm package 发布，由 Hono 提供 `/admin/*`。浏览器内存不计入 gateway daemon RSS；
 关闭页面后后台不新增持久状态；Admin Session 仍按 idle/absolute timeout 管理。
 
+### 16.1.1 管理面 module seam
+
+管理面是同一进程中的独立纵向 module，不是 inference protocol，也不是第二个 server。`web/` 只调用
+`/admin/api/v1/*`，不读取 SQLite、secret file 或 daemon identity。
+
+`AdminModule.handle` 后隐藏 Admin Hono sub-app、bounded JSON body read、TypeBox no-coercion validation、Session/
+CSRF/Origin、Admin envelope 和 monitoring SSE。Admin 不 import inference `WireJson`、protocol presenters、
+protocol converters 或 `better-sqlite3`。
+
+管理 use cases 只调用 Accounts、PreferredModelManager、RuntimeConfigStore、ResponsesHistoryAdmin 与
+AdminTelemetry 的窄 interface。Gateway 通过每次 `AdminRequestContext.activity` 提供 GatewayActivity，避免
+Admin/Gateway composition cycle：
+
+```ts
+export interface AdminTelemetry {
+  queryUsage(query: Readonly<AdminUsageQuery>, signal: AbortSignal): Promise<AdminUsagePage>;
+  queryEvents(query: Readonly<AdminEventQuery>, signal: AbortSignal): Promise<AdminEventPage>;
+  replayEvents(afterEventId: string, signal: AbortSignal): Promise<AdminEventReplay>;
+  snapshot(): AdminTelemetrySnapshot;
+  subscribe(listener: (event: Readonly<AdminMonitorEvent>) => void): () => void;
+}
+
+export interface GatewayActivity {
+  snapshot(): Readonly<{
+    activeRequests: number;
+    activeStreams: number;
+    queuedRequests: number;
+  }>;
+}
+```
+
+`AdminTelemetry` 是 telemetry module 内的只读 adapter，复用 RM-05 已实现 schema、retention、sanitizer 与
+performance state，不改变写入、batch 或 cleanup 行为。`GatewayActivity` 是已实现 admission/stream state 的
+只读视图，不获得 mutation capability。`subscribe` 只发布 sanitized Operational Event 与 performance
+transition；browser replay、queue 和 backpressure 仍由 `AdminModule` 拥有。
+
 ### 16.2 功能
 
 - GitHub.com/GHES device login；
@@ -947,6 +1032,23 @@ response body、Authorization、OAuth token、Copilot token 或完整 upstream e
 - Bootstrap exchange 不要求已有 Admin Session/CSRF，但要求精确 Origin 与 valid one-use token；其他所有
   Admin 写请求同时验证 Admin Session、CSRF token 和精确 Origin。
 - Static catch-all 只能位于 `/admin/*`，不能吞掉 `/v1/*`、`/api/*`、`/healthz` 或 `/readyz`。
+
+Admin HTTP closure：
+
+- `listenerOrigin` 由 active listener 提供，精确为 `http://127.0.0.1:<startup-port>`，不能固定为默认 port。
+- JSON mutations 只接受 `application/json` 或显式 UTF-8 charset，以及缺失/单个 `identity`
+  Content-Encoding；empty、malformed、non-object、unknown fields、unsupported media 或 body over-limit 都返回
+  `400 validation_failed`。
+- Body read 使用请求开始时捕获的 `limits.requestBodyBytes`，读到第一个超限 byte 时取消 reader。
+- No-body routes 拒绝 nonempty body；每个 route 拒绝 unknown 或 duplicate query fields。
+- 每个 Admin JSON/SSE response 设置 `Cache-Control: no-store` 与 gateway-generated `x-request-id`；JSON 使用
+  `application/json; charset=utf-8`。入站 request ID 不回显。
+- Client abort 和 Gateway close 取消 body reader、use case、catalog/device-flow operation 或 SSE subscription，
+  且不再追加 bytes。Admin 不进入 inference admission，不使用 protocol presenter。
+- `AdminModule.close()` 清 sessions/bootstrap tokens、subscribers 与 heartbeat。RM-19 control route 和 Admin HTTP
+  必须引用同一个 `AdminModule` instance。`close()` 幂等；closed 后 `handle` fail closed，`mintBootstrap`
+  返回 `kind:"closed"`。第九个 outstanding bootstrap 返回 `kind:"capacity"`；RM-19 把这两种结果映射为
+  control `503 not_ready`，不泄露内部计数。
 
 ## 17. Error ownership
 
@@ -1161,10 +1263,15 @@ src/
     canonical_json.ts
 
   admin/
+    routes.ts
     api.ts
     auth.ts
-    metrics.ts
+    events.ts
+    static.ts
     contracts.ts
+
+  telemetry/
+    admin.ts
 
 web/
   src/
@@ -1188,8 +1295,8 @@ validator 可以保留在同一文件；只有状态机或 serializer 足够复�
 3. 创建 credential store、Copilot backend 和 model catalog；
 4. 创建 Responses history；
 5. 创建四个 protocol endpoints；
-6. 显式注册 public/admin routes；
-7. 加载静态 Web assets；
+6. 显式注册 public protocol routes，并可选 mount `AdminModule`；
+7. RM-21 后可选 mount `AdminStaticModule` assets；
 8. 注册 graceful shutdown。
 
 Protocol modules 接收 dependencies，不自行读取 `process.env`、打开 database 或创建 HTTP client。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -317,17 +317,52 @@ export type AdminBootstrapResult =
 export interface AdminStaticModule {
   handle(request: Request, signal: AbortSignal): Promise<Response>;
 }
+
+export interface LocalControlModule {
+  handle(
+    request: Request,
+    context: Readonly<{
+      requestId: string;
+      signal: AbortSignal;
+      listenerOrigin: LoopbackOrigin;
+    }>,
+  ): Promise<Response>;
+  close(): void;
+}
+
+export interface AdminRuntimeStatus {
+  snapshot(): Readonly<{
+    version: string;
+    uptimeMs: number;
+    daemon: { readonly managed: boolean; readonly pid?: number; readonly startedAt?: string };
+  }>;
+}
 ```
 
-`GatewayDependencies` 可选接受 `admin?: AdminModule` 与 `adminStatic?: AdminStaticModule`。现有 callers 省略
-它们时行为不变；`RouteRegistration.body` 仍只有 `"none" | "wire-json-object"`，已实现 protocol factories
+`GatewayDependencies` 可选接受 `admin?: AdminModule`、`control?: LocalControlModule` 与
+`adminStatic?: AdminStaticModule`。现有 callers 省略它们时行为不变；`RouteRegistration.body` 仍只有
+`"none" | "wire-json-object"`，已实现 protocol factories
 与 wire behavior 不变。
 
-Host 在 protocol route matching 前把 exact `/admin/api/v1` 与 `/admin/api/v1/*` 交给
+Host 在 protocol route matching 前把 exact `/__ghcg/control/v1/*` 交给 RM-19 `LocalControlModule`，并把
+exact `/admin/api/v1` 与 `/admin/api/v1/*` 交给
 `AdminModule.handle`。RM-21 的 `adminStatic` 只在 Admin API matching 后处理 `GET /admin/*`；未匹配的
 `/admin/api/v1/*` 永远不能变成 SPA HTML。Host 拥有 Admin request ID、caller/shutdown abort 和 active
 listener Origin；Admin module 从 `RuntimeConfigStore` 捕获当前 body limit，并拥有管理 JSON parsing、TypeBox
 validation、authentication、error envelope 与 SSE lifecycle。
+
+`LocalControlModule` 独占 control authentication、identity handshake、command JSON validation 与 control error
+envelope。它不使用 protocol `RouteRegistration`、inference admission 或 Admin browser authentication。RM-19
+把同一个 `AdminModule` instance 注入 LocalControlModule，`admin-bootstrap` 只调用其 `mintBootstrap()`。
+Control request body 使用固定 1 MiB hard cap；status/stop/bootstrap 拒绝 nonempty body，command body 读到第一个
+超限 byte 时取消 reader 并返回 control `400 invalid_command`。Client abort 取消 body/use case 且不追加 bytes。
+
+`createAdminModule` 接收 `AdminRuntimeStatus`。RM-19 production adapter 组合 build version、process uptime 与
+verified daemon identity；RM-20 tests 使用 scripted adapter。Admin 不读取 process globals 或 daemon file。
+
+Gateway close 顺序固定为：停止 mounted admission → abort mounted in-flight requests →
+`LocalControlModule.close()` → `AdminModule.close()` → existing `onClose` persistence/transport cleanup。两个
+`close()` 都幂等；control 先关闭，保证它不能在 Admin teardown 后继续 mint bootstrap 或 dispatch command。
 
 ### 7.2 Protocol endpoint modules
 
@@ -982,9 +1017,9 @@ Semantic Checkpoint 同步等待 transaction commit。Usage Buckets 和 Operatio
 CSRF/Origin、Admin envelope 和 monitoring SSE。Admin 不 import inference `WireJson`、protocol presenters、
 protocol converters 或 `better-sqlite3`。
 
-管理 use cases 只调用 Accounts、PreferredModelManager、RuntimeConfigStore、ResponsesHistoryAdmin 与
-AdminTelemetry 的窄 interface。Gateway 通过每次 `AdminRequestContext.activity` 提供 GatewayActivity，避免
-Admin/Gateway composition cycle：
+管理 use cases 只调用 Accounts、PreferredModelManager、RuntimeConfigStore、ResponsesHistoryAdmin、
+AdminTelemetry 与 AdminRuntimeStatus 的窄 interface。Gateway 通过每次 `AdminRequestContext.activity` 提供
+GatewayActivity，避免 Admin/Gateway composition cycle：
 
 ```ts
 export interface AdminTelemetry {
@@ -1000,6 +1035,14 @@ export interface GatewayActivity {
     activeRequests: number;
     activeStreams: number;
     queuedRequests: number;
+  }>;
+}
+
+export interface AdminRuntimeStatus {
+  snapshot(): Readonly<{
+    version: string;
+    uptimeMs: number;
+    daemon: { readonly managed: boolean; readonly pid?: number; readonly startedAt?: string };
   }>;
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -297,10 +297,11 @@ Gateway Foundation 通过 additive optional mount 接入管理面，而不修改
 export interface AdminRequestContext {
   readonly requestId: string;
   readonly signal: AbortSignal;
-  readonly requestBodyBytes: number;
-  readonly listenerOrigin: string;
+  readonly listenerOrigin: LoopbackOrigin;
   readonly activity: GatewayActivity;
 }
+
+export type LoopbackOrigin = `http://127.0.0.1:${number}`;
 
 export interface AdminModule {
   handle(request: Request, context: Readonly<AdminRequestContext>): Promise<Response>;
@@ -323,9 +324,9 @@ export interface AdminStaticModule {
 与 wire behavior 不变。
 
 Host 在 protocol route matching 前把 exact `/admin/api/v1` 与 `/admin/api/v1/*` 交给
-`AdminModule.handle`。RM-21 的 `adminStatic` 只在 Admin API matching 后处理 `GET /admin` 和
-`GET /admin/*`；未匹配的 `/admin/api/v1/*` 永远不能变成 SPA HTML。Host 拥有 Admin request ID、caller/
-shutdown abort、captured body limit 和 active listener Origin；Admin module 拥有管理 JSON parsing、TypeBox
+`AdminModule.handle`。RM-21 的 `adminStatic` 只在 Admin API matching 后处理 `GET /admin/*`；未匹配的
+`/admin/api/v1/*` 永远不能变成 SPA HTML。Host 拥有 Admin request ID、caller/shutdown abort 和 active
+listener Origin；Admin module 从 `RuntimeConfigStore` 捕获当前 body limit，并拥有管理 JSON parsing、TypeBox
 validation、authentication、error envelope 与 SSE lifecycle。
 
 ### 7.2 Protocol endpoint modules
@@ -1004,9 +1005,15 @@ export interface GatewayActivity {
 ```
 
 `AdminTelemetry` 是 telemetry module 内的只读 adapter，复用 RM-05 已实现 schema、retention、sanitizer 与
-performance state，不改变写入、batch 或 cleanup 行为。`GatewayActivity` 是已实现 admission/stream state 的
-只读视图，不获得 mutation capability。`subscribe` 只发布 sanitized Operational Event 与 performance
-transition；browser replay、queue 和 backpressure 仍由 `AdminModule` 拥有。
+performance state，不改变写入、batch 或 cleanup 行为。RM-20 给 `TelemetryRecorder` 与
+`PerformanceWindows` 增加可选 in-process observer；无 observer 时 write/evaluate 路径与结果不变。
+`subscribe` 只发布 sanitized Operational Event 与 performance transition；browser replay、queue 和
+backpressure 仍由 `AdminModule` 拥有。
+
+`GatewayActivity` 是 RM-20 在 Gateway 内增加的只读 instrumentation。它从既有 admission counts 读取 active/
+queued request，并只在 response lifecycle 上增加 active-stream counter；无 Admin mount 时不创建 observer、
+不增加 timer/queue，也不改变 response bytes、admission、abort 或 cleanup。Admin 只获得 snapshot，不获得
+mutation capability。
 
 ### 16.2 功能
 
@@ -1035,11 +1042,13 @@ response body、Authorization、OAuth token、Copilot token 或完整 upstream e
 
 Admin HTTP closure：
 
-- `listenerOrigin` 由 active listener 提供，精确为 `http://127.0.0.1:<startup-port>`，不能固定为默认 port。
+- `listenerOrigin` 由 active listener 在 validated startup port 上构造为 `LoopbackOrigin`，精确为
+  `http://127.0.0.1:<startup-port>`，不能固定为默认 port 或接受调用方任意 string。
 - JSON mutations 只接受 `application/json` 或显式 UTF-8 charset，以及缺失/单个 `identity`
   Content-Encoding；empty、malformed、non-object、unknown fields、unsupported media 或 body over-limit 都返回
   `400 validation_failed`。
-- Body read 使用请求开始时捕获的 `limits.requestBodyBytes`，读到第一个超限 byte 时取消 reader。
+- Admin module 在 request handling 开始时从 `RuntimeConfigStore.readSnapshot()` 捕获
+  `limits.requestBodyBytes`，读到第一个超限 byte 时取消 reader；后续 config CAS 只影响后续请求。
 - No-body routes 拒绝 nonempty body；每个 route 拒绝 unknown 或 duplicate query fields。
 - 每个 Admin JSON/SSE response 设置 `Cache-Control: no-store` 与 gateway-generated `x-request-id`；JSON 使用
   `application/json; charset=utf-8`。入站 request ID 不回显。

--- a/docs/specs/refactor_master_spec.md
+++ b/docs/specs/refactor_master_spec.md
@@ -383,10 +383,11 @@ use an additive optional Gateway mount:
 export interface AdminRequestContext {
   readonly requestId: string;
   readonly signal: AbortSignal;
-  readonly requestBodyBytes: number;
-  readonly listenerOrigin: string;
+  readonly listenerOrigin: LoopbackOrigin;
   readonly activity: GatewayActivity;
 }
+
+export type LoopbackOrigin = `http://127.0.0.1:${number}`;
 
 export interface AdminModule {
   handle(request: Request, context: Readonly<AdminRequestContext>): Promise<Response>;
@@ -406,8 +407,9 @@ export interface AdminStaticModule {
 
 `GatewayDependencies` adds optional `admin?: AdminModule` and `adminStatic?: AdminStaticModule`. Existing RM-01 through
 RM-18 callers that omit them preserve identical behavior. Gateway owns Admin request-ID creation, caller/shutdown abort,
-captured body limit and active listener Origin；`AdminModule` owns Admin parsing、validation、security、envelope and SSE
-lifecycle。Gateway also supplies `AdminRequestContext.activity` per request, avoiding an Admin/Gateway composition
+active listener Origin and activity snapshot；`AdminModule` captures the current body limit from `RuntimeConfigStore`
+and owns Admin parsing、validation、security、envelope and SSE lifecycle。Gateway supplies
+`AdminRequestContext.activity` per request, avoiding an Admin/Gateway composition
 cycle。Exact Admin API paths are matched before RM-21 static handling；unmatched `/admin/api/v1/*` never becomes
 SPA HTML。
 
@@ -556,11 +558,10 @@ export interface WireJsonObject {
 | Responses History | `ResponsesHistory` | SQLite | only `ChatBridgePlan` |
 | Usage Buckets | `UsageRecorder` | SQLite batched | content-free、bounded |
 | Operational Events | `OperationalEventStore` | SQLite batched | sanitized、bounded |
-| admin bootstrap/session/CSRF | `AdminAuth` | process memory | restart invalidates all |
+| admin bootstrap/session/CSRF | `AdminModule` via internal `AdminAuth` implementation | process memory | restart invalidates all |
 | daemon PID/start identity/nonce/control token | `DaemonIdentityFile` | protected atomic file | authenticated control before action |
 | credentials/admin long-term secret | `FileCredentialStore` | protected atomic file | never SQLite/log |
 | JSONL files/rotation | `JsonlLogger` | data directory | 10 MiB × 5、max age 7d |
-| Admin sessions/bootstrap/CSRF | `AdminModule` | process / bounded memory | RM-19 control and Admin HTTP share one instance |
 | Admin usage/event queries | `AdminTelemetry` | telemetry module / SQLite read adapter | read-only; reuses RM-05 retention/sanitizer |
 | Admin request/activity counters | `GatewayActivity` | process / read-only snapshot | no admission or stream mutation capability |
 
@@ -1011,10 +1012,12 @@ with spaces。HTTP 204 responses have no body。
 
 Admin HTTP behavior is owned by `AdminModule`, not by protocol `RouteRegistration` or Gateway HTTP protocol parsing：
 
-- exact Origin is `http://127.0.0.1:<active-port>` supplied by Gateway；
+- exact Origin is a Gateway-constructed `LoopbackOrigin` for `http://127.0.0.1:<active-port>`；Admin never accepts an
+  arbitrary caller-provided origin string；
 - JSON mutations accept only `application/json` with optional UTF-8 charset and missing/single `identity` encoding；
 - empty、malformed、non-object、unknown-field、unsupported-media and over-limit bodies return `400 validation_failed`；
-- reads use captured `limits.requestBodyBytes` and cancel at the first excess byte；
+- `AdminModule` captures `RuntimeConfigStore.readSnapshot().limits.requestBodyBytes` at request handling start and
+  cancels at the first excess byte；later config CAS affects only later requests；
 - no-body routes reject nonempty bodies and all routes reject unknown/duplicate query fields；
 - every Admin JSON/SSE response uses `Cache-Control: no-store` and gateway-generated `x-request-id`；JSON uses
   `application/json; charset=utf-8`；
@@ -1031,6 +1034,12 @@ transitions。`AdminModule` owns browser subscriber caps、per-subscriber queues
 slow-consumer disconnect。`AdminModule.close()` is idempotent；closed `handle` fails closed and closed
 `mintBootstrap()` returns `kind:"closed"`。The ninth outstanding bootstrap returns `kind:"capacity"`。RM-19 maps both
 capacity and closed to control `503 not_ready` without exposing internal counts。
+
+RM-20 adds optional in-process observers to `TelemetryRecorder` and `PerformanceWindows` to implement that subscription；
+with no observer registered, RM-05 write/evaluate results、batching、retention、cleanup and resource bounds are unchanged。
+RM-20 also adds `GatewayActivity` instrumentation: existing admission counts are read-only, and one bounded active-stream
+counter follows the existing response lifecycle cleanup。Without an Admin mount it creates no observer/timer/queue and
+does not alter protocol bytes、admission、abort or terminal behavior。
 
 Canonical Admin route matrix：
 
@@ -2282,7 +2291,8 @@ route。Examples fixed by `RM-09` and required for later slices：
   `docs/gateway_http_contracts.md` Admin isolation rules。
 - **Owned scope/files**：`src/admin/auth.ts`、`api.ts`、`events.ts`、`routes.ts`、
   additive Admin mount wiring in `src/gateway/hono_app.ts` and `src/gateway/create_gateway.ts`、
-  read-only `src/telemetry/admin.ts`、serialized `src/main.ts` composition、
+  read-only `src/telemetry/admin.ts`、optional observer hooks in `src/telemetry/recorder.ts` and
+  `src/telemetry/performance.ts`、serialized `src/main.ts` composition、
   `tests/refactor/contract/admin_auth.test.ts`、
   `tests/refactor/contract/admin_api.test.ts`、
   `tests/refactor/integration/admin_events.test.ts`。
@@ -2318,7 +2328,7 @@ route。Examples fixed by `RM-09` and required for later slices：
 - **Deliverables/interface**：`Overview`、`Accounts`、`Models`、`Configuration`、`ResponsesHistory`、`Events`；
   fragment bootstrap exchange、CSRF client、SSE reconnect with bounded UI state；no SvelteKit server。
 - **Static seam**：`src/admin/static.ts` implements `AdminStaticModule` and mounts after exact Admin API handling。Only
-  `GET /admin` and `GET /admin/*` may return assets/SPA fallback；`/admin/api/v1/*`、protocol routes and probes never do。
+  `GET /admin/*` may return assets/SPA fallback；`/admin/api/v1/*`、protocol routes and probes never do。
 - **Tests**：`npm run test:e2e:refactor -- tests/refactor/e2e/admin.spec.ts`，exact 7 flows：
   `bootstrap-and-session-expiry`、`github-and-ghes-account-lifecycle`、
   `model-refresh-invalidates-preference`、`config-revision-and-security-rejection`、

--- a/docs/specs/refactor_master_spec.md
+++ b/docs/specs/refactor_master_spec.md
@@ -403,11 +403,32 @@ export type AdminBootstrapResult =
 export interface AdminStaticModule {
   handle(request: Request, signal: AbortSignal): Promise<Response>;
 }
+
+export interface LocalControlModule {
+  handle(
+    request: Request,
+    context: Readonly<{
+      requestId: string;
+      signal: AbortSignal;
+      listenerOrigin: LoopbackOrigin;
+    }>,
+  ): Promise<Response>;
+  close(): void;
+}
+
+export interface AdminRuntimeStatus {
+  snapshot(): Readonly<{
+    version: string;
+    uptimeMs: number;
+    daemon: { readonly managed: boolean; readonly pid?: number; readonly startedAt?: string };
+  }>;
+}
 ```
 
-`GatewayDependencies` adds optional `admin?: AdminModule` and `adminStatic?: AdminStaticModule`. Existing RM-01 through
-RM-18 callers that omit them preserve identical behavior. Gateway owns Admin request-ID creation, caller/shutdown abort,
-active listener Origin and activity snapshot；`AdminModule` captures the current body limit from `RuntimeConfigStore`
+`GatewayDependencies` adds optional `admin?: AdminModule`、`control?: LocalControlModule` and
+`adminStatic?: AdminStaticModule`. Existing RM-01 through RM-18 callers that omit them preserve identical behavior。
+Gateway owns mounted request-ID creation、caller/shutdown abort、active listener Origin and activity snapshot；
+`AdminModule` captures the current body limit from `RuntimeConfigStore`
 and owns Admin parsing、validation、security、envelope and SSE lifecycle。Gateway supplies
 `AdminRequestContext.activity` per request, avoiding an Admin/Gateway composition
 cycle。Exact Admin API paths are matched before RM-21 static handling；unmatched `/admin/api/v1/*` never becomes
@@ -416,6 +437,23 @@ SPA HTML。
 This correction does not reopen observable behavior from RM-01 through RM-18：protocol `RouteRegistration`、Gateway
 public routes、admission、WireJson、timeouts and protocol presenters remain unchanged。Only RM-19、RM-20、RM-21 and
 their transitive RM-22 composition consume these optional interfaces。
+
+Exact `/__ghcg/control/v1/*` requests are matched before protocol routes and delegated to RM-19
+`LocalControlModule`。That module owns control-token/nonce/identity validation、command body validation、control envelope
+and `AdminModule.mintBootstrap()` invocation。It does not use protocol `RouteRegistration`、inference admission or
+Admin browser authentication。
+
+Control HTTP uses a fixed 1 MiB hard body cap。Status/stop/admin-bootstrap reject a nonempty body；command body read
+cancels at the first excess byte and returns control `400 invalid_command`。Caller abort cancels body/use-case work and
+emits no additional bytes。
+
+`createAdminModule` requires an `AdminRuntimeStatus` dependency。RM-19 production composition supplies build version、
+process uptime and verified daemon metadata；RM-20 contract tests use a scripted adapter。Admin never reads process
+globals or the daemon identity file。
+
+Gateway close ordering for optional mounts is exact：stop accepting mounted requests → abort mounted in-flight work →
+`LocalControlModule.close()` → `AdminModule.close()` → existing `onClose` persistence/transport cleanup。Both close
+methods are idempotent；control closes first so it cannot mint or dispatch after Admin teardown begins。
 
 Gateway Foundation owns body read/WireJson parse/admission；each Protocol Endpoint Module owns one
 `FailurePresenter` adapter and endpoint。For `anthropic-version`, an exact single value is accepted；the comma-merged
@@ -564,6 +602,7 @@ export interface WireJsonObject {
 | JSONL files/rotation | `JsonlLogger` | data directory | 10 MiB × 5、max age 7d |
 | Admin usage/event queries | `AdminTelemetry` | telemetry module / SQLite read adapter | read-only; reuses RM-05 retention/sanitizer |
 | Admin request/activity counters | `GatewayActivity` | process / read-only snapshot | no admission or stream mutation capability |
+| Admin version/uptime/daemon status | `AdminRuntimeStatus` | process / read-only snapshot | RM-19 production adapter; no file access from Admin |
 
 ### 6.2 Model resolution
 
@@ -2261,16 +2300,19 @@ route。Examples fixed by `RM-09` and required for later slices：
 - **Must read**：本文第 9 节、[Architecture](../architecture.md) CLI/security sections、
   [ADR-0004](../adr/0004-self-managed-daemon.md)。
 - **Owned scope/files**：`src/daemon/**`、daemon CLI command files、
+  additive control mount wiring in `src/gateway/hono_app.ts` and `src/gateway/create_gateway.ts`、
   serialized non-default composition update in `src/main.ts`、
   `tests/refactor/unit/daemon_identity.test.ts`、
   `tests/refactor/integration/daemon_lifecycle.test.ts`、
   `tests/refactor/integration/daemon_stale_pid.test.ts`。
 - **Deliverables/interface**：`DaemonController.start/stop/restart/status` and protected `DaemonIdentityFile`；
   foreground/managed identity publication；control operations `status`、`stop`、`admin-bootstrap`、`command`
-  require token + PID/start/nonce verification。
+  require token + PID/start/nonce verification；`createLocalControlModule(...): LocalControlModule` owns exact control
+  HTTP routes without widening protocol `RouteRegistration`。
 - **Admin seam**：Admin HTTP and local control receive the same running `AdminModule` instance；
   `admin-bootstrap` calls only `AdminModule.mintBootstrap()` and never creates a second auth/session/token store；
-  `kind:"capacity"|"closed"` maps to control `503 not_ready`。
+  `kind:"capacity"|"closed"` maps to control `503 not_ready`；production composition supplies
+  `AdminRuntimeStatus` from version、uptime and verified daemon state。
 - **Tests**：`npm run test:refactor -- tests/refactor/unit/daemon_identity.test.ts
   tests/refactor/integration/daemon_lifecycle.test.ts tests/refactor/integration/daemon_stale_pid.test.ts`；
   start readiness/failed start cleanup；idempotent status/stop；restart changes nonce/start identity；PID reuse/
@@ -2292,14 +2334,14 @@ route。Examples fixed by `RM-09` and required for later slices：
 - **Owned scope/files**：`src/admin/auth.ts`、`api.ts`、`events.ts`、`routes.ts`、
   additive Admin mount wiring in `src/gateway/hono_app.ts` and `src/gateway/create_gateway.ts`、
   read-only `src/telemetry/admin.ts`、optional observer hooks in `src/telemetry/recorder.ts` and
-  `src/telemetry/performance.ts`、serialized `src/main.ts` composition、
+  `src/telemetry/performance.ts`、
   `tests/refactor/contract/admin_auth.test.ts`、
   `tests/refactor/contract/admin_api.test.ts`、
   `tests/refactor/integration/admin_events.test.ts`。
 - **Deliverables/interface**：60s one-use bootstrap exchange、in-memory `AdminSession`、logout/session introspection；
   `createAdminModule(dependencies): AdminModule` covering all section 9.3 routes/DTOs/pagination/error envelope；
-  `AdminModule.mintBootstrap()` is the control-facing RM-19 seam；`AdminTelemetry` and `GatewayActivity` are read-only
-  module interfaces。Protocol `RouteRegistration` is unchanged。
+  `AdminModule.mintBootstrap()` is the control-facing RM-19 seam；`AdminTelemetry`、`GatewayActivity` and
+  `AdminRuntimeStatus` are read-only module interfaces。Protocol `RouteRegistration` is unchanged。
 - **Tests**：`npm run test:refactor -- tests/refactor/contract/admin_auth.test.ts
   tests/refactor/contract/admin_api.test.ts tests/refactor/integration/admin_events.test.ts`；
   token expiry/reuse/race；bootstrap no-session/CSRF exception with exact Origin；cookie flags；30m idle/12h
@@ -2311,6 +2353,9 @@ route。Examples fixed by `RM-09` and required for later slices：
   JSON 404 and never delegate to a fake static handler。Actual static serving belongs RM-21。
 - **Acceptance/done**：Admin can perform all six views' operations only through module interfaces；mutations fail closed；
   inference middleware/envelopes are not reused；state responses are no-store and sanitized。
+- **Composition handoff**：RM-20 exports the complete `AdminModule` factory and Gateway mount but does not edit production
+  `src/main.ts`。RM-19, which depends on RM-18 and RM-20, performs the single serialized production composition update
+  and injects the same Admin instance into Admin HTTP and local control。
 - **Non-goals/guardrails**：不 implement UI、WebSocket、persistent browser session、remote bind or expose long-term
   admin/control secret。
 - **PR handoff**：提供 route/DTO fixture index、cookie/CSRF bootstrap flow、scripted Admin backend and

--- a/docs/specs/refactor_master_spec.md
+++ b/docs/specs/refactor_master_spec.md
@@ -289,10 +289,12 @@ src/
     usage.ts
     operational_events.ts
     performance.ts
+    admin.ts
   admin/
     auth.ts
     api.ts
     events.ts
+    routes.ts
     static.ts
 web/
   src/
@@ -323,6 +325,8 @@ dist/                          # final package output, never committed
 他人 owned path 前，先在 issue 中记录原因并由 owner/coordinator 确认；共享 composition files
 `src/main.ts` and `package.json` 的修改由依赖顺序串行完成。`createGateway` accepts route registrations，
 so later protocol slices do not edit `src/gateway/create_gateway.ts`。
+RM-20 is the explicit exception for the additive optional `AdminModule` mount；it does not change protocol
+`RouteRegistration` or existing protocol callers。
 
 ## 6. Key interfaces 与 state ownership
 
@@ -371,6 +375,45 @@ export interface RequestScope {
   readonly config: Readonly<RuntimeConfigSnapshot>;
 }
 ```
+
+`RouteRegistration` remains exclusively for public protocol routes and is not widened for Admin JSON. Management routes
+use an additive optional Gateway mount:
+
+```ts
+export interface AdminRequestContext {
+  readonly requestId: string;
+  readonly signal: AbortSignal;
+  readonly requestBodyBytes: number;
+  readonly listenerOrigin: string;
+  readonly activity: GatewayActivity;
+}
+
+export interface AdminModule {
+  handle(request: Request, context: Readonly<AdminRequestContext>): Promise<Response>;
+  mintBootstrap(): AdminBootstrapResult;
+  close(): void;
+}
+
+export type AdminBootstrapResult =
+  | { readonly kind: "issued"; readonly token: string; readonly expiresAt: string }
+  | { readonly kind: "capacity" }
+  | { readonly kind: "closed" };
+
+export interface AdminStaticModule {
+  handle(request: Request, signal: AbortSignal): Promise<Response>;
+}
+```
+
+`GatewayDependencies` adds optional `admin?: AdminModule` and `adminStatic?: AdminStaticModule`. Existing RM-01 through
+RM-18 callers that omit them preserve identical behavior. Gateway owns Admin request-ID creation, caller/shutdown abort,
+captured body limit and active listener Origin；`AdminModule` owns Admin parsing、validation、security、envelope and SSE
+lifecycle。Gateway also supplies `AdminRequestContext.activity` per request, avoiding an Admin/Gateway composition
+cycle。Exact Admin API paths are matched before RM-21 static handling；unmatched `/admin/api/v1/*` never becomes
+SPA HTML。
+
+This correction does not reopen observable behavior from RM-01 through RM-18：protocol `RouteRegistration`、Gateway
+public routes、admission、WireJson、timeouts and protocol presenters remain unchanged。Only RM-19、RM-20、RM-21 and
+their transitive RM-22 composition consume these optional interfaces。
 
 Gateway Foundation owns body read/WireJson parse/admission；each Protocol Endpoint Module owns one
 `FailurePresenter` adapter and endpoint。For `anthropic-version`, an exact single value is accepted；the comma-merged
@@ -517,6 +560,9 @@ export interface WireJsonObject {
 | daemon PID/start identity/nonce/control token | `DaemonIdentityFile` | protected atomic file | authenticated control before action |
 | credentials/admin long-term secret | `FileCredentialStore` | protected atomic file | never SQLite/log |
 | JSONL files/rotation | `JsonlLogger` | data directory | 10 MiB × 5、max age 7d |
+| Admin sessions/bootstrap/CSRF | `AdminModule` | process / bounded memory | RM-19 control and Admin HTTP share one instance |
+| Admin usage/event queries | `AdminTelemetry` | telemetry module / SQLite read adapter | read-only; reuses RM-05 retention/sanitizer |
+| Admin request/activity counters | `GatewayActivity` | process / read-only snapshot | no admission or stream mutation capability |
 
 ### 6.2 Model resolution
 
@@ -962,6 +1008,29 @@ capacity is 503 and internal failure is 500。All Admin JSON/SSE responses are `
 Canonical codes are respectively `validation_failed`、`unauthenticated`、`forbidden`、`not_found`、
 `revision_conflict`、`capacity_exceeded` and `internal_error`；the matching messages are fixed lower-case versions
 with spaces。HTTP 204 responses have no body。
+
+Admin HTTP behavior is owned by `AdminModule`, not by protocol `RouteRegistration` or Gateway HTTP protocol parsing：
+
+- exact Origin is `http://127.0.0.1:<active-port>` supplied by Gateway；
+- JSON mutations accept only `application/json` with optional UTF-8 charset and missing/single `identity` encoding；
+- empty、malformed、non-object、unknown-field、unsupported-media and over-limit bodies return `400 validation_failed`；
+- reads use captured `limits.requestBodyBytes` and cancel at the first excess byte；
+- no-body routes reject nonempty bodies and all routes reject unknown/duplicate query fields；
+- every Admin JSON/SSE response uses `Cache-Control: no-store` and gateway-generated `x-request-id`；JSON uses
+  `application/json; charset=utf-8`；
+- caller abort or Gateway close cancels body/use-case/SSE work and emits no additional bytes；
+- Admin never uses inference admission、WireJson or a protocol failure presenter。
+
+`AdminTelemetry` is a read-only adapter owned in `src/telemetry/admin.ts`。It owns Usage/Event SQLite queries、opaque
+cursors、filtered totals、event replay and sanitized DTO reads while reusing RM-05 schema/retention/sanitizer。RM-20 does
+not change RM-05 telemetry writes、batching、cleanup or performance transitions。`GatewayActivity` exposes read-only
+active request/stream/queue snapshots。
+
+`AdminTelemetry` also exposes `subscribe(listener): unsubscribe` for sanitized Operational Event and performance
+transitions。`AdminModule` owns browser subscriber caps、per-subscriber queues、replay/reset ordering、heartbeat and
+slow-consumer disconnect。`AdminModule.close()` is idempotent；closed `handle` fails closed and closed
+`mintBootstrap()` returns `kind:"closed"`。The ninth outstanding bootstrap returns `kind:"capacity"`。RM-19 maps both
+capacity and closed to control `503 not_ready` without exposing internal counts。
 
 Canonical Admin route matrix：
 
@@ -2190,6 +2259,9 @@ route。Examples fixed by `RM-09` and required for later slices：
 - **Deliverables/interface**：`DaemonController.start/stop/restart/status` and protected `DaemonIdentityFile`；
   foreground/managed identity publication；control operations `status`、`stop`、`admin-bootstrap`、`command`
   require token + PID/start/nonce verification。
+- **Admin seam**：Admin HTTP and local control receive the same running `AdminModule` instance；
+  `admin-bootstrap` calls only `AdminModule.mintBootstrap()` and never creates a second auth/session/token store；
+  `kind:"capacity"|"closed"` maps to control `503 not_ready`。
 - **Tests**：`npm run test:refactor -- tests/refactor/unit/daemon_identity.test.ts
   tests/refactor/integration/daemon_lifecycle.test.ts tests/refactor/integration/daemon_stale_pid.test.ts`；
   start readiness/failed start cleanup；idempotent status/stop；restart changes nonce/start identity；PID reuse/
@@ -2209,12 +2281,15 @@ route。Examples fixed by `RM-09` and required for later slices：
 - **Must read**：本文第 6.1、9.3 节、[Architecture](../architecture.md) Admin/security/routes sections、
   `docs/gateway_http_contracts.md` Admin isolation rules。
 - **Owned scope/files**：`src/admin/auth.ts`、`api.ts`、`events.ts`、`routes.ts`、
+  additive Admin mount wiring in `src/gateway/hono_app.ts` and `src/gateway/create_gateway.ts`、
+  read-only `src/telemetry/admin.ts`、serialized `src/main.ts` composition、
   `tests/refactor/contract/admin_auth.test.ts`、
   `tests/refactor/contract/admin_api.test.ts`、
   `tests/refactor/integration/admin_events.test.ts`。
 - **Deliverables/interface**：60s one-use bootstrap exchange、in-memory `AdminSession`、logout/session introspection；
-  `createAdminRoutes(dependencies): readonly RouteRegistration[]` covering all section 9.3
-  routes/DTOs/pagination/error envelope；control-facing bootstrap mint interface。
+  `createAdminModule(dependencies): AdminModule` covering all section 9.3 routes/DTOs/pagination/error envelope；
+  `AdminModule.mintBootstrap()` is the control-facing RM-19 seam；`AdminTelemetry` and `GatewayActivity` are read-only
+  module interfaces。Protocol `RouteRegistration` is unchanged。
 - **Tests**：`npm run test:refactor -- tests/refactor/contract/admin_auth.test.ts
   tests/refactor/contract/admin_api.test.ts tests/refactor/integration/admin_events.test.ts`；
   token expiry/reuse/race；bootstrap no-session/CSRF exception with exact Origin；cookie flags；30m idle/12h
@@ -2222,7 +2297,8 @@ route。Examples fixed by `RM-09` and required for later slices：
   every mutation；TypeBox no coercion/unknown handling；revision conflicts；no secret fields；history clear；degraded
   transitions；device-flow polling/cap/expiry；usage/event cursor bounds；8 sessions/tokens/subscribers；
   operational/performance/reset SSE exact bytes、Last-Event-ID replay/eviction/malformed、heartbeat；
-  active request versus active stream counters；bounded subscriber/slow disconnect；static catch-all isolation。
+  active request versus active stream counters；bounded subscriber/slow disconnect；Admin API unknown paths remain Admin
+  JSON 404 and never delegate to a fake static handler。Actual static serving belongs RM-21。
 - **Acceptance/done**：Admin can perform all six views' operations only through module interfaces；mutations fail closed；
   inference middleware/envelopes are not reused；state responses are no-store and sanitized。
 - **Non-goals/guardrails**：不 implement UI、WebSocket、persistent browser session、remote bind or expose long-term
@@ -2241,6 +2317,8 @@ route。Examples fixed by `RM-09` and required for later slices：
   `tests/refactor/e2e/admin.spec.ts`、`tests/refactor/e2e/fixtures/**`。
 - **Deliverables/interface**：`Overview`、`Accounts`、`Models`、`Configuration`、`ResponsesHistory`、`Events`；
   fragment bootstrap exchange、CSRF client、SSE reconnect with bounded UI state；no SvelteKit server。
+- **Static seam**：`src/admin/static.ts` implements `AdminStaticModule` and mounts after exact Admin API handling。Only
+  `GET /admin` and `GET /admin/*` may return assets/SPA fallback；`/admin/api/v1/*`、protocol routes and probes never do。
 - **Tests**：`npm run test:e2e:refactor -- tests/refactor/e2e/admin.spec.ts`，exact 7 flows：
   `bootstrap-and-session-expiry`、`github-and-ghes-account-lifecycle`、
   `model-refresh-invalidates-preference`、`config-revision-and-security-rejection`、


### PR DESCRIPTION
## Summary

Closes the normative gap between protocol RouteRegistration and the unimplemented Admin/control/static surfaces.

- keeps completed RM-01 through RM-18 protocol behavior and RouteRegistration unchanged
- adds optional AdminModule, LocalControlModule, and AdminStaticModule gateway mounts
- assigns Admin JSON/security/SSE ownership to AdminModule`n- defines read-only AdminTelemetry, GatewayActivity, and AdminRuntimeStatus seams
- assigns production composition to RM-19 and static handling to RM-21
- defines bounded control bodies and mounted shutdown ordering

## Impact

Only unimplemented RM-19, RM-20, RM-21, and transitive RM-22 consume the corrected interfaces. The dependency DAG and completed public protocol contracts are unchanged.

## Verification

- git diff --check`n- /code-review Standards: no blockers
- /code-review Spec: no blockers

After merge, issues #25, #27, #28, and #29 will be synchronized to the corrected contract.