### PR TITLE
Make CLI entrypoint tests platform-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,7 @@ npm install --global @ljie-pi/ghc-gateway
 
 The package installs one executable: `ghcg`.
 
-To build and run a source checkout, use Node.js 24.20.0 or newer:
-
-```bash
-npm ci
-npm run build
-npm start
-```
-
-`npm start` runs the built gateway in the foreground. Pass startup options after `--`, for example `npm start -- --port 31401`.
+To build and run a source checkout instead, see [Development](#development).
 
 ## Start The Gateway
 
@@ -201,7 +193,50 @@ ghcg --json config get limits.requestBodyBytes
 
 ## Development
 
-```bash
+### Source Checkout Workflow
+
+Install dependencies once after cloning and again only when dependencies change:
+
+```sh
+npm ci
+```
+
+Build after source changes:
+
+```sh
+npm run build
+```
+
+Run the built gateway in the foreground:
+
+```sh
+npm start
+```
+
+This listens on `127.0.0.1:31400` by default. Press `Ctrl+C` to stop it. Pass startup options after `--`, for example `npm start -- --port 31401`.
+
+In a second terminal, use the built CLI for authentication and the Admin UI:
+
+```sh
+node dist/src/cli/main.js auth login
+node dist/src/cli/main.js admin open
+```
+
+OpenAI-compatible clients can use `http://127.0.0.1:31400/v1` as their base URL. The current release does not require a separate gateway API key.
+
+As an alternative to the foreground process, start one detached, self-managed daemon and stop it later:
+
+```sh
+node dist/src/cli/main.js start
+node dist/src/cli/main.js status
+node dist/src/cli/main.js stop
+```
+
+Do not run the foreground process and detached daemon simultaneously for the same data directory and port.
+
+### Checks
+
+```sh
 npm ci
 npm run typecheck
 npm run lint

--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ npm install --global @ljie-pi/ghc-gateway
 
 The package installs one executable: `ghcg`.
 
-To build and run a source checkout instead, see [Development](#development).
+To build and run a source checkout, use Node.js 24.20.0 or newer:
+
+```bash
+npm ci
+npm run build
+npm start
+```
+
+`npm start` runs the built gateway in the foreground. Pass startup options after `--`, for example `npm start -- --port 31401`.
 
 ## Start The Gateway
 
@@ -193,50 +201,7 @@ ghcg --json config get limits.requestBodyBytes
 
 ## Development
 
-### Source Checkout Workflow
-
-Install dependencies once after cloning and again only when dependencies change:
-
-```sh
-npm ci
-```
-
-Build after source changes:
-
-```sh
-npm run build
-```
-
-Run the built gateway in the foreground:
-
-```sh
-npm start
-```
-
-This listens on `127.0.0.1:31400` by default. Press `Ctrl+C` to stop it. Pass startup options after `--`, for example `npm start -- --port 31401`.
-
-In a second terminal, use the built CLI for authentication and the Admin UI:
-
-```sh
-node dist/src/cli/main.js auth login
-node dist/src/cli/main.js admin open
-```
-
-OpenAI-compatible clients can use `http://127.0.0.1:31400/v1` as their base URL. The current release does not require a separate gateway API key.
-
-As an alternative to the foreground process, start one detached, self-managed daemon and stop it later:
-
-```sh
-node dist/src/cli/main.js start
-node dist/src/cli/main.js status
-node dist/src/cli/main.js stop
-```
-
-Do not run the foreground process and detached daemon simultaneously for the same data directory and port.
-
-### Checks
-
-```sh
+```bash
 npm ci
 npm run typecheck
 npm run lint

--- a/scripts/tooling/pack.ts
+++ b/scripts/tooling/pack.ts
@@ -416,7 +416,9 @@ function runNode(
 
 function runBin(binPath: string, args: readonly string[], cwd: string): Promise<CommandResult> {
   return process.platform === "win32"
-    ? runCommand(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", windowsCmdCommandLine(binPath, args)], cwd, [0], true)
+    ? runCommand(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", windowsCmdCommandLine(binPath, args)], cwd, [0], {
+      windowsVerbatimArguments: true,
+    })
     : runCommand(binPath, args, cwd);
 }
 
@@ -425,12 +427,16 @@ interface CommandResult {
   readonly stderr: string;
 }
 
+interface CommandOptions {
+  readonly windowsVerbatimArguments?: boolean;
+}
+
 function runCommand(
   command: string,
   args: readonly string[],
   cwd: string,
   allowedExitCodes: readonly number[] = [0],
-  windowsVerbatimArguments = false,
+  options: CommandOptions = {},
 ): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -438,7 +444,7 @@ function runCommand(
       env: sanitizedEnvironment(),
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
-      windowsVerbatimArguments,
+      windowsVerbatimArguments: options.windowsVerbatimArguments === true,
     });
     let stdout = "";
     let stderr = "";

--- a/scripts/tooling/pack.ts
+++ b/scripts/tooling/pack.ts
@@ -5,6 +5,7 @@ import { createServer } from "node:net";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { assertNode24 } from "./node_version.js";
+import { windowsCmdCommandLine } from "./windows_cmd.js";
 
 const PACKAGE_NAME = "@ljie-pi/ghc-gateway";
 const PACKAGE_VERSION = "0.1.0";
@@ -415,7 +416,7 @@ function runNode(
 
 function runBin(binPath: string, args: readonly string[], cwd: string): Promise<CommandResult> {
   return process.platform === "win32"
-    ? runCommand(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", binPath, ...args], cwd)
+    ? runCommand(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", windowsCmdCommandLine(binPath, args)], cwd, [0], true)
     : runCommand(binPath, args, cwd);
 }
 
@@ -429,6 +430,7 @@ function runCommand(
   args: readonly string[],
   cwd: string,
   allowedExitCodes: readonly number[] = [0],
+  windowsVerbatimArguments = false,
 ): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -436,6 +438,7 @@ function runCommand(
       env: sanitizedEnvironment(),
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
+      windowsVerbatimArguments,
     });
     let stdout = "";
     let stderr = "";

--- a/scripts/tooling/windows_cmd.ts
+++ b/scripts/tooling/windows_cmd.ts
@@ -1,0 +1,7 @@
+export function windowsCmdCommandLine(command: string, args: readonly string[]): string {
+  return `"${[quoteCmdArgument(command), ...args.map(quoteCmdArgument)].join(" ")}"`;
+}
+
+function quoteCmdArgument(value: string): string {
+  return `"${value.replaceAll("\"", "\"\"")}"`;
+}

--- a/tests/integration/cli_commands.test.ts
+++ b/tests/integration/cli_commands.test.ts
@@ -58,19 +58,27 @@ async function runCmd(
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
     const timeout = setTimeout(() => {
-      child.kill();
-      reject(new Error(`${path.basename(command)} did not exit before timeout`));
+      settled = true;
+      void terminateProcessTree(child.pid).then(
+        () => reject(new Error(`${path.basename(command)} did not exit before timeout`)),
+        (error: unknown) => reject(error),
+      );
     }, 15_000);
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => { stdout += chunk; });
     child.stderr.on("data", (chunk: string) => { stderr += chunk; });
     child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timeout);
       reject(error);
     });
     child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timeout);
       if (code !== 0) {
         reject(new Error(`${path.basename(command)} failed with exit code ${String(code)}; stdout=${safeOutput(stdout)}; stderr=${safeOutput(stderr)}`));
@@ -78,6 +86,25 @@ async function runCmd(
       }
       resolve({ stdout, stderr });
     });
