### PR TITLE
Hide Windows console windows spawned by credential store and test helpers

### DIFF
--- a/src/accounts/credential_store.ts
+++ b/src/accounts/credential_store.ts
@@ -180,10 +180,10 @@ function protectFile(filePath: string): void {
 function restrictWindowsAcl(target: string): void {
   const current = currentWindowsIdentity();
   const grant = isDirectory(target) ? `*${current.sid}:(OI)(CI)(F)` : `*${current.sid}:(F)`;
-  execFileSync("icacls", [target, "/inheritance:r", "/grant:r", grant], { stdio: "ignore" });
+  execFileSync("icacls", [target, "/inheritance:r", "/grant:r", grant], { stdio: "ignore", windowsHide: true });
   for (const identity of windowsAclIdentities(target)) {
     if (!isCurrentWindowsIdentity(identity, current)) {
-      execFileSync("icacls", [target, "/remove:g", identity], { stdio: "ignore" });
+      execFileSync("icacls", [target, "/remove:g", identity], { stdio: "ignore", windowsHide: true });
     }
   }
 }
@@ -197,7 +197,7 @@ function assertWindowsAclCurrentUserOnly(target: string): void {
 }
 
 function currentWindowsIdentity(): { readonly name: string; readonly sid: string } {
-  const csv = execFileSync("whoami", ["/user", "/fo", "csv", "/nh"], { encoding: "utf8" }).trim();
+  const csv = execFileSync("whoami", ["/user", "/fo", "csv", "/nh"], { encoding: "utf8", windowsHide: true }).trim();
   const match = /^"([^"]+)","([^"]+)"$/u.exec(csv);
   if (match === null || match[1] === undefined || match[2] === undefined) {
     throw new Error("unable to resolve current Windows identity");
@@ -206,7 +206,7 @@ function currentWindowsIdentity(): { readonly name: string; readonly sid: string
 }
 
 function windowsAclIdentities(target: string): readonly string[] {
-  const output = execFileSync("icacls", [target], { encoding: "utf8" });
+  const output = execFileSync("icacls", [target], { encoding: "utf8", windowsHide: true });
   const identities: string[] = [];
   for (const rawLine of output.split(/\r?\n/u)) {
     const line = rawLine.trim();

--- a/tests/integration/copilot_transport.test.ts
+++ b/tests/integration/copilot_transport.test.ts
@@ -54,7 +54,7 @@ describe("Copilot transport", () => {
         "--eval",
         source,
         dataDir,
-      ], { cwd: process.cwd(), env: { ...process.env, NODE_OPTIONS: "" } });
+      ], { cwd: process.cwd(), windowsHide: true, env: { ...process.env, NODE_OPTIONS: "" } });
     } finally {
       await rm(dataDir, { recursive: true, force: true });
     }

--- a/tests/integration/credential_store_permissions.test.ts
+++ b/tests/integration/credential_store_permissions.test.ts
@@ -38,7 +38,7 @@ describe("credential file protection", () => {
     const filePath = path.join(dir, "credentials.json");
     const store = new FileCredentialStore(filePath);
     await store.putGeneration("github.com/1", 1, { generation: 1, githubToken: "tok" });
-    execFileSync("icacls", [filePath, "/grant", "*S-1-1-0:(R)"], { stdio: "ignore" });
+    execFileSync("icacls", [filePath, "/grant", "*S-1-1-0:(R)"], { stdio: "ignore", windowsHide: true });
     await expect(store.readGeneration("github.com/1", 1)).rejects.toThrow();
   });
 
@@ -55,7 +55,7 @@ describe("credential file protection", () => {
   });
 
   function windowsAclPrincipals(target: string): readonly string[] {
-    const output = execFileSync("icacls", [target], { encoding: "utf8" });
+    const output = execFileSync("icacls", [target], { encoding: "utf8", windowsHide: true });
     const principals: string[] = [];
     for (const rawLine of output.split(/\r?\n/u)) {
       const line = rawLine.trim();

--- a/tests/unit/toolchain.test.ts
+++ b/tests/unit/toolchain.test.ts
@@ -112,14 +112,17 @@ describe("package entrypoints and toolchain", () => {
     const command = ["scripts/tooling/bootstrap.mjs", "scripts/tooling/require_opt_in.ts"];
 
     await expect(execFileAsync(process.execPath, [...command, "GHC_GATEWAY_SDK_TESTS"], {
+      windowsHide: true,
       env: { ...process.env, GHC_GATEWAY_SDK_TESTS: "" },
     })).rejects.toMatchObject({ code: 2 });
 
     await expect(execFileAsync(process.execPath, [...command, "GHC_GATEWAY_LIVE_TESTS"], {
+      windowsHide: true,
       env: { ...process.env, GHC_GATEWAY_LIVE_TESTS: "" },
     })).rejects.toMatchObject({ code: 2 });
 
     await expect(execFileAsync(process.execPath, [...command, "GHC_GATEWAY_SDK_TESTS"], {
+      windowsHide: true,
       env: { ...process.env, GHC_GATEWAY_SDK_TESTS: "1" },
     })).resolves.toMatchObject({ stdout: "" });
   });
@@ -185,6 +188,7 @@ describe("package entrypoints and toolchain", () => {
       "--eval",
       "fetch('https://github.com').catch((error) => { console.error(error.message); process.exit(2); })",
     ], {
+      windowsHide: true,
       env: { ...process.env, GHC_GATEWAY_CI_NETWORK_GUARD: "1" },
     })).rejects.toMatchObject({ code: 2 });
   });


### PR DESCRIPTION
## Problem
On Windows, running the test suite flashes a console window for each subprocess spawned without `windowsHide: true`. `src/accounts/credential_store.ts` was the only source file missing the flag, so every `whoami`/`icacls` call made during credential ACL checks popped a window.

## Change
Add `windowsHide: true` to all remaining console-subsystem subprocess spawns reachable from `npm test`, matching the existing convention already used across `src/daemon/*`, `src/cli/control_client.ts`, and `tests/integration/cli_commands.test.ts`:

- `src/accounts/credential_store.ts` (4 `execFileSync` calls: whoami + icacls)
- `tests/integration/credential_store_permissions.test.ts` (2 `icacls`)
- `tests/integration/copilot_transport.test.ts` (1 `node`)
- `tests/unit/toolchain.test.ts` (4 `node`)

## Verification
- `tsc -p tsconfig.test.json --noEmit` passes
- Affected tests pass: 3 files / 25 tests, including the Windows ACL permission tests