### PR TITLE
fix: normalize published bin metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,6 @@
   },
   "type": "module",
   "bin": {
-    "ghcg": "./dist/src/cli/main.js"
+    "ghcg": "dist/src/cli/main.js"
   }
 }

--- a/tests/refactor/unit/toolchain.test.ts
+++ b/tests/refactor/unit/toolchain.test.ts
@@ -43,7 +43,7 @@ describe("RM-22 atomic package cutover", () => {
       ".": "./dist/src/main.js",
       "./cli": "./dist/src/cli/main.js",
     });
-    expect(pkg.bin).toEqual({ ghcg: "./dist/src/cli/main.js" });
+    expect(pkg.bin).toEqual({ ghcg: "dist/src/cli/main.js" });
     expect(pkg.files).toEqual(["dist/src/", "dist/admin/", "README.md", "LICENSE"]);
     expect(pkg.engines.node).toBe(">=24");
     expect(pkg.repository.url).toBe("git+https://github.com/ljie-PI/ghc-gateway.git");


### PR DESCRIPTION
## Summary
- use npm 11 canonical bin metadata for the sole ghcg executable
- prevent npm publish from auto-normalizing package.json
- update the atomic cutover assertion

## Root cause
The publish attempt did not create a package because npm required 2FA, but its dry packaging stage revealed that npm 11 normalizes a bin path with a leading dot-slash. The lockfile was already canonical.

## Verification
- npm publish dry-run reports no metadata correction
- focused toolchain tests passed
- package smoke still installs and runs ghcg
- git diff check passed
- @ljie-pi/ghc-gateway@0.1.0 remains unpublished