+  });
+}
+
+async function terminateProcessTree(pid: number | undefined): Promise<void> {
+  if (pid === undefined) return;
+  await new Promise<void>((resolve, reject) => {
+    const script = [
+      "function Stop-Tree([int]$id) {",
+      "  Get-CimInstance Win32_Process -Filter \"ParentProcessId=$id\" | ForEach-Object { Stop-Tree ([int]$_.ProcessId) }",
+      "  Stop-Process -Id $id -Force -ErrorAction SilentlyContinue",
+      "}",
+      `Stop-Tree ${pid}`,
+    ].join("; ");
+    const killer = spawn("powershell.exe", ["-NoProfile", "-Command", script], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    killer.once("error", reject);
+    killer.once("close", () => resolve());
   });
 }
 
@@ -128,12 +155,12 @@ describe("CLI commands", () => {
         "",
       ].join("\r\n"));
 
-      const result = await runCmd(shim, ["--json", "--help"], directory);
+      const result = await runCmd(shim, ["--json", "auth", "login", "--help"], directory);
 
       expect(result.stderr).toBe("");
       expect(JSON.parse(result.stdout)).toMatchObject({
         ok: true,
-        data: { help: expect.stringContaining("Usage: ghcg") },
+        data: { help: expect.stringContaining("Usage: ghcg [--data-dir <path>] [--json] auth login [--host <domain>]") },
       });
     } finally {
       await rm(directory, { recursive: true, force: true });

--- a/tests/integration/cli_commands.test.ts
+++ b/tests/integration/cli_commands.test.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { AccountDirectory } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import { DeviceFlowService, type DeviceOAuthClient } from "../../src/accounts/device_flow.js";
@@ -30,6 +30,7 @@ import { SqliteResponsesHistory } from "../../src/protocols/responses/history.js
 import { windowsCmdCommandLine } from "../../scripts/tooling/windows_cmd.js";
 
 const encoder = new TextEncoder();
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 afterEach(() => {
   vi.useRealTimers();
@@ -110,13 +111,28 @@ async function terminateProcessTree(pid: number | undefined): Promise<void> {
 
 function testProcessEnvironment(): NodeJS.ProcessEnv {
   const env = { ...process.env };
+  env.NODE_OPTIONS = absoluteNodeOptionsPreloads(env.NODE_OPTIONS);
   for (const key of Object.keys(env)) {
-    if (/^(?:GHC_GATEWAY_)/u.test(key)
+    if (/^(?:GHC_GATEWAY_(?!CI_NETWORK_GUARD))/u.test(key)
       || /(?:token|secret|password|authorization|auth_token)/iu.test(key)) {
       delete env[key];
     }
   }
   return env;
+}
+
+function absoluteNodeOptionsPreloads(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const tokens = value.split(/\s+/u);
+  return tokens.map((token, index) => {
+    if (token.startsWith("--import=./scripts/tooling/")) {
+      return `--import=${pathToFileURL(path.join(repoRoot, token.slice("--import=./".length))).href}`;
+    }
+    if (tokens[index - 1] === "--import" && token.startsWith("./scripts/tooling/")) {
+      return pathToFileURL(path.join(repoRoot, token.slice(2))).href;
+    }
+    return token;
+  }).join(" ");
 }
 
 function safeOutput(value: string): string {
@@ -125,10 +141,10 @@ function safeOutput(value: string): string {
 
 describe("CLI commands", () => {
   it("recognizes the direct CLI entrypoint only when argv names that module", () => {
-    const entry = path.resolve("src", "cli", "main.ts");
+    const entry = path.join(repoRoot, "src", "cli", "main.ts");
 
     expect(isMainModule(pathToFileURL(entry).href, entry)).toBe(true);
-    expect(isMainModule(pathToFileURL(entry).href, path.resolve("src", "main.ts"))).toBe(false);
+    expect(isMainModule(pathToFileURL(entry).href, path.join(repoRoot, "src", "main.ts"))).toBe(false);
     expect(isMainModule(pathToFileURL(entry).href, undefined)).toBe(false);
   });
 
@@ -151,7 +167,7 @@ describe("CLI commands", () => {
     try {
       await writeFile(shim, [
         "@echo off",
-        `"${process.execPath}" "${path.resolve("scripts", "tooling", "bootstrap.mjs")}" "${path.resolve("src", "cli", "main.ts")}" %*`,
+        `"${process.execPath}" "${path.join(repoRoot, "scripts", "tooling", "bootstrap.mjs")}" "${path.join(repoRoot, "src", "cli", "main.ts")}" %*`,
         "",
       ].join("\r\n"));
 

--- a/tests/integration/cli_commands.test.ts
+++ b/tests/integration/cli_commands.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { spawn } from "node:child_process";
 import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -26,6 +27,7 @@ import { migration as historyMigration } from "../../src/persistence/migrations/
 import { bootstrapGateway, createPublicRouteRegistrations } from "../../src/main.js";
 import { litellmStyleTokenCounter } from "../../src/protocols/ollama_chat/token_counter.js";
 import { SqliteResponsesHistory } from "../../src/protocols/responses/history.js";
+import { windowsCmdCommandLine } from "../../scripts/tooling/windows_cmd.js";
 
 const encoder = new TextEncoder();
 
@@ -41,8 +43,69 @@ class CaptureStream {
   }
 }
 
+async function runCmd(
+  command: string,
+  args: readonly string[],
+  cwd: string,
+): Promise<Readonly<{ stdout: string; stderr: string }>> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", windowsCmdCommandLine(command, args)], {
+      cwd,
+      env: testProcessEnvironment(),
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(`${path.basename(command)} did not exit before timeout`));
+    }, 15_000);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+    child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timeout);
+      if (code !== 0) {
+        reject(new Error(`${path.basename(command)} failed with exit code ${String(code)}; stdout=${safeOutput(stdout)}; stderr=${safeOutput(stderr)}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function testProcessEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (/^(?:GHC_GATEWAY_)/u.test(key)
+      || /(?:token|secret|password|authorization|auth_token)/iu.test(key)) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
+function safeOutput(value: string): string {
+  return value.trim().replaceAll(/[\r\n]+/gu, " ").slice(0, 512);
+}
+
 describe("CLI commands", () => {
-  it("recognizes an executable symlink as the CLI main module", async () => {
+  it("recognizes the direct CLI entrypoint only when argv names that module", () => {
+    const entry = path.resolve("src", "cli", "main.ts");
+
+    expect(isMainModule(pathToFileURL(entry).href, entry)).toBe(true);
+    expect(isMainModule(pathToFileURL(entry).href, path.resolve("src", "main.ts"))).toBe(false);
+    expect(isMainModule(pathToFileURL(entry).href, undefined)).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")("recognizes a POSIX executable symlink as the CLI main module", async () => {
     const directory = await mkdtemp(path.join(tmpdir(), "ghcg-bin-link-"));
     const target = path.join(directory, "main.js");
     const link = path.join(directory, "ghcg");
@@ -54,6 +117,29 @@ describe("CLI commands", () => {
       await rm(directory, { recursive: true, force: true });
     }
   });
+
+  it.runIf(process.platform === "win32")("dispatches through a Windows command shim and forwards arguments", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "ghcg-bin-shim-"));
+    const shim = path.join(directory, "ghcg.cmd");
+    try {
+      await writeFile(shim, [
+        "@echo off",
+        `"${process.execPath}" "${path.resolve("scripts", "tooling", "bootstrap.mjs")}" "${path.resolve("src", "cli", "main.ts")}" %*`,
+        "",
+      ].join("\r\n"));
+
+      const result = await runCmd(shim, ["--json", "--help"], directory);
+
+      expect(result.stderr).toBe("");
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        ok: true,
+        data: { help: expect.stringContaining("Usage: ghcg") },
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("separates human stdout/stderr, JSON envelopes, and exit codes", async () => {
     const client = new ScriptedControlClient({
       "accounts.list": [{ defaultRevision: 1, defaultAccountId: null, items: [] }],


### PR DESCRIPTION
## Summary

- Split CLI entrypoint coverage by platform: direct entry recognition on all platforms, POSIX real executable symlink coverage outside Windows, and Windows `.cmd` shim dispatch/argument forwarding coverage.
- Added a shared Windows `cmd.exe /s /c` command-line quoting helper and used it in the installed-package smoke so the real npm-generated Windows shim works from paths containing spaces.
- Preserved CI network guard settings in the Windows shim child and rewrote inherited relative `NODE_OPTIONS --import ./scripts/tooling/...` preloads to absolute file URLs for temp-cwd execution.
- Preserved installed package smoke evidence for real CLI help, foreground health, daemon lifecycle, install scripts, and native dependency audit.

## Validation

- Baseline red reproduced on Windows before the fix: `npm test -- --run tests/integration/cli_commands.test.ts` failed with `EPERM` at `symlink(...)`.
- CI-shaped Windows repro after remote failure: `GHC_GATEWAY_CI_NETWORK_GUARD=1`, `NODE_OPTIONS='--import ./scripts/tooling/bootstrap.mjs'`, blocked proxy env, and `npm test -- --run tests/integration/cli_commands.test.ts` — 19 passed, 1 skipped.
- `npm test -- --run tests/integration/cli_commands.test.ts tests/integration/pack.test.ts` — 33 passed, 1 skipped.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm test` — 62 files passed; 413 passed, 4 skipped, 0 failed.
- `npm run pack` — passed; real installed package smoke reported help=true, foregroundHealth=true, daemonLifecycle=true, installScriptsEnabled=true, nativeBuildAudit=passed on Node 26.8.1.
- Hosted CI run 33978283016 at head `652fd2f` — all checks passed: linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64, Node.js 24.20.0 runtime/install, Node.js 26 runtime/install.

Earlier evidence note: PR run 33977699403 failed Windows before the CI-env fix with 412 passed, 4 skipped, 1 failed due to `ERR_MODULE_NOT_FOUND` for temp-cwd `scripts/tooling/bootstrap.mjs`; that failure is not counted as green.

## Review

Two-axis review against `bb84b212e616a3d0f4373c9366cc4fffe81ec580...HEAD` at head `652fd2f`:

- Standards: no must-fix findings and no safe-to-defer findings. The previous Windows command-spawn duplication note is no-action: `windowsCmdCommandLine` is the shared quoting interface; remaining call-site similarity is expected for two different process-spawn callers using the same boundary.
- Spec: no findings. Net diff is limited to `scripts/tooling/pack.ts`, `scripts/tooling/windows_cmd.ts`, and `tests/integration/cli_commands.test.ts`.

## CI annotations

No failure annotations were present on run 33978283016. The only warning annotations are GitHub Actions Node 20 deprecation warnings for upstream action versions (`actions/checkout@v4`, `actions/setup-node@v4`, `actions/cache@v4`, `actions/upload-artifact@v4`) being forced to run on Node 24; these are unrelated to this diff.

## Notes

- README source workflow changes were explicitly cancelled and reverted in a separate commit; the final net diff contains no README changes.
- Does not merge or close #88; parent session coordinates merging.

Refs #88