### PR TITLE
Enforce supported Node runtime before daemon startup

### DIFF
--- a/src/cli/control_client.ts
+++ b/src/cli/control_client.ts
@@ -12,6 +12,7 @@ import { captureProcessStartIdentity } from "../daemon/process_identity.js";
 export type CliErrorCode =
   | "internal_error"
   | "usage_error"
+  | "unsupported_runtime"
   | "validation_error"
   | "not_found"
   | "revision_conflict"
@@ -35,6 +36,7 @@ export class CliError extends Error {
 export const CLI_ERROR_EXIT: Readonly<Record<CliErrorCode, number>> = {
   internal_error: 1,
   usage_error: 2,
+  unsupported_runtime: 2,
   validation_error: 2,
   not_found: 3,
   revision_conflict: 3,
@@ -52,6 +54,7 @@ export const CLI_ERROR_EXIT: Readonly<Record<CliErrorCode, number>> = {
 export const SAFE_ERROR_MESSAGES: Readonly<Record<CliErrorCode, string>> = {
   internal_error: "internal error",
   usage_error: "usage error",
+  unsupported_runtime: "Node.js 24.20.0 or newer is required",
   validation_error: "validation error",
   not_found: "not found",
   revision_conflict: "revision conflict",

--- a/src/cli/control_client.ts
+++ b/src/cli/control_client.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
+import { UNSUPPORTED_RUNTIME_MESSAGE } from "../runtime_support.js";
 import type { AccountSummary } from "../accounts/account_directory.js";
 import type { ModelPreference } from "../accounts/model_preferences.js";
 import type { CatalogSnapshot } from "../copilot/model_catalog.js";
@@ -54,7 +55,7 @@ export const CLI_ERROR_EXIT: Readonly<Record<CliErrorCode, number>> = {
 export const SAFE_ERROR_MESSAGES: Readonly<Record<CliErrorCode, string>> = {
   internal_error: "internal error",
   usage_error: "usage error",
-  unsupported_runtime: "Node.js 24.20.0 or newer is required",
+  unsupported_runtime: UNSUPPORTED_RUNTIME_MESSAGE,
   validation_error: "validation error",
   not_found: "not found",
   revision_conflict: "revision conflict",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -16,6 +16,7 @@ import {
   type DaemonRuntimeDependencies,
   type RunDaemonRuntimeOptions,
 } from "../daemon/runtime.js";
+import { composeLazyProductionDaemonGateway } from "../daemon/production_gateway.js";
 
 export interface RunCliOptions {
   readonly argv?: readonly string[];
@@ -170,7 +171,7 @@ async function runServe(
   const shutdownSignal = options.shutdownSignal ?? shutdown?.signal ?? new AbortController().signal;
   const composeGateway: ComposeDaemonGateway = options.composeGateway
     ?? (options.createGateway === undefined
-      ? async (context) => await (await import("../main.js")).composeProductionDaemonGateway(context)
+      ? composeLazyProductionDaemonGateway
       : async (context) => await options.createGateway?.(context.startup, context.env) as HostedGateway);
   try {
     await (options.runDaemonRuntime ?? runDaemonRuntime)({

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,7 @@ import { parseCli } from "./parser.js";
 import { exitCodeForError, writeError, writeSuccess, type WritableCliStream } from "./output.js";
 import type { HostedGateway } from "../gateway/create_gateway.js";
 import { parseStartupConfig, type StartupConfig } from "../config/startup_config.js";
+import { isSupportedNodeVersion } from "../runtime_support.js";
 import type { DaemonController } from "../daemon/controller.js";
 import {
   createProductionDaemonController,
@@ -15,7 +16,6 @@ import {
   type DaemonRuntimeDependencies,
   type RunDaemonRuntimeOptions,
 } from "../daemon/runtime.js";
-import { composeProductionDaemonGateway } from "../main.js";
 
 export interface RunCliOptions {
   readonly argv?: readonly string[];
@@ -33,6 +33,7 @@ export interface RunCliOptions {
   readonly pollDelayMs?: number;
   readonly pid?: number;
   readonly now?: () => Date;
+  readonly nodeVersion?: string;
 }
 
 export async function runCli(options: RunCliOptions = {}): Promise<number> {
@@ -43,6 +44,9 @@ export async function runCli(options: RunCliOptions = {}): Promise<number> {
   let client: ControlClient | undefined;
   try {
     const env = options.env ?? process.env;
+    if (!isSupportedNodeVersion(options.nodeVersion ?? process.versions.node)) {
+      throw new CliError("unsupported_runtime");
+    }
     const parsed = parseCli(argv, { env, ...(options.homedir === undefined ? {} : { homedir: options.homedir }) });
     json = parsed.json;
     const command = parsed.command;
@@ -166,7 +170,7 @@ async function runServe(
   const shutdownSignal = options.shutdownSignal ?? shutdown?.signal ?? new AbortController().signal;
   const composeGateway: ComposeDaemonGateway = options.composeGateway
     ?? (options.createGateway === undefined
-      ? composeProductionDaemonGateway
+      ? async (context) => await (await import("../main.js")).composeProductionDaemonGateway(context)
       : async (context) => await options.createGateway?.(context.startup, context.env) as HostedGateway);
   try {
     await (options.runDaemonRuntime ?? runDaemonRuntime)({

--- a/src/daemon/child.ts
+++ b/src/daemon/child.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { pathToFileURL } from "node:url";
 import { parseStartupConfig } from "../config/startup_config.js";
+import { composeLazyProductionDaemonGateway } from "./production_gateway.js";
 import { runDaemonRuntime } from "./runtime.js";
 
 export async function runManagedChild(argv = process.argv.slice(2), env = process.env): Promise<void> {
@@ -14,7 +15,7 @@ export async function runManagedChild(argv = process.argv.slice(2), env = proces
       startup,
       env,
       managed: true,
-      composeGateway: async (context) => await (await import("../main.js")).composeProductionDaemonGateway(context),
+      composeGateway: composeLazyProductionDaemonGateway,
       shutdownSignal: shutdown.signal,
       stderr: process.stderr,
     });

--- a/src/daemon/child.ts
+++ b/src/daemon/child.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { pathToFileURL } from "node:url";
 import { parseStartupConfig } from "../config/startup_config.js";
-import { composeProductionDaemonGateway } from "../main.js";
 import { runDaemonRuntime } from "./runtime.js";
 
 export async function runManagedChild(argv = process.argv.slice(2), env = process.env): Promise<void> {
@@ -15,7 +14,7 @@ export async function runManagedChild(argv = process.argv.slice(2), env = proces
       startup,
       env,
       managed: true,
-      composeGateway: composeProductionDaemonGateway,
+      composeGateway: async (context) => await (await import("../main.js")).composeProductionDaemonGateway(context),
       shutdownSignal: shutdown.signal,
       stderr: process.stderr,
     });

--- a/src/daemon/local_control.ts
+++ b/src/daemon/local_control.ts
@@ -364,6 +364,7 @@ function failureDetails(code: ControlFailureCode): { readonly status: number; re
 function cliStatus(code: CliErrorCode): number {
   switch (code) {
   case "usage_error":
+  case "unsupported_runtime":
   case "validation_error":
     return 400;
   case "not_found":

--- a/src/daemon/production_gateway.ts
+++ b/src/daemon/production_gateway.ts
@@ -1,0 +1,8 @@
+import type { HostedGateway } from "../gateway/create_gateway.js";
+import type { DaemonRuntimeComposition } from "./runtime.js";
+
+export async function composeLazyProductionDaemonGateway(
+  context: Readonly<DaemonRuntimeComposition>,
+): Promise<HostedGateway> {
+  return await (await import("../main.js")).composeProductionDaemonGateway(context);
+}

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -6,6 +6,7 @@ import { authenticatedControlRequest } from "../cli/control_client.js";
 import type { StartupConfig } from "../config/startup_config.js";
 import type { HostedGateway } from "../gateway/create_gateway.js";
 import { GRACEFUL_SHUTDOWN_MS } from "../gateway/create_gateway.js";
+import { assertSupportedRuntime } from "../runtime_support.js";
 import { DaemonController } from "./controller.js";
 import {
   DaemonIdentityFile,
@@ -39,6 +40,7 @@ export interface DaemonRuntimeDependencies {
   ) => DaemonIdentityLease | Promise<DaemonIdentityLease>;
   readonly createLogger?: (managed: boolean, startup: StartupConfig) => DaemonLogger;
   readonly scheduleStop?: (stop: () => void) => void;
+  readonly nodeVersion?: string;
 }
 
 export interface ProductionDaemonControllerOptions {
@@ -108,6 +110,7 @@ export interface RunDaemonRuntimeOptions {
 
 export async function runDaemonRuntime(options: Readonly<RunDaemonRuntimeOptions>): Promise<void> {
   const dependencies = options.dependencies ?? {};
+  assertSupportedRuntime(dependencies.nodeVersion ?? process.versions.node);
   const pid = dependencies.pid ?? process.pid;
   const processStartIdentity = await (dependencies.captureProcessIdentity ?? captureProcessStartIdentity)(pid);
   if (processStartIdentity === null) {

--- a/src/runtime_support.ts
+++ b/src/runtime_support.ts
@@ -1,0 +1,45 @@
+export const MINIMUM_NODE_VERSION = "24.20.0";
+
+const MINIMUM_MAJOR = 24;
+const MINIMUM_MINOR = 20;
+const MINIMUM_PATCH = 0;
+
+interface ParsedVersion {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+}
+
+export function isSupportedNodeVersion(version = process.versions.node): boolean {
+  const parsed = parseNodeVersion(version);
+  if (parsed === null) {
+    return false;
+  }
+  if (parsed.major !== MINIMUM_MAJOR) {
+    return parsed.major > MINIMUM_MAJOR;
+  }
+  if (parsed.minor !== MINIMUM_MINOR) {
+    return parsed.minor > MINIMUM_MINOR;
+  }
+  return parsed.patch >= MINIMUM_PATCH;
+}
+
+export function assertSupportedRuntime(version = process.versions.node): void {
+  if (!isSupportedNodeVersion(version)) {
+    throw new Error(`Node.js ${MINIMUM_NODE_VERSION} or newer is required; current ${version}`);
+  }
+}
+
+function parseNodeVersion(version: string): ParsedVersion | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:[+-].*)?$/u.exec(version);
+  if (match === null || match[1] === undefined || match[2] === undefined || match[3] === undefined) {
+    return null;
+  }
+  const major = Number.parseInt(match[1], 10);
+  const minor = Number.parseInt(match[2], 10);
+  const patch = Number.parseInt(match[3], 10);
+  if (!Number.isSafeInteger(major) || !Number.isSafeInteger(minor) || !Number.isSafeInteger(patch)) {
+    return null;
+  }
+  return { major, minor, patch };
+}

--- a/src/runtime_support.ts
+++ b/src/runtime_support.ts
@@ -1,8 +1,7 @@
 export const MINIMUM_NODE_VERSION = "24.20.0";
+export const UNSUPPORTED_RUNTIME_MESSAGE = `Node.js ${MINIMUM_NODE_VERSION} or newer is required`;
 
-const MINIMUM_MAJOR = 24;
-const MINIMUM_MINOR = 20;
-const MINIMUM_PATCH = 0;
+const MINIMUM_VERSION = parseRequiredNodeVersion(MINIMUM_NODE_VERSION);
 
 interface ParsedVersion {
   readonly major: number;
@@ -15,18 +14,18 @@ export function isSupportedNodeVersion(version = process.versions.node): boolean
   if (parsed === null) {
     return false;
   }
-  if (parsed.major !== MINIMUM_MAJOR) {
-    return parsed.major > MINIMUM_MAJOR;
+  if (parsed.major !== MINIMUM_VERSION.major) {
+    return parsed.major > MINIMUM_VERSION.major;
   }
-  if (parsed.minor !== MINIMUM_MINOR) {
-    return parsed.minor > MINIMUM_MINOR;
+  if (parsed.minor !== MINIMUM_VERSION.minor) {
+    return parsed.minor > MINIMUM_VERSION.minor;
   }
-  return parsed.patch >= MINIMUM_PATCH;
+  return parsed.patch >= MINIMUM_VERSION.patch;
 }
 
 export function assertSupportedRuntime(version = process.versions.node): void {
   if (!isSupportedNodeVersion(version)) {
-    throw new Error(`Node.js ${MINIMUM_NODE_VERSION} or newer is required; current ${version}`);
+    throw new Error(`${UNSUPPORTED_RUNTIME_MESSAGE}; current ${version}`);
   }
 }
 
@@ -42,4 +41,12 @@ function parseNodeVersion(version: string): ParsedVersion | null {
     return null;
   }
   return { major, minor, patch };
+}
+
+function parseRequiredNodeVersion(version: string): ParsedVersion {
+  const parsed = parseNodeVersion(version);
+  if (parsed === null) {
+    throw new Error(`invalid minimum Node.js version: ${version}`);
+  }
+  return parsed;
 }

--- a/tests/integration/daemon_runtime.test.ts
+++ b/tests/integration/daemon_runtime.test.ts
@@ -6,6 +6,35 @@ import { parseStartupConfig } from "../../src/config/startup_config.js";
 import { runDaemonRuntime } from "../../src/daemon/runtime.js";
 
 describe("daemon runtime listener", () => {
+  it("rejects unsupported Node.js runtimes before publishing daemon identity", async () => {
+    const events: string[] = [];
+    await expect(runDaemonRuntime({
+      startup: parseStartupConfig(["--data-dir", "runtime-unsupported"], {}),
+      env: {},
+      managed: true,
+      shutdownSignal: new AbortController().signal,
+      stderr: { write: () => undefined },
+      composeGateway: async () => { throw new Error("must not compose"); },
+      dependencies: {
+        nodeVersion: "24.0.0",
+        pid: 123,
+        captureProcessIdentity: async () => {
+          events.push("process-identity");
+          return "windows:1";
+        },
+        acquireIdentity: () => {
+          events.push("acquire");
+          throw new Error("must not acquire");
+        },
+        createLogger: () => {
+          events.push("logger");
+          return { write() {} };
+        },
+      },
+    })).rejects.toThrow("Node.js 24.20.0 or newer is required");
+    expect(events).toEqual([]);
+  });
+
   it("holds the identity lease before composition and cleans only its lease after shutdown", async () => {
     const events: string[] = [];
     const shutdown = new AbortController();

--- a/tests/integration/log_rotation.test.ts
+++ b/tests/integration/log_rotation.test.ts
@@ -65,6 +65,26 @@ describe("daemon JSONL logger", () => {
     expect(vi.mocked(security.assertFile).mock.calls.length).toBeGreaterThan(afterFirst);
   });
 
+  it.runIf(process.platform === "win32")("fails closed when an existing log becomes unsafe before append", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ghc-gateway-log-windows-unsafe-"));
+    const security: WindowsLogSecurity = {
+      restrict: vi.fn(),
+      assertDirectory: vi.fn(),
+      assertFile: vi.fn(),
+    };
+    const logger = new JsonlLogger(path.join(root, "logs"), () => 1_700_000_000_000, security);
+    logger.write({ category: "first" });
+    vi.mocked(security.assertFile).mockImplementation(() => {
+      throw new Error("unsafe log");
+    });
+
+    expect(() => logger.write({ category: "second" })).toThrow("unsafe log");
+    const active = path.join(root, "logs", "gateway.jsonl");
+    const content = readFileSync(active, "utf8");
+    expect(content).toContain("first");
+    expect(content).not.toContain("second");
+  });
+
   it.skipIf(process.platform === "win32")("protects JSONL files, rotates before overflow, and applies count and age retention", async () => {
     let now = 1_700_000_000_000;
     const root = await mkdtemp(path.join(tmpdir(), "ghc-gateway-log-protected-"));

--- a/tests/unit/cli_runtime_support.test.ts
+++ b/tests/unit/cli_runtime_support.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { runCli } from "../../src/cli/main.js";
+
+class CaptureStream {
+  chunks = "";
+  write(chunk: string): void {
+    this.chunks += chunk;
+  }
+}
+
+describe("CLI runtime support", () => {
+  it("fails early with a safe unsupported-runtime diagnostic", async () => {
+    const stdout = new CaptureStream();
+    const stderr = new CaptureStream();
+
+    await expect(runCli({
+      argv: ["--json", "status"],
+      homedir: "Q:\\tmp\\home",
+      stdout,
+      stderr,
+      nodeVersion: "24.0.0",
+    })).resolves.toBe(2);
+
+    expect(stdout.chunks).toBe("");
+    expect(stderr.chunks).toBe(`${JSON.stringify({
+      ok: false,
+      error: {
+        code: "unsupported_runtime",
+        message: "Node.js 24.20.0 or newer is required",
+      },
+    })}\n`);
+  });
+});

--- a/tests/unit/runtime_support.test.ts
+++ b/tests/unit/runtime_support.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  MINIMUM_NODE_VERSION,
+  assertSupportedRuntime,
+  isSupportedNodeVersion,
+} from "../../src/runtime_support.js";
+
+describe("production runtime support", () => {
+  it("keeps the documented Node.js floor at 24.20.0", () => {
+    expect(MINIMUM_NODE_VERSION).toBe("24.20.0");
+
+    for (const version of ["24.0.0", "24.1.0", "24.2.0", "24.19.9", "23.99.99"]) {
+      expect(isSupportedNodeVersion(version), version).toBe(false);
+      expect(() => assertSupportedRuntime(version)).toThrow(/24\.20\.0/u);
+    }
+
+    for (const version of ["24.20.0", "24.21.0", "25.0.0", "26.8.1"]) {
+      expect(isSupportedNodeVersion(version), version).toBe(true);
+      expect(() => assertSupportedRuntime(version)).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Addresses #87 without lowering the supported runtime floor.

- keep the documented Node.js >=24.20.0 policy intact
- add an early `unsupported_runtime` CLI/control diagnostic before daemon identity or log validation can emit misleading failures on older Windows Node runtimes
- lazy-load production gateway composition so unsupported runtimes can return clean machine-readable JSON before loading Node APIs that warn on old 24.x releases
- add public-interface coverage for runtime support, CLI output, daemon startup ordering, and Windows logger fail-closed behavior

## Evidence

- Synthetic Windows file-identity matrix saved in session artifacts and posted to #87:
  - Node 24.0.0 / libuv 1.50.0: strict identity failed (`stat.dev=0`, descriptor dev non-zero)
  - Node 24.1.0 / libuv 1.50.0: strict identity failed
  - Node 24.2.0 / libuv 1.51.0: strict identity passed
  - Node 24.20.0 / libuv 1.52.1: strict identity passed
  - Node 26.8.1 / libuv 1.52.1: strict identity passed
- Upstream root cause: libuv/libuv#4698 / libuv commit `82cdfb75ff9bbd0dc65820ca418b7c5d412ff4d7`, pulled into Node by nodejs/node commit `0315283cbdb7745c7e35bb49ac48b0ebcadcb228`
- Portable Node 24.0.0 built CLI probe now exits 2 with clean JSON: `unsupported_runtime`

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` — 64 files passed, 417 passed, 4 skipped
- `npm run fixtures:verify` — 54 fixture manifest entries verified
- `npm run e2e` — 7 passed after installing the existing Playwright Chromium browser dependency; one initial events test timing failure passed on targeted rerun and full rerun
- `npm run smoke:sqlite`
- `npm run bench -- full --repeat 3`
- `npm run pack`

## Review

- Code review against `dfaf0601c7a9ac614928da364e5551c590428b2d`: Standards 0 findings, Spec 0 findings
- Code review after merging latest `origin/main` (`793cc781896fd053696e630001e6393613f6017b`): Standards 0 findings, Spec 0 findings

Deferred follow-ups: none.