### PR TITLE
Complete Admin device authorization automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Admin security defaults:
 - bounded, replayable SSE monitoring with no WebSocket or remote Admin access
 
 The six views are Overview, Accounts, Models, Configuration, Responses History, and Events.
+The Accounts view checks an active device authorization automatically at GitHub's required interval. Keep that
+view open until it reports completion; closing or leaving it stops browser polling, and no device code or token is
+stored in browser storage.
 
 ## HTTP Interfaces
 

--- a/src/accounts/account_directory.ts
+++ b/src/accounts/account_directory.ts
@@ -40,6 +40,18 @@ export class AccountDirectoryError extends Error {
     this.name = "AccountDirectoryError";
     this.code = code;
   }
+
+}
+
+export class AccountDirectoryPostCommitError extends Error {
+  constructor(
+    readonly accountId: AccountId,
+    readonly retryCleanup: (signal?: AbortSignal) => Promise<void>,
+    options: ErrorOptions,
+  ) {
+    super("account committed but credential cleanup failed", options);
+    this.name = "AccountDirectoryPostCommitError";
+  }
 }
 
 let accountLifecycleLock: Promise<void> = Promise.resolve();
@@ -129,9 +141,9 @@ export class AccountDirectory {
       }
       const generation = (existing?.credential_generation ?? 0) + 1;
       const secret = { ...input.secret, generation };
-      await this.credentials.putGeneration(accountId, generation, secret);
+      await this.credentials.putGeneration(accountId, generation, secret, signal);
       if (signal?.aborted === true) {
-        await this.credentials.prune(this.activeCredentialReferences());
+        await this.credentials.prune(this.activeCredentialReferences(), signal);
         throw new DOMException("aborted", "AbortError");
       }
 
@@ -178,11 +190,22 @@ export class AccountDirectory {
           }
         })();
       } catch (error: unknown) {
-        await this.credentials.prune(this.activeCredentialReferences());
+        await this.credentials.prune(this.activeCredentialReferences(), signal);
         throw error;
       }
 
-      await this.credentials.prune(this.activeCredentialReferences());
+      try {
+        await this.credentials.prune(this.activeCredentialReferences(), signal);
+      } catch (error: unknown) {
+        throw new AccountDirectoryPostCommitError(
+          accountId,
+          async (cleanupSignal) => await withAccountLifecycleLock(
+            async () => await this.credentials.prune(this.activeCredentialReferences(), cleanupSignal),
+            cleanupSignal,
+          ),
+          { cause: error },
+        );
+      }
       return this.bind(accountId);
     }, signal), signal);
   }

--- a/src/accounts/credential_store.ts
+++ b/src/accounts/credential_store.ts
@@ -13,9 +13,14 @@ export interface SecretCredential {
 
 export interface CredentialStore {
   readGeneration(accountId: AccountId, generation: number): Promise<SecretCredential | null>;
-  putGeneration(accountId: AccountId, generation: number, value: SecretCredential): Promise<void>;
+  putGeneration(
+    accountId: AccountId,
+    generation: number,
+    value: SecretCredential,
+    signal?: AbortSignal,
+  ): Promise<void>;
   removeAccount(accountId: AccountId): Promise<void>;
-  prune(references: ReadonlyMap<AccountId, number>): Promise<void>;
+  prune(references: ReadonlyMap<AccountId, number>, signal?: AbortSignal): Promise<void>;
 }
 
 interface FileDocument {
@@ -30,17 +35,25 @@ export class MemoryCredentialStore implements CredentialStore {
     return this.data.get(accountId)?.get(generation) ?? null;
   }
 
-  async putGeneration(accountId: AccountId, generation: number, value: SecretCredential): Promise<void> {
+  async putGeneration(
+    accountId: AccountId,
+    generation: number,
+    value: SecretCredential,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    signal?.throwIfAborted();
     const current = this.data.get(accountId) ?? new Map<number, SecretCredential>();
     current.set(generation, value);
     this.data.set(accountId, current);
+    signal?.throwIfAborted();
   }
 
   async removeAccount(accountId: AccountId): Promise<void> {
     this.data.delete(accountId);
   }
 
-  async prune(references: ReadonlyMap<AccountId, number>): Promise<void> {
+  async prune(references: ReadonlyMap<AccountId, number>, signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
     for (const [accountId, generations] of this.data) {
       const keep = references.get(accountId);
       if (keep === undefined) {
@@ -52,6 +65,7 @@ export class MemoryCredentialStore implements CredentialStore {
           generations.delete(generation);
         }
       }
+      signal?.throwIfAborted();
     }
   }
 }
@@ -66,7 +80,13 @@ export class FileCredentialStore implements CredentialStore {
     return document.credentials[accountId]?.[String(generation)] ?? null;
   }
 
-  async putGeneration(accountId: AccountId, generation: number, value: SecretCredential): Promise<void> {
+  async putGeneration(
+    accountId: AccountId,
+    generation: number,
+    value: SecretCredential,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    signal?.throwIfAborted();
     const document = readDocument(this.filePath);
     const account = document.credentials[accountId] ?? {};
     account[String(generation)] = value;
@@ -74,6 +94,7 @@ export class FileCredentialStore implements CredentialStore {
       version: 1,
       credentials: { ...document.credentials, [accountId]: account },
     });
+    signal?.throwIfAborted();
   }
 
   async removeAccount(accountId: AccountId): Promise<void> {
@@ -83,7 +104,8 @@ export class FileCredentialStore implements CredentialStore {
     writeDocument(this.filePath, { version: 1, credentials: next });
   }
 
-  async prune(references: ReadonlyMap<AccountId, number>): Promise<void> {
+  async prune(references: ReadonlyMap<AccountId, number>, signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
     const document = readDocument(this.filePath);
     const next: FileDocument["credentials"] = {};
     for (const [accountId, generation] of references) {
@@ -93,6 +115,7 @@ export class FileCredentialStore implements CredentialStore {
       }
     }
     writeDocument(this.filePath, { version: 1, credentials: next });
+    signal?.throwIfAborted();
   }
 }
 

--- a/src/accounts/device_flow.ts
+++ b/src/accounts/device_flow.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from "node:crypto";
 import { resolveGitHubEnvironment, type GitHubEnvironment } from "./github_environment.js";
-import type { AccountDirectory } from "./account_directory.js";
+import {
+  AccountDirectoryError,
+  AccountDirectoryPostCommitError,
+  type AccountDirectory,
+} from "./account_directory.js";
 import type { SecretCredential } from "./credential_store.js";
 
 export const MAX_DEVICE_FLOWS = 8;
 export const DEVICE_FLOW_TTL_MS = 15 * 60 * 1000;
+export const DEVICE_FLOW_TERMINAL_TTL_MS = 60_000;
 
 export interface DeviceOAuthClient {
   requestDeviceCode(environment: GitHubEnvironment, signal?: AbortSignal): Promise<{
@@ -14,15 +19,28 @@ export interface DeviceOAuthClient {
     readonly intervalSec: number;
     readonly expiresInSec: number;
   }>;
-  exchangeDeviceCode(environment: GitHubEnvironment, deviceCode: string, signal?: AbortSignal): Promise<
+  exchangeDeviceCode(
+    environment: GitHubEnvironment,
+    deviceCode: string,
+    signal?: AbortSignal,
+  ): Promise<
     | { readonly status: "pending" }
+    | { readonly status: "slow_down"; readonly pollIntervalSeconds?: number }
+    | { readonly status: "expired" }
+    | { readonly status: "denied" }
     | { readonly status: "failed" }
     | {
         readonly status: "complete";
         readonly accessToken: string;
         readonly user: { readonly id: string | number; readonly login: string; readonly name?: string };
       }
+    | { readonly status: "authorized"; readonly accessToken: string }
   >;
+  fetchUser?(
+    environment: GitHubEnvironment,
+    accessToken: string,
+    signal?: AbortSignal,
+  ): Promise<{ readonly id: string | number; readonly login: string; readonly name?: string }>;
 }
 
 export interface DeviceFlowSnapshot {
@@ -31,6 +49,7 @@ export interface DeviceFlowSnapshot {
   readonly verificationUri: string;
   readonly expiresAtMs: number;
   readonly pollIntervalSeconds: number;
+  readonly nextPollAtMs: number;
 }
 
 export class DeviceFlowError extends Error {
@@ -43,117 +62,525 @@ export class DeviceFlowError extends Error {
   }
 }
 
-interface PendingFlow extends DeviceFlowSnapshot {
+interface PendingFlow {
+  readonly kind: "pending";
+  readonly flowId: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  expiresAtMs: number;
+  pollIntervalSeconds: number;
+  nextPollAtMs: number;
   readonly environment: GitHubEnvironment;
   readonly deviceCode: string;
+  authorized: {
+    readonly accessToken: string;
+    user?: { readonly id: string | number; readonly login: string; readonly name?: string };
+  } | null;
+  readonly cancellation: AbortController;
+  readonly settlement: AbortController;
+  expiryTimer: ReturnType<typeof setTimeout> | null;
 }
 
+interface TerminalFlow {
+  readonly kind: "terminal";
+  readonly flowId: string;
+  readonly expiresAtMs: number;
+  readonly status: "complete" | "expired" | "denied" | "failed";
+  readonly accountId?: string;
+  expiryTimer: ReturnType<typeof setTimeout> | null;
+}
+
+type DeviceFlowState = PendingFlow | TerminalFlow;
+
+export interface DeviceFlowPending {
+  readonly status: "pending";
+  readonly pollIntervalSeconds: number;
+  readonly nextPollAtMs: number;
+}
+
+export type DeviceFlowCancelResult =
+  | { readonly status: "canceled" | "not_found" }
+  | { readonly status: "complete"; readonly accountId: string };
+
 export class DeviceFlowService {
-  private readonly flows = new Map<string, PendingFlow>();
+  private readonly flows = new Map<string, DeviceFlowState>();
   private readonly pollingFlows = new Set<string>();
+  private readonly settlements = new Map<string, Promise<DeviceFlowCancelResult>>();
+  private readonly startingControllers = new Set<AbortController>();
+  private readonly forceCloseController = new AbortController();
   private startingFlows = 0;
+  private closed = false;
+  private forceClosed = false;
 
   constructor(
     private readonly directory: AccountDirectory,
     private readonly oauth: DeviceOAuthClient,
     private readonly nowMs: () => number = Date.now,
+    private readonly timers: {
+      readonly setTimeout: typeof setTimeout;
+      readonly clearTimeout: typeof clearTimeout;
+    } = { setTimeout, clearTimeout },
   ) {}
 
   async start(host: string, signal?: AbortSignal): Promise<DeviceFlowSnapshot> {
+    throwIfClosed(this.closed);
     throwIfAborted(signal);
     this.gc();
-    if (this.flows.size + this.startingFlows >= MAX_DEVICE_FLOWS) {
+    if (this.activeFlowCount() + this.startingFlows >= MAX_DEVICE_FLOWS) {
       throw new DeviceFlowError("capacity", "too many active device flows");
     }
     const environment = resolveGitHubEnvironment(host);
+    const startingController = new AbortController();
+    const operationSignal = signal === undefined
+      ? startingController.signal
+      : AbortSignal.any([signal, startingController.signal]);
+    this.startingControllers.add(startingController);
+    const startTimer = this.timers.setTimeout(
+      () => startingController.abort(),
+      DEVICE_FLOW_TTL_MS,
+    );
     this.startingFlows += 1;
     let requested: Awaited<ReturnType<DeviceOAuthClient["requestDeviceCode"]>>;
     try {
-      requested = await this.oauth.requestDeviceCode(environment, signal);
+      requested = await this.oauth.requestDeviceCode(environment, operationSignal);
     } finally {
+      this.timers.clearTimeout(startTimer);
+      this.startingControllers.delete(startingController);
       this.startingFlows -= 1;
     }
-    throwIfAborted(signal);
+    throwIfAborted(operationSignal);
     const flowId = randomUUID();
+    const startedAtMs = this.nowMs();
+    const pollIntervalSeconds = Math.max(1, requested.intervalSec);
+    const expiresAtMs = startedAtMs + Math.min(requested.expiresInSec * 1000, DEVICE_FLOW_TTL_MS);
     const snapshot: PendingFlow = {
+      kind: "pending",
       flowId,
       environment,
       deviceCode: requested.deviceCode,
+      authorized: null,
       userCode: requested.userCode,
       verificationUri: requested.verificationUri,
-      expiresAtMs: this.nowMs() + Math.min(requested.expiresInSec * 1000, DEVICE_FLOW_TTL_MS),
-      pollIntervalSeconds: Math.max(1, requested.intervalSec),
+      expiresAtMs,
+      pollIntervalSeconds,
+      nextPollAtMs: Math.min(expiresAtMs, startedAtMs + pollIntervalSeconds * 1000),
+      cancellation: new AbortController(),
+      settlement: new AbortController(),
+      expiryTimer: null,
     };
     this.flows.set(flowId, snapshot);
+    snapshot.expiryTimer = this.timers.setTimeout(() => {
+      const current = this.flows.get(flowId);
+      if (current?.kind === "pending") {
+        current.cancellation.abort();
+        current.settlement.abort();
+        if (!this.pollingFlows.has(flowId)) this.rememberTerminal(flowId, "expired");
+      }
+    }, Math.max(0, expiresAtMs - this.nowMs()));
     return {
       flowId,
       userCode: snapshot.userCode,
       verificationUri: snapshot.verificationUri,
       expiresAtMs: snapshot.expiresAtMs,
       pollIntervalSeconds: snapshot.pollIntervalSeconds,
+      nextPollAtMs: snapshot.nextPollAtMs,
     };
   }
 
   async poll(flowId: string, signal?: AbortSignal): Promise<
-    | { readonly status: "pending" }
+    | DeviceFlowPending
     | { readonly status: "expired" }
+    | { readonly status: "denied" }
     | { readonly status: "failed" }
     | { readonly status: "complete"; readonly accountId: string }
   > {
+    throwIfClosed(this.closed);
     throwIfAborted(signal);
-    const flow = this.flows.get(flowId);
-    if (flow === undefined) {
+    const state = this.flows.get(flowId);
+    if (state === undefined) {
       throw new DeviceFlowError("not_found", "device flow not found");
     }
-    if (flow.expiresAtMs <= this.nowMs()) {
-      this.flows.delete(flowId);
+    const now = this.nowMs();
+    if (state.kind === "terminal") {
+      if (state.expiresAtMs <= now) {
+        this.removeFlow(flowId, state);
+        throw new DeviceFlowError("not_found", "device flow not found");
+      }
+      return state.status === "complete"
+        ? { status: "complete", accountId: requireTerminalAccountId(state) }
+        : { status: state.status };
+    }
+    if (state.expiresAtMs <= now) {
+      if (this.pollingFlows.has(flowId)) {
+        return pending(state, now + 1_000);
+      }
+      this.rememberTerminal(flowId, "expired");
       return { status: "expired" };
     }
+    const flow = state;
     if (this.pollingFlows.has(flowId)) {
-      return { status: "pending" };
+      return pending(flow, Math.max(
+        flow.nextPollAtMs,
+        now + flow.pollIntervalSeconds * 1000,
+      ));
     }
+    if (flow.nextPollAtMs > now) {
+      return pending(flow);
+    }
+    const exchangeStartedAtMs = now;
+    flow.nextPollAtMs = Math.min(flow.expiresAtMs, exchangeStartedAtMs + flow.pollIntervalSeconds * 1000);
     this.pollingFlows.add(flowId);
+    const operationSignal = signal === undefined
+      ? flow.cancellation.signal
+      : AbortSignal.any([signal, flow.cancellation.signal]);
+    let settle = (_result: DeviceFlowCancelResult): void => undefined;
+    let settled = false;
+    const settlement = new Promise<DeviceFlowCancelResult>((resolve) => { settle = resolve; });
+    this.settlements.set(flowId, settlement);
+    const settleOnce = (result: DeviceFlowCancelResult): void => {
+      if (settled) return;
+      settled = true;
+      settle(result);
+    };
     try {
-      const result = await this.oauth.exchangeDeviceCode(flow.environment, flow.deviceCode, signal);
-      throwIfAborted(signal);
-      if (result.status === "pending") {
-        return { status: "pending" };
+      let result: Awaited<ReturnType<DeviceOAuthClient["exchangeDeviceCode"]>>;
+      if (flow.authorized?.user !== undefined) {
+        result = {
+          status: "complete",
+          accessToken: flow.authorized.accessToken,
+          user: flow.authorized.user,
+        };
+      } else if (flow.authorized !== null) {
+        const user = await this.fetchAuthorizedUser(flow);
+        flow.authorized.user = user;
+        result = { status: "complete", accessToken: flow.authorized.accessToken, user };
+      } else {
+        result = await this.oauth.exchangeDeviceCode(
+          flow.environment,
+          flow.deviceCode,
+          operationSignal,
+        );
+        if (result.status === "authorized") {
+          flow.authorized = { accessToken: result.accessToken };
+          this.extendAuthorizedSettlement(flow);
+          const user = await this.fetchAuthorizedUser(flow);
+          flow.authorized.user = user;
+          result = { status: "complete", accessToken: flow.authorized.accessToken, user };
+        }
       }
-      if (result.status === "failed") {
-        this.flows.delete(flowId);
+      if (result.status === "complete" && flow.authorized === null) {
+        flow.authorized = { accessToken: result.accessToken, user: result.user };
+        this.extendAuthorizedSettlement(flow);
+      }
+      if (result.status !== "complete") {
+        throwIfAborted(operationSignal);
+        if (this.flows.get(flowId) !== flow) {
+          throw new DeviceFlowError("not_found", "device flow not found");
+        }
+        if (flow.expiresAtMs <= this.nowMs()) {
+          this.rememberTerminal(flowId, "expired");
+          return { status: "expired" };
+        }
+        if (result.status === "pending") {
+          return pending(flow);
+        }
+        if (result.status === "slow_down") {
+          flow.pollIntervalSeconds = Math.max(
+            flow.pollIntervalSeconds + 5,
+            result.pollIntervalSeconds ?? 0,
+          );
+          flow.nextPollAtMs = Math.min(
+            flow.expiresAtMs,
+            exchangeStartedAtMs + flow.pollIntervalSeconds * 1000,
+          );
+          return pending(flow);
+        }
+        if (result.status === "expired" || result.status === "denied") {
+          this.rememberTerminal(flowId, result.status);
+          return { status: result.status };
+        }
+        this.rememberTerminal(flowId, "failed");
         return { status: "failed" };
       }
-      const secret: SecretCredential = { generation: 0, githubToken: result.accessToken };
-      const bound = await this.directory.upsertAuthenticated({
-        host: flow.environment.host,
-        userId: result.user.id,
-        login: result.user.login,
-        ...(result.user.name === undefined ? {} : { displayName: result.user.name }),
-        secret,
-      }, signal);
-      this.flows.delete(flowId);
-      return { status: "complete", accountId: bound.accountId };
+
+      if (this.closed && flow.settlement.signal.aborted) throwIfClosed(true);
+      for (;;) {
+        try {
+          const secret: SecretCredential = { generation: 0, githubToken: result.accessToken };
+          const bound = await this.directory.upsertAuthenticated({
+            host: flow.environment.host,
+            userId: result.user.id,
+            login: result.user.login,
+            ...(result.user.name === undefined ? {} : { displayName: result.user.name }),
+            secret,
+          }, flow.settlement.signal);
+          this.rememberTerminal(flowId, "complete", bound.accountId);
+          const complete = { status: "complete" as const, accountId: bound.accountId };
+          settleOnce(complete);
+          return complete;
+        } catch (error: unknown) {
+          if (error instanceof AccountDirectoryPostCommitError) {
+            await this.retryPostCommitCleanup(error, flow.settlement.signal);
+            this.rememberTerminal(flowId, "complete", error.accountId);
+            const complete = { status: "complete" as const, accountId: error.accountId };
+            settleOnce(complete);
+            return complete;
+          }
+          if (error instanceof AccountDirectoryError) throw error;
+          await this.waitForAuthorizedRetry(flow, error);
+        }
+      }
+    } catch (error: unknown) {
+      if (isPermanentOAuthError(error)) {
+        this.rememberTerminal(flowId, "failed");
+        return { status: "failed" };
+      }
+      if (this.nowMs() >= flow.expiresAtMs && operationSignal.aborted) {
+        this.rememberTerminal(flowId, "expired");
+        return { status: "expired" };
+      }
+      throw error;
     } finally {
+      settleOnce({ status: "canceled" });
+      this.settlements.delete(flowId);
       this.pollingFlows.delete(flowId);
     }
   }
 
-  cancel(flowId: string): void {
-    this.flows.delete(flowId);
+  async cancel(flowId: string): Promise<DeviceFlowCancelResult> {
+    const flow = this.flows.get(flowId);
+    if (flow === undefined) return { status: "not_found" };
+    if (flow.kind === "terminal" && flow.status === "complete") {
+      return { status: "complete", accountId: requireTerminalAccountId(flow) };
+    }
+    const settlement = this.settlements.get(flowId);
+    if (settlement !== undefined && flow.kind === "pending") {
+      flow.cancellation.abort();
+      const result = await settlement;
+      if (result.status !== "complete" && this.flows.get(flowId) === flow) {
+        this.removeFlow(flowId, flow);
+      }
+      return result;
+    }
+    this.removeFlow(flowId, flow);
+    return { status: "canceled" };
+  }
+
+  has(flowId: string): boolean {
+    return this.flows.has(flowId);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    for (const controller of this.startingControllers) controller.abort();
+    this.startingControllers.clear();
+    for (const [flowId, flow] of this.flows) {
+      if (
+        flow.kind === "pending"
+        && flow.authorized !== null
+        && this.settlements.has(flowId)
+      ) {
+        flow.cancellation.abort();
+        if (flow.expiryTimer !== null) {
+          this.timers.clearTimeout(flow.expiryTimer);
+          flow.expiryTimer = null;
+        }
+      } else {
+        this.removeFlow(flowId, flow);
+      }
+    }
+    if (this.settlements.size > 0) {
+      let onForceClose = (): void => undefined;
+      await Promise.race([
+        Promise.allSettled(this.settlements.values()),
+        new Promise<void>((resolve) => {
+          onForceClose = resolve;
+          this.forceCloseController.signal.addEventListener("abort", onForceClose, { once: true });
+        }),
+      ]).finally(() => this.forceCloseController.signal.removeEventListener("abort", onForceClose));
+    }
+    for (const [flowId, flow] of this.flows) this.removeFlow(flowId, flow);
+  }
+
+  forceClose(): void {
+    if (this.forceClosed) return;
+    this.forceClosed = true;
+    this.forceCloseController.abort();
+    this.closed = true;
+    for (const controller of this.startingControllers) controller.abort();
+    this.startingControllers.clear();
+    for (const [flowId, flow] of this.flows) {
+      this.removeFlow(flowId, flow);
+    }
   }
 
   private gc(): void {
     const now = this.nowMs();
     for (const [flowId, flow] of this.flows) {
-      if (flow.expiresAtMs <= now) {
-        this.flows.delete(flowId);
+      if (flow.kind === "pending" && flow.expiresAtMs <= now) {
+        this.rememberTerminal(flowId, "expired");
+      } else if (flow.kind === "terminal" && flow.expiresAtMs <= now) {
+        this.removeFlow(flowId, flow);
       }
     }
   }
+
+  private activeFlowCount(): number {
+    let count = 0;
+    for (const flow of this.flows.values()) {
+      if (flow.kind === "pending") count += 1;
+    }
+    return count;
+  }
+
+  private async fetchAuthorizedUser(flow: PendingFlow): Promise<{
+    readonly id: string | number;
+    readonly login: string;
+    readonly name?: string;
+  }> {
+    for (;;) {
+      try {
+        if (this.oauth.fetchUser === undefined || flow.authorized === null) {
+          throw new Error("device OAuth client cannot resolve an authorized user");
+        }
+
+        return await this.oauth.fetchUser(
+          flow.environment,
+          flow.authorized.accessToken,
+          flow.settlement.signal,
+        );
+      } catch (error: unknown) {
+        if (isPermanentOAuthError(error)) throw error;
+        await this.waitForAuthorizedRetry(flow, error);
+      }
+    }
+  }
+
+  private extendAuthorizedSettlement(flow: PendingFlow): void {
+    if (flow.expiryTimer !== null) this.timers.clearTimeout(flow.expiryTimer);
+    flow.expiresAtMs += DEVICE_FLOW_TERMINAL_TTL_MS;
+    flow.expiryTimer = this.timers.setTimeout(() => {
+      flow.cancellation.abort();
+      flow.settlement.abort();
+    }, Math.max(0, flow.expiresAtMs - this.nowMs()));
+  }
+
+  private async waitForAuthorizedRetry(flow: PendingFlow, error: unknown): Promise<void> {
+    if (flow.settlement.signal.aborted || this.nowMs() >= flow.expiresAtMs) throw error;
+    const delayMs = Math.min(
+      Math.max(flow.pollIntervalSeconds * 1000, oauthRetryAfterMs(error)),
+      Math.max(1, flow.expiresAtMs - this.nowMs()),
+    );
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = (): void => {
+        this.timers.clearTimeout(timer);
+        flow.settlement.signal.removeEventListener("abort", onAbort);
+        reject(flow.settlement.signal.reason);
+      };
+      const timer = this.timers.setTimeout(() => {
+        flow.settlement.signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, delayMs);
+      flow.settlement.signal.addEventListener("abort", onAbort, { once: true });
+      if (flow.settlement.signal.aborted) onAbort();
+    });
+  }
+
+  private async retryPostCommitCleanup(
+    error: AccountDirectoryPostCommitError,
+    signal: AbortSignal,
+  ): Promise<void> {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        await error.retryCleanup(signal);
+        return;
+      } catch {
+        // The account commit is authoritative; startup reconciliation retries any remaining cleanup.
+      }
+    }
+  }
+
+  private rememberTerminal(
+    flowId: string,
+    status: TerminalFlow["status"],
+    accountId?: string,
+  ): void {
+    if (this.closed) return;
+    const current = this.flows.get(flowId);
+    if (current !== undefined) this.removeFlow(flowId, current);
+    const terminals = [...this.flows.entries()].filter((entry) => entry[1].kind === "terminal");
+    if (terminals.length >= MAX_DEVICE_FLOWS) {
+      const oldest = terminals[0];
+      if (oldest !== undefined) this.removeFlow(oldest[0], oldest[1]);
+    }
+    const terminal: TerminalFlow = {
+      kind: "terminal",
+      flowId,
+      expiresAtMs: this.nowMs() + DEVICE_FLOW_TERMINAL_TTL_MS,
+      status,
+      ...(accountId === undefined ? {} : { accountId }),
+      expiryTimer: null,
+    };
+    this.flows.set(flowId, terminal);
+    terminal.expiryTimer = this.timers.setTimeout(() => {
+      if (this.flows.get(flowId) === terminal) this.removeFlow(flowId, terminal);
+    }, DEVICE_FLOW_TERMINAL_TTL_MS);
+  }
+
+  private removeFlow(flowId: string, flow: DeviceFlowState): void {
+    this.flows.delete(flowId);
+    if (flow.expiryTimer !== null) {
+      this.timers.clearTimeout(flow.expiryTimer);
+      flow.expiryTimer = null;
+    }
+    if (flow.kind === "pending") flow.cancellation.abort();
+    if (flow.kind === "pending") flow.settlement.abort();
+  }
+}
+
+function pending(flow: PendingFlow, nextPollAtMs = flow.nextPollAtMs): DeviceFlowPending {
+  return {
+    status: "pending",
+    pollIntervalSeconds: flow.pollIntervalSeconds,
+    nextPollAtMs,
+  };
+}
+
+function requireTerminalAccountId(flow: TerminalFlow): string {
+  if (flow.accountId === undefined) {
+    throw new Error("completed device flow is missing its account");
+  }
+  return flow.accountId;
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted === true) {
     throw new DOMException("aborted", "AbortError");
   }
+}
+
+function throwIfClosed(closed: boolean): void {
+  if (closed) {
+    throw new DOMException("closed", "AbortError");
+  }
+}
+
+function isPermanentOAuthError(error: unknown): boolean {
+  return error !== null
+    && typeof error === "object"
+    && "code" in error
+    && error.code === "remote_error"
+    && "retryable" in error
+    && error.retryable === false;
+}
+
+function oauthRetryAfterMs(error: unknown): number {
+  return error !== null
+    && typeof error === "object"
+    && "retryAfterMs" in error
+    && typeof error.retryAfterMs === "number"
+    && Number.isFinite(error.retryAfterMs)
+    ? Math.max(0, error.retryAfterMs)
+    : 0;
 }

--- a/src/accounts/device_oauth.ts
+++ b/src/accounts/device_oauth.ts
@@ -5,7 +5,10 @@ const DEVICE_OAUTH_RESPONSE_BYTES = 1_048_576;
 export class DeviceOAuthError extends Error {
   readonly code = "remote_error";
 
-  constructor() {
+  constructor(
+    readonly retryable = true,
+    readonly retryAfterMs: number | null = null,
+  ) {
     super("remote error");
     this.name = "DeviceOAuthError";
   }
@@ -68,8 +71,20 @@ export class HttpDeviceOAuthClient implements DeviceOAuthClient {
       throw new DeviceOAuthError();
     }
     const value = await readJsonObject(response, signal);
-    if (value.error === "authorization_pending" || value.error === "slow_down") {
+    if (value.error === "authorization_pending") {
       return { status: "pending" } as const;
+    }
+    if (value.error === "slow_down") {
+      return {
+        status: "slow_down",
+        ...(positiveNumber(value.interval) ? { pollIntervalSeconds: value.interval } : {}),
+      } as const;
+    }
+    if (value.error === "expired_token") {
+      return { status: "expired" } as const;
+    }
+    if (value.error === "access_denied") {
+      return { status: "denied" } as const;
     }
     if (typeof value.error === "string") {
       return { status: "failed" } as const;
@@ -77,29 +92,37 @@ export class HttpDeviceOAuthClient implements DeviceOAuthClient {
     if (!nonemptyString(value.access_token)) {
       throw new DeviceOAuthError();
     }
+    return { status: "authorized" as const, accessToken: value.access_token };
+  }
+
+  async fetchUser(
+    environment: Parameters<NonNullable<DeviceOAuthClient["fetchUser"]>>[0],
+    accessToken: string,
+    signal?: AbortSignal,
+  ) {
     const userUrl = new URL(environment.apiBaseUrl);
     userUrl.pathname = `${userUrl.pathname.replace(/\/$/u, "")}/user`;
     const userResponse = await this.fetch(userUrl, {
-      headers: { accept: "application/vnd.github+json", authorization: `Bearer ${value.access_token}` },
+      headers: { accept: "application/vnd.github+json", authorization: `Bearer ${accessToken}` },
       ...(signal === undefined ? {} : { signal }),
     }, signal);
     if (!userResponse.ok) {
+      const retryAfterMs = rateLimitDelayMs(userResponse.headers);
+      const retryable = userResponse.status === 429
+        || userResponse.status >= 500
+        || (userResponse.status === 403 && retryAfterMs !== null);
       await cancelResponse(userResponse);
-      throw new DeviceOAuthError();
+      throw new DeviceOAuthError(retryable, retryAfterMs);
     }
     const user = await readJsonObject(userResponse, signal);
     if ((typeof user.id !== "string" && typeof user.id !== "number")
       || !nonemptyString(user.login)) {
-      throw new DeviceOAuthError();
+      throw new DeviceOAuthError(false);
     }
     return {
-      status: "complete" as const,
-      accessToken: value.access_token,
-      user: {
-        id: user.id,
-        login: user.login,
-        ...(typeof user.name === "string" ? { name: user.name } : {}),
-      },
+      id: user.id,
+      login: user.login,
+      ...(typeof user.name === "string" ? { name: user.name } : {}),
     };
   }
 
@@ -192,4 +215,19 @@ function positiveNumber(value: unknown): value is number {
 
 function nonemptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
+}
+
+function rateLimitDelayMs(headers: Headers): number | null {
+  const retryAfter = headers.get("retry-after");
+  if (retryAfter !== null) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+    const date = Date.parse(retryAfter);
+    if (Number.isFinite(date)) return Math.max(0, date - Date.now());
+  }
+  if (headers.get("x-ratelimit-remaining") === "0") {
+    const resetSeconds = Number(headers.get("x-ratelimit-reset"));
+    if (Number.isFinite(resetSeconds)) return Math.max(0, resetSeconds * 1000 - Date.now());
+  }
+  return null;
 }

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -1,3 +1,4 @@
+import type { DeviceFlowCancelResult } from "../accounts/device_flow.js";
 import type { RuntimeConfigSnapshot } from "../config/schema.js";
 import { RUNTIME_CONFIG_RANGES } from "../config/schema.js";
 import type { GatewayActivity } from "../gateway/create_gateway.js";
@@ -151,12 +152,38 @@ export interface AdminDeviceFlows {
     readonly verificationUri: string;
     readonly expiresAtMs: number;
     readonly pollIntervalSeconds: number;
+    readonly nextPollAtMs: number;
   }>;
   poll(flowId: string, signal?: AbortSignal): Promise<
-    | { readonly status: "pending" | "expired" | "failed" }
+    | {
+        readonly status: "pending";
+        readonly pollIntervalSeconds: number;
+        readonly nextPollAtMs: number;
+      }
+    | { readonly status: "expired" | "denied" | "failed" }
     | { readonly status: "complete"; readonly accountId: string }
   >;
+  cancel(flowId: string): Promise<DeviceFlowCancelResult>;
+  has(flowId: string): boolean;
 }
+
+export interface AdminDeviceFlow {
+  readonly flowId: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly expiresAt: string;
+  readonly pollIntervalSeconds: number;
+  readonly nextPollAt: string;
+}
+
+export type AdminDeviceFlowPoll =
+  | {
+      readonly state: "pending";
+      readonly pollIntervalSeconds: number;
+      readonly nextPollAt: string;
+    }
+  | { readonly state: "expired" | "denied" | "failed" }
+  | { readonly state: "complete"; readonly account: AdminAccount };
 
 export interface AdminCatalog {
   get(accountId: string, signal: AbortSignal): Promise<{
@@ -281,34 +308,52 @@ export class AdminManagementApi {
     };
   }
 
-  async startDeviceFlow(host: string, signal: AbortSignal): Promise<{
-    readonly flowId: string;
-    readonly userCode: string;
-    readonly verificationUri: string;
-    readonly expiresAt: string;
-    readonly pollIntervalSeconds: number;
-  }> {
+  async startDeviceFlow(host: string, signal: AbortSignal): Promise<AdminDeviceFlow> {
     const flow = await this.dependencies.deviceFlows.start(host, signal);
-    signal.throwIfAborted();
+    try {
+      signal.throwIfAborted();
+    } catch (error: unknown) {
+      await this.dependencies.deviceFlows.cancel(flow.flowId);
+      throw error;
+    }
     return {
       flowId: flow.flowId,
       userCode: flow.userCode,
       verificationUri: flow.verificationUri,
       expiresAt: toIso(flow.expiresAtMs),
       pollIntervalSeconds: flow.pollIntervalSeconds,
+      nextPollAt: toIso(flow.nextPollAtMs),
     };
   }
 
-  async pollDeviceFlow(flowId: string, signal: AbortSignal): Promise<
-    | { readonly state: "pending" | "expired" | "failed" }
-    | { readonly state: "complete"; readonly account: AdminAccount }
-  > {
+  async pollDeviceFlow(flowId: string, signal: AbortSignal): Promise<AdminDeviceFlowPoll> {
     const result = await this.dependencies.deviceFlows.poll(flowId, signal);
     signal.throwIfAborted();
+    if (result.status === "pending") {
+      return {
+        state: "pending",
+        pollIntervalSeconds: result.pollIntervalSeconds,
+        nextPollAt: toIso(result.nextPollAtMs),
+      };
+    }
     if (result.status !== "complete") {
       return { state: result.status };
     }
     return { state: "complete", account: this.account(this.requireAccount(result.accountId)) };
+  }
+
+  async cancelDeviceFlow(flowId: string): Promise<
+    | { readonly state: "canceled" | "not_found" }
+    | { readonly state: "complete"; readonly account: AdminAccount }
+  > {
+    const result = await this.dependencies.deviceFlows.cancel(flowId);
+    return result.status === "complete"
+      ? { state: "complete", account: this.account(this.requireAccount(result.accountId)) }
+      : { state: result.status };
+  }
+
+  hasDeviceFlow(flowId: string): boolean {
+    return this.dependencies.deviceFlows.has(flowId);
   }
 
   async removeAccount(accountId: string, expectedRevision: number, signal: AbortSignal): Promise<AdminAccount> {

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -1,5 +1,6 @@
 import { Type, type Static, type TSchema } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
+import { DEVICE_FLOW_TERMINAL_TTL_MS } from "../accounts/device_flow.js";
 import { RuntimeConfigSchema } from "../config/schema.js";
 import type {
   AdminBootstrapResult,
@@ -63,6 +64,13 @@ export function createAdminModule(dependencies: Readonly<AdminModuleDependencies
     dependencies.setTimeout,
     dependencies.clearTimeout,
   );
+  const flowOwners = new AdminDeviceFlowOwners(
+    auth,
+    api,
+    dependencies.setTimeout,
+    dependencies.clearTimeout,
+    dependencies.nowMs,
+  );
   const eventHub = new AdminEventStreamHub(
     dependencies.telemetry,
     api,
@@ -78,7 +86,16 @@ export function createAdminModule(dependencies: Readonly<AdminModuleDependencies
       }
       try {
         const bodyLimit = dependencies.runtimeConfig.read().config.limits.requestBodyBytes;
-        return await dispatch(request, context, bodyLimit, auth, api, eventHub, dependencies.nowMs ?? Date.now);
+        return await dispatch(
+          request,
+          context,
+          bodyLimit,
+          auth,
+          api,
+          flowOwners,
+          eventHub,
+          dependencies.nowMs ?? Date.now,
+        );
       } catch (error: unknown) {
         if (context.signal.aborted || (error instanceof DOMException && error.name === "AbortError")) {
           return new Response(null);
@@ -95,6 +112,7 @@ export function createAdminModule(dependencies: Readonly<AdminModuleDependencies
       }
       closed = true;
       eventHub.close();
+      flowOwners.close();
       auth.close();
     },
   };
@@ -106,6 +124,7 @@ async function dispatch(
   bodyLimit: number,
   auth: AdminAuth,
   api: AdminManagementApi,
+  flowOwners: AdminDeviceFlowOwners,
   events: AdminEventStreamHub,
   nowMs: () => number,
 ): Promise<Response> {
@@ -162,17 +181,33 @@ async function dispatch(
     break;
   case "deviceStart": {
     const value = checked(DeviceFlowStartSchema, body);
-    response = success(await api.startDeviceFlow(value.host, context.signal), context.requestId, 201);
+    const flow = await api.startDeviceFlow(value.host, context.signal);
+    flowOwners.own(session.sessionId, flow.flowId, Date.parse(flow.expiresAt));
+    if (context.signal.aborted) {
+      await flowOwners.cancel(session.sessionId, flow.flowId);
+      context.signal.throwIfAborted();
+    }
+    response = success(flow, context.requestId, 201);
     break;
   }
-  case "devicePoll":
-    response = success(await api.pollDeviceFlow(route.parameter, context.signal), context.requestId);
+  case "devicePoll": {
+    flowOwners.requireOwner(session.sessionId, route.parameter);
+    const result = await api.pollDeviceFlow(route.parameter, context.signal);
+    if (result.state !== "pending") {
+      flowOwners.retainTerminal(route.parameter);
+    }
+    response = success(result, context.requestId);
+    break;
+  }
+  case "deviceCancel":
+    response = success(await flowOwners.cancel(session.sessionId, route.parameter), context.requestId);
     break;
   case "accountDelete": {
     const value = checked(ExpectedRevisionSchema, body);
     response = success(await api.removeAccount(route.parameter, value.expectedRevision, context.signal), context.requestId);
     break;
   }
+
   case "accountDefault": {
     const value = checked(DefaultAccountSchema, body);
     response = success(await api.useDefaultAccount(value.accountId, value.expectedRevision, context.signal), context.requestId);
@@ -226,8 +261,95 @@ async function dispatch(
   return response;
 }
 
+class AdminDeviceFlowOwners {
+  private readonly flows = new Map<string, {
+    readonly sessionId: string;
+    readonly unsubscribe: () => void;
+    expiryTimer: ReturnType<typeof setTimeout>;
+  }>();
+
+  constructor(
+    private readonly auth: AdminAuth,
+    private readonly api: AdminManagementApi,
+    private readonly setTimer: typeof setTimeout = setTimeout,
+    private readonly clearTimer: typeof clearTimeout = clearTimeout,
+    private readonly nowMs: () => number = Date.now,
+  ) {}
+
+  own(sessionId: string, flowId: string, expiresAtMs: number): void {
+    for (const ownedFlowId of this.flows.keys()) {
+      if (!this.api.hasDeviceFlow(ownedFlowId)) this.release(ownedFlowId);
+    }
+    try {
+      const unsubscribe = this.auth.watchSession(sessionId, () => {
+        void this.api.cancelDeviceFlow(flowId).then(
+          () => this.release(flowId, false),
+          () => this.release(flowId, false),
+        );
+      });
+      const expiryTimer = this.setTimer(() => {
+        void this.api.cancelDeviceFlow(flowId).then(
+          () => this.release(flowId),
+          () => this.release(flowId),
+        );
+      }, Math.max(0, expiresAtMs + DEVICE_FLOW_TERMINAL_TTL_MS - this.nowMs()));
+      this.flows.set(flowId, { sessionId, unsubscribe, expiryTimer });
+    } catch (error: unknown) {
+      void this.api.cancelDeviceFlow(flowId);
+      throw error;
+    }
+  }
+
+  async cancel(sessionId: string, flowId: string): ReturnType<AdminManagementApi["cancelDeviceFlow"]> {
+    this.requireOwner(sessionId, flowId);
+    const result = await this.api.cancelDeviceFlow(flowId);
+    if (result.state === "complete") {
+      this.retainTerminal(flowId);
+    } else {
+      this.release(flowId);
+    }
+    return result;
+  }
+
+  requireOwner(sessionId: string, flowId: string): void {
+    const owner = this.flows.get(flowId);
+    if (owner === undefined) throw new AdminApiError("not_found");
+    if (owner.sessionId !== sessionId) throw new AdminApiError("forbidden");
+  }
+
+  retainTerminal(flowId: string): void {
+    const owner = this.flows.get(flowId);
+    if (owner === undefined) return;
+    this.clearTimer(owner.expiryTimer);
+    owner.expiryTimer = this.setTimer(() => {
+      void this.api.cancelDeviceFlow(flowId).then(
+        () => this.release(flowId),
+        () => this.release(flowId),
+      );
+    }, DEVICE_FLOW_TERMINAL_TTL_MS);
+  }
+
+  release(flowId: string, unsubscribe = true): void {
+    const owner = this.flows.get(flowId);
+    this.flows.delete(flowId);
+    if (owner !== undefined) {
+      this.clearTimer(owner.expiryTimer);
+      if (unsubscribe) owner.unsubscribe();
+    }
+  }
+
+  close(): void {
+    for (const [flowId, owner] of this.flows) {
+      this.clearTimer(owner.expiryTimer);
+      owner.unsubscribe();
+      void this.api.cancelDeviceFlow(flowId);
+    }
+    this.flows.clear();
+  }
+}
+
 type RouteId = "bootstrap" | "session" | "logout" | "status" | "usage" | "accounts" | "deviceStart"
-  | "devicePoll" | "accountDelete" | "accountDefault" | "models" | "modelsRefresh" | "modelsPreferred"
+  | "devicePoll" | "deviceCancel" | "accountDelete" | "accountDefault" | "models" | "modelsRefresh" | "modelsPreferred"
   | "configGet" | "configPut" | "historyGet" | "historyDelete" | "events" | "eventStream";
 
 interface MatchedRoute {
@@ -247,6 +369,9 @@ function matchRoute(method: string, pathname: string): MatchedRoute | null {
   if (method === "GET" && device?.[1] !== undefined) {
     return parameterRoute("devicePoll", device[1], false);
   }
+  if (method === "DELETE" && device?.[1] !== undefined) {
+    return parameterRoute("deviceCancel", device[1], false);
+  }
   const account = /^\/admin\/api\/v1\/accounts\/(.+)$/u.exec(pathname);
   if (method === "DELETE" && account?.[1] !== undefined) {
     return parameterRoute("accountDelete", account[1], true);
@@ -254,7 +379,7 @@ function matchRoute(method: string, pathname: string): MatchedRoute | null {
   return null;
 }
 
-function parameterRoute(id: "devicePoll" | "accountDelete", encoded: string, body: boolean): MatchedRoute {
+function parameterRoute(id: "devicePoll" | "deviceCancel" | "accountDelete", encoded: string, body: boolean): MatchedRoute {
   let parameter: string;
   try {
     parameter = decodeURIComponent(encoded);
@@ -264,7 +389,7 @@ function parameterRoute(id: "devicePoll" | "accountDelete", encoded: string, bod
   if (parameter.length === 0) {
     throw new AdminApiError("validation_failed");
   }
-  return { id, body, mutation: id === "accountDelete", query: new Set(), parameter };
+  return { id, body, mutation: id !== "devicePoll", query: new Set(), parameter };
 }
 
 const ROUTES = new Map<string, Omit<MatchedRoute, "parameter">>([

--- a/src/cli/commands/dispatcher.ts
+++ b/src/cli/commands/dispatcher.ts
@@ -21,7 +21,7 @@ import {
 
 export interface CommandDispatcherDependencies {
   readonly directory: AccountDirectory;
-  readonly deviceFlows: Pick<DeviceFlowService, "start" | "poll">;
+  readonly deviceFlows: Pick<DeviceFlowService, "start" | "poll" | "cancel">;
   readonly catalog: CopilotModelCatalog;
   readonly runtimeConfig: RuntimeConfigStore;
   readonly updateRuntimeConfig?: (
@@ -63,22 +63,37 @@ export class CommandDispatcher {
         verificationUri: started.verificationUri,
         expiresAt: new Date(started.expiresAtMs).toISOString(),
         pollIntervalSeconds: started.pollIntervalSeconds,
+        nextPollAt: new Date(started.nextPollAtMs).toISOString(),
       } as ControlOperationMap[Operation]["result"];
     }
     case "auth.login.poll": {
       const input = args as ControlOperationMap["auth.login.poll"]["args"];
       const result = await this.dependencies.deviceFlows.poll(input.flowId, signal);
       if (result.status === "pending") {
-        return { state: "pending" } as ControlOperationMap[Operation]["result"];
+        return {
+          state: "pending",
+          pollIntervalSeconds: result.pollIntervalSeconds,
+          nextPollAt: new Date(result.nextPollAtMs).toISOString(),
+        } as ControlOperationMap[Operation]["result"];
       }
       if (result.status === "expired") {
         return { state: "expired" } as ControlOperationMap[Operation]["result"];
+      }
+      if (result.status === "denied") {
+        return { state: "denied" } as ControlOperationMap[Operation]["result"];
       }
       if (result.status === "failed") {
         return { state: "failed" } as ControlOperationMap[Operation]["result"];
       }
       const account = this.requireAccount(result.accountId);
       return { state: "complete", account: this.adminAccount(account) } as ControlOperationMap[Operation]["result"];
+    }
+    case "auth.login.cancel": {
+      const input = args as ControlOperationMap["auth.login.cancel"]["args"];
+      const result = await this.dependencies.deviceFlows.cancel(input.flowId);
+      return (result.status === "complete"
+        ? { state: "complete", accountId: result.accountId }
+        : { state: result.status }) as ControlOperationMap[Operation]["result"];
     }
     case "auth.logout": {
       const input = args as ControlOperationMap["auth.logout"]["args"];

--- a/src/cli/control_client.ts
+++ b/src/cli/control_client.ts
@@ -19,6 +19,9 @@ export type CliErrorCode =
   | "revision_conflict"
   | "permission_denied"
   | "security_error"
+  | "authorization_expired"
+  | "authorization_denied"
+  | "authorization_failed"
   | "remote_error"
   | "timeout"
   | "unavailable"
@@ -43,6 +46,9 @@ export const CLI_ERROR_EXIT: Readonly<Record<CliErrorCode, number>> = {
   revision_conflict: 3,
   permission_denied: 4,
   security_error: 4,
+  authorization_expired: 5,
+  authorization_denied: 5,
+  authorization_failed: 5,
   remote_error: 5,
   timeout: 5,
   unavailable: 5,
@@ -61,6 +67,9 @@ export const SAFE_ERROR_MESSAGES: Readonly<Record<CliErrorCode, string>> = {
   revision_conflict: "revision conflict",
   permission_denied: "permission denied",
   security_error: "security error",
+  authorization_expired: "authorization expired",
+  authorization_denied: "authorization denied",
+  authorization_failed: "authorization failed",
   remote_error: "remote error",
   timeout: "timeout",
   unavailable: "gateway unavailable",
@@ -149,13 +158,23 @@ export interface DeviceFlowStartResult {
   readonly verificationUri: string;
   readonly expiresAt: string;
   readonly pollIntervalSeconds: number;
+  readonly nextPollAt?: string;
 }
 
 export type DeviceFlowPollResult =
-  | { readonly state: "pending" }
+  | {
+      readonly state: "pending";
+      readonly pollIntervalSeconds?: number;
+      readonly nextPollAt?: string;
+    }
   | { readonly state: "complete"; readonly account: AdminAccount }
   | { readonly state: "expired" }
+  | { readonly state: "denied" }
   | { readonly state: "failed" };
+
+export type DeviceFlowCancelControlResult =
+  | { readonly state: "canceled" | "not_found" }
+  | { readonly state: "complete"; readonly accountId: string };
 
 export interface ControlOperationMap {
   readonly "auth.login.start": {
@@ -165,6 +184,10 @@ export interface ControlOperationMap {
   readonly "auth.login.poll": {
     readonly args: { readonly flowId: string };
     readonly result: DeviceFlowPollResult;
+  };
+  readonly "auth.login.cancel": {
+    readonly args: { readonly flowId: string };
+    readonly result: DeviceFlowCancelControlResult;
   };
   readonly "auth.logout": {
     readonly args: { readonly accountId?: string };
@@ -325,13 +348,18 @@ export class HttpControlClient implements ControlClient {
     args: ControlOperationMap[Operation]["args"],
     context: CliLifecycleContext,
   ): Promise<ControlOperationMap[Operation]["result"]> {
-    const endpoint = await this.requireEndpoint(context.dataDir);
-    await this.verifyEndpoint(endpoint);
-    const data = await this.controlRequest(endpoint, "POST", "/__ghcg/control/v1/command", {
-      operation,
-      arguments: args,
-    }, context);
-    return data as ControlOperationMap[Operation]["result"];
+    const request = async (): Promise<ControlOperationMap[Operation]["result"]> => {
+      const endpoint = await this.requireEndpoint(context.dataDir);
+      await this.verifyEndpoint(endpoint);
+      const data = await this.controlRequest(endpoint, "POST", "/__ghcg/control/v1/command", {
+        operation,
+        arguments: args,
+      }, context);
+      return data as ControlOperationMap[Operation]["result"];
+    };
+    return context.timeoutMs === undefined
+      ? await request()
+      : await withCliTimeout(request(), context.timeoutMs);
   }
 
   async adminOpen(context: CliLifecycleContext): Promise<CliAdminOpenResult> {
@@ -384,6 +412,20 @@ export class HttpControlClient implements ControlClient {
       }
       throw error;
     }
+  }
+}
+
+async function withCliTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new CliError("timeout")), Math.max(0, timeoutMs));
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -18,6 +18,8 @@ import {
 } from "../daemon/runtime.js";
 import { composeLazyProductionDaemonGateway } from "../daemon/production_gateway.js";
 
+const INTERACTIVE_LOGIN_CLEANUP_TIMEOUT_MS = 1_000;
+
 export interface RunCliOptions {
   readonly argv?: readonly string[];
   readonly env?: NodeJS.ProcessEnv;
@@ -124,24 +126,66 @@ async function runInteractiveLogin(
     dataDir: context.dataDir,
     signal: localSignal.signal,
   };
+  let flowId: string | null = null;
+  let authenticatedAccountId: string | null = null;
+  let failure: unknown = null;
   try {
     const started = await client.request("auth.login.start", args, controlContext);
+    flowId = started.flowId;
     stdout.write(`Code: ${started.userCode}\n`);
     stdout.write(`Open: ${started.verificationUri}\n`);
+    const expiresAtMs = Date.parse(started.expiresAt);
+    let pollIntervalSeconds = started.pollIntervalSeconds;
+    let nextPollAtMs = validDate(started.nextPollAt)
+      ?? Date.now() + pollIntervalSeconds * 1000;
     for (;;) {
+      const delayMs = options.pollDelayMs
+        ?? Math.max(0, Math.min(nextPollAtMs, expiresAtMs) - Date.now());
+      await sleep(delayMs, localSignal.signal);
       const result = await client.request("auth.login.poll", { flowId: started.flowId }, controlContext);
       if (result.state === "complete") {
-        stdout.write(`Authenticated: ${result.account.accountId}\n`);
-        return 0;
+        authenticatedAccountId = result.account.accountId;
+        break;
       }
       if (result.state !== "pending") {
-        throw new CliError("remote_error");
+        throw new CliError(result.state === "expired"
+          ? "authorization_expired"
+          : result.state === "denied"
+            ? "authorization_denied"
+            : "authorization_failed");
       }
-      await sleep(options.pollDelayMs ?? started.pollIntervalSeconds * 1000, localSignal.signal);
+      pollIntervalSeconds = result.pollIntervalSeconds ?? pollIntervalSeconds;
+      nextPollAtMs = validDate(result.nextPollAt)
+        ?? Date.now() + pollIntervalSeconds * 1000;
     }
-  } finally {
-    localSignal.dispose();
+
+  } catch (error: unknown) {
+    failure = error;
   }
+  localSignal.dispose();
+  if (flowId !== null && authenticatedAccountId === null) {
+    try {
+      const canceled = await client.request("auth.login.cancel", { flowId }, {
+        dataDir: context.dataDir,
+        timeoutMs: INTERACTIVE_LOGIN_CLEANUP_TIMEOUT_MS,
+      });
+      if (canceled.state === "complete") authenticatedAccountId = canceled.accountId;
+    } catch (error: unknown) {
+      if (failure === null) failure = error;
+    }
+  }
+  if (authenticatedAccountId !== null) {
+    stdout.write(`Authenticated: ${authenticatedAccountId}\n`);
+    return 0;
+  }
+  if (failure !== null) throw failure;
+  throw new CliError("internal_error");
+}
+
+function validDate(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function processSignal(): { readonly signal: AbortSignal; readonly dispose: () => void } {

--- a/src/daemon/local_control.ts
+++ b/src/daemon/local_control.ts
@@ -22,6 +22,9 @@ const ControlCommandSchema = Type.Union([
   commandSchema("auth.login.poll", Type.Object({
     flowId: Type.String({ minLength: 1 }),
   }, { additionalProperties: false })),
+  commandSchema("auth.login.cancel", Type.Object({
+    flowId: Type.String({ minLength: 1 }),
+  }, { additionalProperties: false })),
   commandSchema("auth.logout", OptionalAccountSchema),
   commandSchema("auth.status", EmptyArgumentsSchema),
   commandSchema("accounts.list", EmptyArgumentsSchema),
@@ -382,6 +385,9 @@ function cliStatus(code: CliErrorCode): number {
   case "daemon_unreachable":
     return 503;
   case "remote_error":
+  case "authorization_expired":
+  case "authorization_denied":
+  case "authorization_failed":
     return 502;
   case "internal_error":
   case "interrupted":

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,6 +230,7 @@ export async function composeProductionDaemonGateway(
   const application = options.application
     ?? await createProductionApplicationContext(composition.startup, composition.env);
   let supplementalTelemetryRuntime: TelemetryRuntime | undefined;
+  let deviceFlows: DeviceFlowService | undefined;
   try {
     const runtime = application.runtime;
     const database = application.database;
@@ -267,7 +268,18 @@ export async function composeProductionDaemonGateway(
       application.history,
       telemetryRecorder,
     );
-    const deviceFlows = new DeviceFlowService(application.directory, new HttpDeviceOAuthClient());
+    deviceFlows = new DeviceFlowService(application.directory, new HttpDeviceOAuthClient());
+    const applicationWithDeviceFlows: ApplicationContext = {
+      ...applicationWithTelemetry,
+      async close() {
+        await deviceFlows?.close();
+        await applicationWithTelemetry.close?.();
+      },
+      forceClose() {
+        deviceFlows?.forceClose();
+        return applicationWithTelemetry.forceClose?.();
+      },
+    };
     const accountCaches = {
       invalidate(accountId: string): void {
         application.catalog.invalidate(accountId);
@@ -322,7 +334,7 @@ export async function composeProductionDaemonGateway(
     return await bootstrapGateway({
       startup: composition.startup,
       env: composition.env,
-      application: applicationWithTelemetry,
+      application: applicationWithDeviceFlows,
       dependencies: {
         admin,
         control,
@@ -338,6 +350,7 @@ export async function composeProductionDaemonGateway(
     });
   } catch (error: unknown) {
     try {
+      await deviceFlows?.close();
       await supplementalTelemetryRuntime?.close();
     } finally {
       await application.close?.();

--- a/tests/contract/admin_api.test.ts
+++ b/tests/contract/admin_api.test.ts
@@ -24,6 +24,31 @@ describe("Admin API", () => {
       expect((await read(harness.gateway, "/admin/api/v1/accounts", session.cookie)).data).toMatchObject({
         defaultRevision: 2, defaultAccountId: "github.com/42", items: [{ numericUserId: "42", preferredModel: null }],
       });
+      const started = await mutate(harness.gateway, "POST", "/admin/api/v1/device-flows", session, {
+        host: "github.com",
+      });
+      expect(await started.json()).toEqual({
+        data: {
+          flowId: "flow-1",
+          userCode: "ABCD-1234",
+          verificationUri: "https://github.com/login/device",
+          expiresAt: "2027-01-15T08:15:00.000Z",
+          pollIntervalSeconds: 5,
+          nextPollAt: "2027-01-15T08:00:05.000Z",
+        },
+      });
+      expect((await read(harness.gateway, "/admin/api/v1/device-flows/flow-1", session.cookie)).data).toEqual({
+        state: "pending",
+        pollIntervalSeconds: 5,
+        nextPollAt: "2027-01-15T08:00:05.000Z",
+      });
+      const canceled = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/device-flows/flow-1`, {
+        method: "DELETE",
+        headers: { cookie: session.cookie, origin: ORIGIN, "x-ghcg-csrf": session.csrf },
+      }));
+      expect(canceled.status).toBe(200);
+      expect(await canceled.json()).toEqual({ data: { state: "canceled" } });
+      expect(harness.dependencies.calls).toContain("device-cancel:flow-1");
       expect((await read(harness.gateway, "/admin/api/v1/models", session.cookie)).data).toMatchObject({
         accountId: "github.com/42", catalogGeneration: 7, items: [{ id: "gpt-test", maxInputTokens: 200_000, maxOutputTokens: 8_192 }],
       });
@@ -198,6 +223,89 @@ describe("Admin API", () => {
       expect((await first).status).toBe(200);
       expect((await third).status).toBe(200);
       expect(calls).toBe(2);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("cancels a flow when its start request aborts before ownership", async () => {
+    const dependencies = adminDependencies();
+    let started = (): void => undefined;
+    let release = (): void => undefined;
+    const startCalled = new Promise<void>((resolve) => { started = resolve; });
+    const startRelease = new Promise<void>((resolve) => { release = resolve; });
+    dependencies.deviceFlows.start = async (...args) => {
+      started();
+      await startRelease;
+      dependencies.calls.push(`device-start:${args[0]}`);
+      return {
+        flowId: "flow-1",
+        userCode: "ABCD-1234",
+        verificationUri: "https://github.com/login/device",
+        expiresAtMs: dependencies.now.value + 900_000,
+        pollIntervalSeconds: 5,
+        nextPollAtMs: dependencies.now.value + 5_000,
+      };
+    };
+    const harness = await createHarness(dependencies);
+    try {
+      const session = await login(harness.gateway, harness.admin);
+      const controller = new AbortController();
+      const request = harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/device-flows`, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          "content-type": "application/json",
+          cookie: session.cookie,
+          origin: ORIGIN,
+          "x-ghcg-csrf": session.csrf,
+        },
+        body: JSON.stringify({ host: "github.com" }),
+      }));
+      await startCalled;
+      controller.abort();
+      release();
+      expect(await (await request).text()).toBe("");
+      expect(dependencies.calls).toContain("device-cancel:flow-1");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("releases provisional ownership when a start aborts after registration", async () => {
+    const dependencies = adminDependencies();
+    const harness = await createHarness(dependencies);
+    try {
+      const session = await login(harness.gateway, harness.admin);
+      expect((await mutate(harness.gateway, "POST", "/admin/api/v1/device-flows", session, {
+        host: "github.com",
+      })).status).toBe(201);
+      dependencies.deviceFlows.start = async () => ({
+        flowId: "flow-2",
+        userCode: "WXYZ-9999",
+        verificationUri: "https://github.com/login/device",
+        expiresAtMs: dependencies.now.value + 900_000,
+        pollIntervalSeconds: 5,
+        nextPollAtMs: dependencies.now.value + 5_000,
+      });
+      const controller = new AbortController();
+      dependencies.deviceFlows.has = () => {
+        controller.abort();
+        return true;
+      };
+      const response = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/device-flows`, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          "content-type": "application/json",
+          cookie: session.cookie,
+          origin: ORIGIN,
+          "x-ghcg-csrf": session.csrf,
+        },
+        body: JSON.stringify({ host: "github.com" }),
+      }));
+      expect(await response.text()).toBe("");
+      expect(dependencies.calls).toContain("device-cancel:flow-2");
     } finally {
       await harness.close();
     }

--- a/tests/contract/admin_auth.test.ts
+++ b/tests/contract/admin_auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createAdminModule } from "../../src/admin/routes.js";
 import type { AdminModule } from "../../src/gateway/create_gateway.js";
 import { createGateway, type Gateway } from "../../src/gateway/create_gateway.js";
@@ -67,12 +67,19 @@ describe("Admin authentication", () => {
     const absolute = await createHarness({ value: 1_800_000_000_000 });
     try {
       const loggedIn = await login(absolute.gateway, absolute.admin);
+      expect((await mutate(
+        absolute.gateway,
+        "/admin/api/v1/device-flows",
+        loggedIn,
+        { host: "github.com" },
+      )).status).toBe(201);
       for (let interval = 1; interval < 36; interval += 1) {
         absolute.dependencies.now.value += 20 * 60_000;
         expect((await session(absolute.gateway, loggedIn.cookie)).status).toBe(200);
       }
       absolute.dependencies.now.value += 20 * 60_000;
       expect((await session(absolute.gateway, loggedIn.cookie)).status).toBe(401);
+      expect(absolute.dependencies.calls).toContain("device-cancel:flow-1");
       absolute.admin.close();
       absolute.admin.close();
       expect(absolute.admin.mintBootstrap()).toEqual({ kind: "closed" });
@@ -94,10 +101,25 @@ describe("Admin authentication", () => {
         origin: "http://127.0.0.1:9999",
       })).status).toBe(403);
       expect((await mutate(harness.gateway, "/admin/api/v1/device-flows", loggedIn, { host: "github.com" })).status).toBe(201);
+      const otherSession = await login(harness.gateway, harness.admin);
+      expect((await get(
+        harness.gateway,
+        "/admin/api/v1/device-flows/flow-1",
+        otherSession.cookie,
+      )).status).toBe(403);
+      expect((await securedRequest(
+        harness.gateway,
+        "DELETE",
+        "/admin/api/v1/device-flows/flow-1",
+        otherSession,
+        undefined,
+        {},
+      )).status).toBe(403);
 
       const mutations = [
         ["POST", "/admin/api/v1/auth/logout", undefined],
         ["POST", "/admin/api/v1/device-flows", { host: "github.com" }],
+        ["DELETE", "/admin/api/v1/device-flows/flow-1", undefined],
         ["DELETE", "/admin/api/v1/accounts/github.com%2F42", { expectedRevision: 3 }],
         ["PUT", "/admin/api/v1/accounts/default", { accountId: "github.com/42", expectedRevision: 2 }],
         ["POST", "/admin/api/v1/models/refresh", { accountId: "github.com/42" }],
@@ -112,6 +134,9 @@ describe("Admin authentication", () => {
         expect(wrongOrigin.status, `${method} ${path} with wrong Origin`).toBe(403);
       }
 
+      expect((await mutate(harness.gateway, "/admin/api/v1/device-flows", loggedIn, {
+        host: "github.com",
+      })).status).toBe(201);
       const logout = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/auth/logout`, {
         method: "POST",
         headers: { cookie: loggedIn.cookie, origin: ORIGIN, "x-ghcg-csrf": loggedIn.csrf },
@@ -119,6 +144,7 @@ describe("Admin authentication", () => {
       expect(logout.status).toBe(204);
       expect(await logout.text()).toBe("");
       expect(logout.headers.get("set-cookie")).toContain("Max-Age=0");
+      expect(harness.dependencies.calls).toContain("device-cancel:flow-1");
       expect((await session(harness.gateway, loggedIn.cookie)).status).toBe(401);
     } finally {
       await harness.close();
@@ -136,6 +162,28 @@ describe("Admin authentication", () => {
       expect((await exchange(harness.gateway, ninth.token)).status).toBe(503);
     } finally {
       await harness.close();
+    }
+  });
+
+  it("cancels and releases an owned flow at its deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_800_000_000_000);
+    const harness = await createHarness({ value: 1_800_000_000_000 });
+    try {
+      const loggedIn = await login(harness.gateway, harness.admin);
+      expect((await mutate(harness.gateway, "/admin/api/v1/device-flows", loggedIn, {
+        host: "github.com",
+      })).status).toBe(201);
+      await vi.advanceTimersByTimeAsync(16 * 60_000);
+      expect(harness.dependencies.calls).toContain("device-cancel:flow-1");
+      expect((await get(
+        harness.gateway,
+        "/admin/api/v1/device-flows/flow-1",
+        loggedIn.cookie,
+      )).status).toBe(404);
+    } finally {
+      await harness.close();
+      vi.useRealTimers();
     }
   });
 });

--- a/tests/contract/admin_test_harness.ts
+++ b/tests/contract/admin_test_harness.ts
@@ -105,13 +105,25 @@ export function adminDependencies(now = { value: 1_800_000_000_000 }): TestAdmin
       async start(host, signal) {
         signal?.throwIfAborted();
         calls.push(`device-start:${host}`);
-        return { flowId: "flow-1", userCode: "ABCD-1234", verificationUri: "https://github.com/login/device", expiresAtMs: now.value + 900_000, pollIntervalSeconds: 5 };
+        return {
+          flowId: "flow-1",
+          userCode: "ABCD-1234",
+          verificationUri: "https://github.com/login/device",
+          expiresAtMs: now.value + 900_000,
+          pollIntervalSeconds: 5,
+          nextPollAtMs: now.value + 5_000,
+        };
       },
       async poll(flowId, signal) {
         signal?.throwIfAborted();
         calls.push(`device-poll:${flowId}`);
-        return { status: "pending" };
+        return { status: "pending", pollIntervalSeconds: 5, nextPollAtMs: now.value + 5_000 };
       },
+      async cancel(flowId) {
+        calls.push(`device-cancel:${flowId}`);
+        return { status: "canceled" };
+      },
+      has: () => true,
     },
     catalog: {
       async get(accountId, signal) {

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -186,19 +186,28 @@ test("device-flow retries network failures without accepting stale responses", a
   await page.getByRole("button", { name: "Refresh" }).click();
   await expect(page.getByText("Enterprise Admin")).toHaveCount(0);
   fixture.state.devicePollStates = ["complete"];
-  fixture.state.devicePollDelayMs = 100;
-  await page.getByRole("button", { name: "Start login" }).click();
-  await advanceDeviceClock(page, fixture, 5_000);
-  await page.getByRole("button", { name: "Cancel" }).click();
-  await page.waitForTimeout(150);
+  const heldPoll = fixture.holdNextDevicePoll();
+  try {
+    await page.getByRole("button", { name: "Start login" }).click();
+    await advanceDeviceClock(page, fixture, 5_000);
+    await heldPoll.started;
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect.poll(() => fixture.requests.filter((request) => (
+      request.method() === "DELETE" && request.url().endsWith("/device-flows/flow-1")
+    )).length).toBe(1);
+  } finally {
+    heldPoll.release();
+  }
+  await heldPoll.responseFinished;
+  await expect.poll(() => fixture.state.accounts.items.some((account) => account.login === "enterprise")).toBe(true);
   await expect(page.getByText("ABCD-1234")).toHaveCount(0);
   await expect(page.getByText("Enterprise Admin")).toHaveCount(0);
+  await expect(page.getByRole("status")).toContainText("Authorization canceled in this view");
 
   fixture.state.accounts = {
     ...fixture.state.accounts,
     items: fixture.state.accounts.items.filter((account) => account.login !== "enterprise"),
   };
-  fixture.state.devicePollDelayMs = 0;
   fixture.state.accountsDelayMs = 1_000;
   const staleRefreshCount = fixture.requests.filter((request) => request.url().endsWith("/accounts")).length;
   await page.getByRole("button", { name: "Refresh" }).click();

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from "@playwright/test";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
+  ADMIN_FIXTURE_NOW_MS,
   installAdminFixture,
   operationalEvent,
   sse,
@@ -56,6 +57,21 @@ async function recordAccessibilityEvidence(page: Page): Promise<void> {
   }, null, 2)}\n`, "utf8");
 }
 
+async function advanceDeviceClock(
+  page: Page,
+  fixture: Awaited<ReturnType<typeof installAdminFixture>>,
+  milliseconds: number,
+): Promise<void> {
+  fixture.state.deviceNowMs += milliseconds;
+  await page.clock.fastForward(milliseconds);
+}
+
+function devicePollRequests(fixture: Awaited<ReturnType<typeof installAdminFixture>>) {
+  return fixture.requests.filter((request) => (
+    request.method() === "GET" && request.url().endsWith("/device-flows/flow-1")
+  ));
+}
+
 test("bootstrap-and-session-expiry", async ({ page }) => {
   const fixture = await openAdmin(page);
   await expect(page).toHaveURL(/\/admin\/$/);
@@ -76,13 +92,19 @@ test("bootstrap-and-session-expiry", async ({ page }) => {
 });
 
 test("github-and-ghes-account-lifecycle", async ({ page }) => {
+  await page.clock.install({ time: ADMIN_FIXTURE_NOW_MS });
   const fixture = await openAdmin(page);
   await keyboardNavigate(page, "Accounts");
   await page.getByLabel("GitHub host").fill("github.example.test");
   await page.getByRole("button", { name: "Start login" }).click();
   await expect(page.getByText("ABCD-1234")).toBeVisible();
-  await page.getByRole("button", { name: "I've authorized" }).click();
+  await expect(page.getByText("checking automatically")).toBeVisible();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect.poll(() => devicePollRequests(fixture).length).toBe(1);
+  await advanceDeviceClock(page, fixture, 10_000);
   await expect(page.getByText("Enterprise Admin")).toBeVisible();
+  await expect(page.getByRole("status")).toContainText("Current default is @octo");
+  expect(fixture.state.accounts.defaultAccountId).toBe("github:1");
   fixture.state.conflictAccount = true;
   await page.getByRole("button", { name: "Make default" }).click();
   await expect(page.getByRole("alert")).toContainText("changed elsewhere");
@@ -106,6 +128,144 @@ test("github-and-ghes-account-lifecycle", async ({ page }) => {
     .click();
   await expect(page.getByRole("article").filter({ hasText: "Enterprise Admin" }).getByText("removed"))
     .toBeVisible();
+});
+
+test("device-flow disposal and terminal failures clean up polling", async ({ page }) => {
+  await page.clock.install({ time: ADMIN_FIXTURE_NOW_MS });
+  const fixture = await openAdmin(page);
+  await page.getByRole("button", { name: "Accounts" }).click();
+  await page.getByRole("button", { name: "Start login" }).click();
+  await page.getByRole("button", { name: "Check now" }).click();
+  expect(devicePollRequests(fixture)).toHaveLength(0);
+  await page.getByRole("button", { name: "Replace login" }).click();
+  await expect.poll(() => fixture.requests.filter((request) => request.url().endsWith("/device-flows")).length)
+    .toBe(2);
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect.poll(() => devicePollRequests(fixture).length).toBe(1);
+  await page.getByRole("button", { name: "Models" }).click();
+  await advanceDeviceClock(page, fixture, 20_000);
+  expect(devicePollRequests(fixture)).toHaveLength(1);
+
+  fixture.state.devicePollStates = ["denied"];
+  await page.getByRole("button", { name: "Accounts" }).click();
+  await page.getByRole("button", { name: "Start login" }).click();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect(page.getByRole("alert")).toContainText("denied in GitHub");
+  await expect(page.getByText("ABCD-1234")).toHaveCount(0);
+
+  fixture.state.devicePollStates = ["expired"];
+  await page.getByRole("button", { name: "Start login" }).click();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect(page.getByRole("alert")).toContainText("Authorization expired");
+
+  fixture.state.devicePollStates = ["pending"];
+  await page.getByRole("button", { name: "Start login" }).click();
+  fixture.state.authenticated = false;
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect(page.getByRole("heading", { name: "Control room locked" })).toBeFocused();
+  await advanceDeviceClock(page, fixture, 20_000);
+  expect(devicePollRequests(fixture)).toHaveLength(4);
+});
+
+test("device-flow retries network failures without accepting stale responses", async ({ page }) => {
+  await page.clock.install({ time: ADMIN_FIXTURE_NOW_MS });
+  const fixture = await openAdmin(page);
+  fixture.state.devicePollStates = ["network", "complete"];
+  await page.getByRole("button", { name: "Accounts" }).click();
+  await page.getByRole("button", { name: "Start login" }).click();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect(page.getByRole("alert")).toContainText("gateway is unreachable");
+  await expect(page.getByText("retrying automatically")).toBeVisible();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect(page.getByText("Enterprise Admin")).toBeVisible();
+
+  fixture.state.accounts = {
+    ...fixture.state.accounts,
+    items: fixture.state.accounts.items.filter((account) => account.login !== "enterprise"),
+  };
+  await page.getByRole("button", { name: "Refresh" }).click();
+  await expect(page.getByText("Enterprise Admin")).toHaveCount(0);
+  fixture.state.devicePollStates = ["complete"];
+  fixture.state.devicePollDelayMs = 100;
+  await page.getByRole("button", { name: "Start login" }).click();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await page.waitForTimeout(150);
+  await expect(page.getByText("ABCD-1234")).toHaveCount(0);
+  await expect(page.getByText("Enterprise Admin")).toHaveCount(0);
+
+  fixture.state.accounts = {
+    ...fixture.state.accounts,
+    items: fixture.state.accounts.items.filter((account) => account.login !== "enterprise"),
+  };
+  fixture.state.devicePollDelayMs = 0;
+  fixture.state.accountsDelayMs = 1_000;
+  const staleRefreshCount = fixture.requests.filter((request) => request.url().endsWith("/accounts")).length;
+  await page.getByRole("button", { name: "Refresh" }).click();
+  await expect.poll(() => fixture.requests.filter((request) => request.url().endsWith("/accounts")).length)
+    .toBeGreaterThan(staleRefreshCount);
+  fixture.state.accountsDelayMs = 0;
+  fixture.state.devicePollStates = ["complete"];
+  await page.getByRole("button", { name: "Start login" }).click();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect(page.getByText("Enterprise Admin")).toBeVisible();
+  await page.waitForTimeout(1_100);
+  await expect(page.getByText("Enterprise Admin")).toBeVisible();
+
+  fixture.state.accounts = {
+    ...fixture.state.accounts,
+    items: fixture.state.accounts.items.filter((account) => account.login !== "enterprise"),
+  };
+  fixture.state.accountsDelayMs = 0;
+  const clearingRequestCount = fixture.requests.filter((request) => request.url().endsWith("/accounts")).length;
+  await page.getByRole("button", { name: "Refresh" }).click();
+  await expect.poll(() => fixture.requests.filter((request) => request.url().endsWith("/accounts")).length)
+    .toBeGreaterThan(clearingRequestCount);
+  await expect(page.getByText("Enterprise Admin")).toHaveCount(0);
+  fixture.state.accountsDelayMs = 1_000;
+  fixture.state.devicePollStates = ["complete"];
+  const accountRequestsBefore = fixture.requests.filter((request) => request.url().endsWith("/accounts")).length;
+  await page.getByRole("button", { name: "Start login" }).click();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect.poll(() => fixture.requests.filter((request) => request.url().endsWith("/accounts")).length)
+    .toBeGreaterThan(accountRequestsBefore);
+  await page.getByRole("button", { name: "Start login" }).click();
+  await page.waitForTimeout(1_100);
+  await expect(page.getByText("ABCD-1234")).toBeVisible();
+  await expect(page.getByText("Enterprise Admin")).toHaveCount(0);
+  await expect(page.getByRole("status")).toHaveCount(0);
+  await expect(page.getByText("Octo Admin")).toBeVisible();
+  await expect(page.locator(".loading-line")).toHaveCount(0);
+});
+
+test("device-flow expiry aborts a hanging browser poll", async ({ page }) => {
+  await page.clock.install({ time: ADMIN_FIXTURE_NOW_MS });
+  const fixture = await openAdmin(page);
+  fixture.state.devicePollStates = ["pending"];
+  fixture.state.devicePollDelayMs = 1_000;
+  await page.getByRole("button", { name: "Accounts" }).click();
+  await page.getByRole("button", { name: "Start login" }).click();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect.poll(() => devicePollRequests(fixture).length).toBe(1);
+  await advanceDeviceClock(page, fixture, 595_000);
+  await expect(page.getByRole("alert")).toContainText("Authorization expired");
+  await expect(page.getByText("ABCD-1234")).toHaveCount(0);
+});
+
+test("device-flow expiry reconciles a raced completion", async ({ page }) => {
+  await page.clock.install({ time: ADMIN_FIXTURE_NOW_MS });
+  const fixture = await openAdmin(page);
+  fixture.state.devicePollStates = ["pending"];
+  fixture.state.devicePollDelayMs = 1_000;
+  fixture.state.cancelCompletesDeviceFlow = true;
+  await page.getByRole("button", { name: "Accounts" }).click();
+  await page.getByRole("button", { name: "Start login" }).click();
+  await advanceDeviceClock(page, fixture, 5_000);
+  await expect.poll(() => devicePollRequests(fixture).length).toBe(1);
+  await advanceDeviceClock(page, fixture, 595_000);
+  await expect(page.getByText("Enterprise Admin")).toBeVisible();
+  await expect(page.getByRole("status")).toContainText("Connected @enterprise");
+  await expect(page.getByRole("alert")).toHaveCount(0);
 });
 
 test("model-refresh-invalidates-preference", async ({ page }) => {

--- a/tests/e2e/fixtures/admin_fixture.ts
+++ b/tests/e2e/fixtures/admin_fixture.ts
@@ -12,6 +12,8 @@ import type {
 } from "../../../web/src/types.js";
 
 const NOW = "2026-09-03T12:00:00.000Z";
+export const ADMIN_FIXTURE_NOW_MS = Date.parse(NOW);
+const DEVICE_POLL_INTERVAL_MS = 5_000;
 
 export interface AdminFixture {
   readonly requests: Request[];
@@ -31,6 +33,11 @@ export interface AdminFixture {
     conflictHistory: boolean;
     conflictModel: boolean;
     failAccountRemoval: boolean;
+    devicePollStates: Array<"pending" | "complete" | "expired" | "denied" | "failed" | "network">;
+    devicePollDelayMs: number;
+    deviceNowMs: number;
+    accountsDelayMs: number;
+    cancelCompletesDeviceFlow: boolean;
     streamBodies: string[];
     streamDelaysMs: number[];
     streamHoldsMs: number[];
@@ -85,6 +92,11 @@ export async function installAdminFixture(page: Page): Promise<AdminFixture> {
       conflictHistory: false,
       conflictModel: false,
       failAccountRemoval: false,
+      devicePollStates: ["pending", "complete"],
+      devicePollDelayMs: 0,
+      deviceNowMs: ADMIN_FIXTURE_NOW_MS,
+      accountsDelayMs: 0,
+      cancelCompletesDeviceFlow: false,
       streamBodies: [sse("performance", { kind: "performance", status: status("healthy") })],
       streamDelaysMs: [],
       streamHoldsMs: [],
@@ -163,17 +175,53 @@ async function handle(route: Route, fixture: AdminFixture): Promise<void> {
       },
     });
   }
-  if (path === "/accounts") return json(route, 200, fixture.state.accounts);
+  if (path === "/accounts") {
+    const accounts = structuredClone(fixture.state.accounts);
+    if (fixture.state.accountsDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, fixture.state.accountsDelayMs));
+    }
+    return json(route, 200, accounts);
+  }
   if (path === "/device-flows" && request.method() === "POST") {
+    const now = fixture.state.deviceNowMs;
     return json(route, 201, {
       flowId: "flow-1",
       userCode: "ABCD-1234",
       verificationUri: "https://github.invalid/login/device",
-      expiresAt: "2026-09-03T12:10:00.000Z",
-      pollIntervalSeconds: 1,
+      expiresAt: new Date(now + 10 * 60_000).toISOString(),
+      pollIntervalSeconds: DEVICE_POLL_INTERVAL_MS / 1_000,
+      nextPollAt: new Date(now + DEVICE_POLL_INTERVAL_MS).toISOString(),
     });
   }
-  if (path === "/device-flows/flow-1") {
+  if (path === "/device-flows/flow-1" && request.method() === "DELETE") {
+    if (fixture.state.cancelCompletesDeviceFlow) {
+      const ghes = account("ghes:2", "github.example.test", "enterprise");
+      if (!fixture.state.accounts.items.some((item) => item.accountId === ghes.accountId)) {
+        fixture.state.accounts = {
+          ...fixture.state.accounts,
+          items: [...fixture.state.accounts.items, ghes],
+        };
+      }
+      return json(route, 200, { state: "complete", account: ghes });
+    }
+    return json(route, 200, { state: "canceled" });
+  }
+  if (path === "/device-flows/flow-1" && request.method() === "GET") {
+    if (fixture.state.devicePollDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, fixture.state.devicePollDelayMs));
+    }
+    const state = fixture.state.devicePollStates.shift() ?? "pending";
+    if (state === "network") return route.abort("connectionfailed");
+    if (state === "pending") {
+      return json(route, 200, {
+        state,
+        pollIntervalSeconds: 10,
+        nextPollAt: new Date(fixture.state.deviceNowMs + 10_000).toISOString(),
+      });
+    }
+    if (state === "expired" || state === "denied" || state === "failed") {
+      return json(route, 200, { state });
+    }
     const ghes = account("ghes:2", "github.example.test", "enterprise");
     if (!fixture.state.accounts.items.some((item) => item.accountId === ghes.accountId)) {
       fixture.state.accounts = {

--- a/tests/e2e/fixtures/admin_fixture.ts
+++ b/tests/e2e/fixtures/admin_fixture.ts
@@ -15,10 +15,23 @@ const NOW = "2026-09-03T12:00:00.000Z";
 export const ADMIN_FIXTURE_NOW_MS = Date.parse(NOW);
 const DEVICE_POLL_INTERVAL_MS = 5_000;
 
+interface DevicePollHold {
+  readonly started: Promise<void>;
+  readonly responseFinished: Promise<void>;
+  release(): void;
+}
+
+interface HeldDevicePoll {
+  markStarted(): void;
+  markResponseFinished(): void;
+  readonly released: Promise<void>;
+}
+
 export interface AdminFixture {
   readonly requests: Request[];
   readonly streamRequests: Request[];
   readonly streamRequestHeaders: Array<Record<string, string | string[] | undefined>>;
+  holdNextDevicePoll(): DevicePollHold;
   readonly state: {
     authenticated: boolean;
     accounts: AdminAccounts;
@@ -46,10 +59,28 @@ export interface AdminFixture {
 
 export async function installAdminFixture(page: Page): Promise<AdminFixture> {
   const github = account("github:1", "github.com", "octo");
+  let heldDevicePoll: HeldDevicePoll | null = null;
   const fixture: AdminFixture = {
     requests: [],
     streamRequests: [],
     streamRequestHeaders: [],
+    holdNextDevicePoll() {
+      if (heldDevicePoll !== null) throw new Error("A device poll is already held");
+      let markStarted!: () => void;
+      let markResponseFinished!: () => void;
+      let release!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const responseFinished = new Promise<void>((resolve) => {
+        markResponseFinished = resolve;
+      });
+      const released = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      heldDevicePoll = { markStarted, markResponseFinished, released };
+      return { started, responseFinished, release };
+    },
     state: {
       authenticated: false,
       accounts: { defaultRevision: 1, defaultAccountId: github.accountId, items: [github] },
@@ -125,7 +156,11 @@ export async function installAdminFixture(page: Page): Promise<AdminFixture> {
   const { port } = streamServer.address() as AddressInfo;
   page.once("close", () => streamServer.close());
   page.once("crash", () => streamServer.close());
-  await page.route("**/admin/api/v1/**", (route) => handle(route, fixture));
+  await page.route("**/admin/api/v1/**", (route) => handle(route, fixture, () => {
+    const heldPoll = heldDevicePoll;
+    heldDevicePoll = null;
+    return heldPoll;
+  }));
   await page.route("**/admin/api/v1/events/stream", async (route) => {
     fixture.requests.push(route.request());
     fixture.streamRequests.push(route.request());
@@ -137,7 +172,11 @@ export async function installAdminFixture(page: Page): Promise<AdminFixture> {
   return fixture;
 }
 
-async function handle(route: Route, fixture: AdminFixture): Promise<void> {
+async function handle(
+  route: Route,
+  fixture: AdminFixture,
+  takeHeldDevicePoll: () => HeldDevicePoll | null,
+): Promise<void> {
   const request = route.request();
   fixture.requests.push(request);
   const url = new URL(request.url());
@@ -207,29 +246,47 @@ async function handle(route: Route, fixture: AdminFixture): Promise<void> {
     return json(route, 200, { state: "canceled" });
   }
   if (path === "/device-flows/flow-1" && request.method() === "GET") {
-    if (fixture.state.devicePollDelayMs > 0) {
-      await new Promise((resolve) => setTimeout(resolve, fixture.state.devicePollDelayMs));
+    const heldPoll = takeHeldDevicePoll();
+    if (heldPoll !== null) {
+      heldPoll.markStarted();
+      await heldPoll.released;
     }
-    const state = fixture.state.devicePollStates.shift() ?? "pending";
-    if (state === "network") return route.abort("connectionfailed");
-    if (state === "pending") {
-      return json(route, 200, {
-        state,
-        pollIntervalSeconds: 10,
-        nextPollAt: new Date(fixture.state.deviceNowMs + 10_000).toISOString(),
-      });
+    try {
+      if (fixture.state.devicePollDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, fixture.state.devicePollDelayMs));
+      }
+      const state = fixture.state.devicePollStates.shift() ?? "pending";
+      if (state === "network") {
+        await route.abort("connectionfailed");
+        return;
+      }
+      if (state === "pending") {
+        await json(route, 200, {
+          state,
+          pollIntervalSeconds: 10,
+          nextPollAt: new Date(fixture.state.deviceNowMs + 10_000).toISOString(),
+        });
+        return;
+      }
+      if (state === "expired" || state === "denied" || state === "failed") {
+        await json(route, 200, { state });
+        return;
+      }
+      const ghes = account("ghes:2", "github.example.test", "enterprise");
+      if (!fixture.state.accounts.items.some((item) => item.accountId === ghes.accountId)) {
+        fixture.state.accounts = {
+          ...fixture.state.accounts,
+          items: [...fixture.state.accounts.items, ghes],
+        };
+      }
+      await json(route, 200, { state: "complete", account: ghes });
+      return;
+    } catch (error: unknown) {
+      if (heldPoll === null || !isHandledRoute(error)) throw error;
+    } finally {
+      heldPoll?.markResponseFinished();
     }
-    if (state === "expired" || state === "denied" || state === "failed") {
-      return json(route, 200, { state });
-    }
-    const ghes = account("ghes:2", "github.example.test", "enterprise");
-    if (!fixture.state.accounts.items.some((item) => item.accountId === ghes.accountId)) {
-      fixture.state.accounts = {
-        ...fixture.state.accounts,
-        items: [...fixture.state.accounts.items, ghes],
-      };
-    }
-    return json(route, 200, { state: "complete", account: ghes });
+    return;
   }
   if (path === "/accounts/default") {
     if (fixture.state.conflictAccount) {
@@ -453,4 +510,8 @@ async function failure(route: Route, statusCode: number, code: string): Promise<
       error: { code, message: code.replaceAll("_", " "), requestId: "fixture-request" },
     }),
   });
+}
+
+function isHandledRoute(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Route is already handled");
 }

--- a/tests/integration/cli_commands.test.ts
+++ b/tests/integration/cli_commands.test.ts
@@ -215,13 +215,13 @@ describe("CLI commands", () => {
 
   it("sends exact control operations to the selected data directory", async () => {
     const client = new ScriptedControlClient({
-      "auth.login.start": [{ flowId: "flow", userCode: "ABCD-1234", verificationUri: "https://github.com/login/device", expiresAt: "2026-09-02T00:00:00.000Z", pollIntervalSeconds: 5 }],
+      "auth.login.start": [{ flowId: "flow", userCode: "ABCD-1234", verificationUri: "https://github.com/login/device", expiresAt: "2026-09-02T00:00:00.000Z", pollIntervalSeconds: 5, nextPollAt: "2026-09-01T23:45:05.000Z" }],
       "admin.open": [{ opened: true }],
     });
     const stdout = new CaptureStream();
     const stderr = new CaptureStream();
     expect(await runCli({ argv: ["--json", "--data-dir", "selected", "auth", "login", "--host", "ghe.example.com"], homedir: "Q:/tmp/home", stdout, stderr, controlClient: client })).toBe(0);
-    expect(JSON.parse(stdout.chunks)).toEqual({ ok: true, data: { flowId: "flow", userCode: "ABCD-1234", verificationUri: "https://github.com/login/device", expiresAt: "2026-09-02T00:00:00.000Z", pollIntervalSeconds: 5 } });
+    expect(JSON.parse(stdout.chunks)).toEqual({ ok: true, data: { flowId: "flow", userCode: "ABCD-1234", verificationUri: "https://github.com/login/device", expiresAt: "2026-09-02T00:00:00.000Z", pollIntervalSeconds: 5, nextPollAt: "2026-09-01T23:45:05.000Z" } });
     expect(stderr.chunks).toBe("");
     expect(client.calls[0]).toEqual({ kind: "control", operation: "auth.login.start", args: { host: "ghe.example.com" }, dataDir: expect.stringContaining("selected") });
 
@@ -233,8 +233,8 @@ describe("CLI commands", () => {
 
   it("polls interactive login until terminal and handles interruption without leaking tokens", async () => {
     const client = new ScriptedControlClient({
-      "auth.login.start": [{ flowId: "flow", userCode: "ABCD-1234", verificationUri: "https://github.com/login/device", expiresAt: "2026-09-02T00:00:00.000Z", pollIntervalSeconds: 1 }],
-      "auth.login.poll": [{ state: "pending" }, { state: "complete", account: accountDto("github.com/42") }],
+      "auth.login.start": [{ flowId: "flow", userCode: "ABCD-1234", verificationUri: "https://github.com/login/device", expiresAt: "2026-09-02T00:00:00.000Z", pollIntervalSeconds: 1, nextPollAt: "2026-09-01T23:45:01.000Z" }],
+      "auth.login.poll": [{ state: "pending", pollIntervalSeconds: 6, nextPollAt: "2026-09-01T23:45:07.000Z" }, { state: "complete", account: accountDto("github.com/42") }],
     });
     const stdout = new CaptureStream();
     const stderr = new CaptureStream();
@@ -245,13 +245,138 @@ describe("CLI commands", () => {
 
     const abort = new AbortController();
     const interrupted = new ScriptedControlClient({
-      "auth.login.start": [{ flowId: "flow", userCode: "WXYZ-9999", verificationUri: "https://github.com/login/device", expiresAt: "2026-09-02T00:00:00.000Z", pollIntervalSeconds: 30 }],
-      "auth.login.poll": [{ state: "pending" }],
+      "auth.login.start": [{ flowId: "flow", userCode: "WXYZ-9999", verificationUri: "https://github.com/login/device", expiresAt: "2026-09-02T00:00:00.000Z", pollIntervalSeconds: 30, nextPollAt: "2026-09-01T23:45:30.000Z" }],
+      "auth.login.poll": [{ state: "pending", pollIntervalSeconds: 30, nextPollAt: "2026-09-01T23:46:00.000Z" }],
+      "auth.login.cancel": [{ state: "canceled" }],
     });
     const interruptedErr = new CaptureStream();
     abort.abort();
     expect(await runCli({ argv: ["auth", "login"], homedir: "Q:/tmp/home", stdout: new CaptureStream(), stderr: interruptedErr, controlClient: interrupted, shutdownSignal: abort.signal })).toBe(130);
     expect(interruptedErr.chunks).toBe("error: interrupted\n");
+    expect(interrupted.calls.some((call) => call.operation === "auth.login.cancel")).toBe(true);
+
+    const completedDuringCancel = new ScriptedControlClient({
+      "auth.login.start": [{ flowId: "flow", userCode: "DONE-1234", verificationUri: "https://github.com/login/device", expiresAt: "2026-09-02T00:00:00.000Z", pollIntervalSeconds: 30, nextPollAt: "2026-09-01T23:45:30.000Z" }],
+      "auth.login.cancel": [{ state: "complete", accountId: "github.com/42" }],
+    });
+    const completedOut = new CaptureStream();
+    const completedErr = new CaptureStream();
+    expect(await runCli({
+      argv: ["auth", "login"],
+      homedir: "Q:/tmp/home",
+      stdout: completedOut,
+      stderr: completedErr,
+      controlClient: completedDuringCancel,
+      shutdownSignal: abort.signal,
+    })).toBe(0);
+    expect(completedOut.chunks).toContain("Authenticated: github.com/42");
+    expect(completedErr.chunks).toBe("");
+  });
+
+  it("updates interactive login cadence from pending poll results", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T23:45:00.000Z"));
+    try {
+      const client = new ScriptedControlClient({
+        "auth.login.start": [{
+          flowId: "flow",
+          userCode: "ABCD-1234",
+          verificationUri: "https://github.com/login/device",
+          expiresAt: "2026-09-02T00:00:00.000Z",
+          pollIntervalSeconds: 1,
+          nextPollAt: "2026-09-01T23:45:01.000Z",
+        }],
+        "auth.login.poll": [
+          { state: "pending", pollIntervalSeconds: 6, nextPollAt: "2026-09-01T23:45:07.000Z" },
+          { state: "complete", account: accountDto("github.com/42") },
+        ],
+      });
+
+      const login = runCli({
+        argv: ["auth", "login"],
+        homedir: "Q:/tmp/home",
+        stdout: new CaptureStream(),
+        stderr: new CaptureStream(),
+        controlClient: client,
+      });
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(client.calls.filter((call) => call.operation === "auth.login.poll")).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(client.calls.filter((call) => call.operation === "auth.login.poll")).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(5_999);
+      expect(client.calls.filter((call) => call.operation === "auth.login.poll")).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(login).resolves.toBe(0);
+      expect(client.calls.filter((call) => call.operation === "auth.login.poll")).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    ["expired", "authorization expired"],
+    ["denied", "authorization denied"],
+    ["failed", "authorization failed"],
+  ] as const)("reports interactive login %s distinctly", async (state, message) => {
+    const client = new ScriptedControlClient({
+      "auth.login.start": [{
+        flowId: "flow",
+        userCode: "ABCD-1234",
+        verificationUri: "https://github.com/login/device",
+        expiresAt: "2026-09-02T00:00:00.000Z",
+        pollIntervalSeconds: 1,
+        nextPollAt: "2026-09-01T23:45:01.000Z",
+      }],
+      "auth.login.poll": [{ state }],
+      "auth.login.cancel": [{ state: "canceled" }],
+    });
+    const stderr = new CaptureStream();
+    expect(await runCli({
+      argv: ["auth", "login"],
+      homedir: "Q:/tmp/home",
+      stdout: new CaptureStream(),
+      stderr,
+      controlClient: client,
+      pollDelayMs: 0,
+    })).toBe(5);
+    expect(stderr.chunks).toBe(`error: ${message}\n`);
+  });
+
+  it("falls back to the last interval for an older daemon without scheduling fields", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T23:45:00.000Z"));
+    try {
+      const client = new ScriptedControlClient({
+        "auth.login.start": [{
+          flowId: "flow",
+          userCode: "ABCD-1234",
+          verificationUri: "https://github.com/login/device",
+          expiresAt: "2026-09-02T00:00:00.000Z",
+          pollIntervalSeconds: 2,
+        }],
+        "auth.login.poll": [
+          { state: "pending" },
+          { state: "complete", account: accountDto("github.com/42") },
+        ],
+      });
+      const login = runCli({
+        argv: ["auth", "login"],
+        homedir: "Q:/tmp/home",
+        stdout: new CaptureStream(),
+        stderr: new CaptureStream(),
+        controlClient: client,
+      });
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(client.calls.filter((call) => call.operation === "auth.login.poll")).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(client.calls.filter((call) => call.operation === "auth.login.poll")).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await expect(login).resolves.toBe(0);
+      expect(client.calls.filter((call) => call.operation === "auth.login.poll")).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("dispatches management commands through application modules with one CAS attempt", async () => {
@@ -260,6 +385,7 @@ describe("CLI commands", () => {
       const client = new DispatcherControlClient(harness.dispatcher);
       const login = await client.request("auth.login.start", { host: "github.com" }, { dataDir: "unused" });
       expect(login.pollIntervalSeconds).toBe(5);
+      harness.advanceTime(5_000);
       const poll = await client.request("auth.login.poll", { flowId: login.flowId }, { dataDir: "unused" });
       expect(poll).toMatchObject({ state: "complete", account: { accountId: "github.com/42" } });
       expect(await client.request("accounts.list", {}, { dataDir: "unused" })).toMatchObject({ defaultAccountId: "github.com/42", defaultRevision: 1 });
@@ -331,7 +457,7 @@ describe("CLI commands", () => {
       const started = await client.request("auth.login.start", {}, { dataDir: "unused" });
       nowValue += 2_000;
       expect(await client.request("auth.login.poll", { flowId: started.flowId }, { dataDir: "unused" })).toEqual({ state: "expired" });
-      await expect(client.request("auth.login.poll", { flowId: started.flowId }, { dataDir: "unused" })).rejects.toMatchObject({ code: "not_found" });
+      expect(await client.request("auth.login.poll", { flowId: started.flowId }, { dataDir: "unused" })).toEqual({ state: "expired" });
     } finally {
       expiredHarness.close();
     }
@@ -340,8 +466,9 @@ describe("CLI commands", () => {
     try {
       const client = new DispatcherControlClient(failedHarness.dispatcher);
       const started = await client.request("auth.login.start", {}, { dataDir: "unused" });
+      failedHarness.advanceTime(5_000);
       expect(await client.request("auth.login.poll", { flowId: started.flowId }, { dataDir: "unused" })).toEqual({ state: "failed" });
-      await expect(client.request("auth.login.poll", { flowId: started.flowId }, { dataDir: "unused" })).rejects.toMatchObject({ code: "not_found" });
+      expect(await client.request("auth.login.poll", { flowId: started.flowId }, { dataDir: "unused" })).toEqual({ state: "failed" });
     } finally {
       failedHarness.close();
     }
@@ -764,8 +891,10 @@ async function dispatcherHarness(options: {
   readonly runtimeConfig: RuntimeConfigStore;
   capiModels: Array<{ readonly id: string; readonly name: string; readonly vendor: string; readonly model_picker_enabled: boolean }>;
   readonly close: () => void;
+  readonly advanceTime: (milliseconds: number) => void;
 }> {
-  const now = options.now ?? (() => 1_800_000_000_000);
+  const clock = { value: 1_800_000_000_000 };
+  const now = options.now ?? (() => clock.value);
   const database = openDatabase({
     path: ":memory:",
     migrations: [
@@ -805,6 +934,7 @@ async function dispatcherHarness(options: {
     backend,
     history,
     runtimeConfig,
+    advanceTime: (milliseconds) => { clock.value += milliseconds; },
     get capiModels() {
       return harness.capiModels;
     },

--- a/tests/integration/device_flow.test.ts
+++ b/tests/integration/device_flow.test.ts
@@ -1,15 +1,17 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AccountDirectory } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import {
+  DEVICE_FLOW_TTL_MS,
   DeviceFlowError,
   DeviceFlowService,
   MAX_DEVICE_FLOWS,
   type DeviceOAuthClient,
 } from "../../src/accounts/device_flow.js";
+import { DeviceOAuthError } from "../../src/accounts/device_oauth.js";
 import { closeDatabase, openDatabase } from "../../src/persistence/database.js";
 import { embedMigration } from "../../src/persistence/migrations.js";
 import { migration as runtimeConfigMigration } from "../../src/persistence/migrations/001_runtime_config.js";
@@ -47,14 +49,22 @@ describe("device flow", () => {
       nowMs,
     });
     try {
-      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
-      const flows = new DeviceFlowService(accounts, scriptedClient(), nowMs);
+      let now = nowMs();
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      const flows = new DeviceFlowService(accounts, scriptedClient(), () => now);
       const started = await flows.start("github.com");
       expect(started.userCode).toBe("ABCD-1234");
+      await expect(flows.poll(started.flowId)).resolves.toMatchObject({
+        status: "pending",
+        pollIntervalSeconds: 5,
+        nextPollAtMs: now + 5_000,
+      });
+      now += 5_000;
       const result = await flows.poll(started.flowId);
       expect(result).toEqual({ status: "complete", accountId: "github.com/42" });
       const bound = await accounts.bindDefault();
       expect(bound.login).toBe("octo");
+      await expect(flows.poll(started.flowId)).resolves.toEqual(result);
     } finally {
       closeDatabase(database);
     }
@@ -130,13 +140,14 @@ describe("device flow", () => {
 
   it("allows only one concurrent poll to consume a terminal result", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
     const database = openDatabase({
       path: path.join(dir, "state.db"),
       migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
-      nowMs,
+      nowMs: () => now,
     });
     try {
-      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
       let exchanges = 0;
       let release = (): void => undefined;
       const flows = new DeviceFlowService(accounts, {
@@ -148,15 +159,25 @@ describe("device flow", () => {
           await new Promise<void>((resolve) => { release = resolve; });
           return { status: "complete", accessToken: "token", user: { id: "42", login: "octo" } };
         },
-      }, nowMs);
+      }, () => now);
       const started = await flows.start("github.com");
+      now += 5_000;
       const first = flows.poll(started.flowId);
       await new Promise((resolve) => setTimeout(resolve, 0));
-      await expect(flows.poll(started.flowId)).resolves.toEqual({ status: "pending" });
+      await expect(flows.poll(started.flowId)).resolves.toMatchObject({ status: "pending" });
+      now += 10_000;
+      await expect(flows.poll(started.flowId)).resolves.toEqual({
+        status: "pending",
+        pollIntervalSeconds: 5,
+        nextPollAtMs: now + 5_000,
+      });
       release();
       await expect(first).resolves.toEqual({ status: "complete", accountId: "github.com/42" });
       expect(exchanges).toBe(1);
-      await expect(flows.poll(started.flowId)).rejects.toBeInstanceOf(DeviceFlowError);
+      await expect(flows.poll(started.flowId)).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
     } finally {
       closeDatabase(database);
     }
@@ -164,14 +185,14 @@ describe("device flow", () => {
 
   it("cancels and expires scripted flows", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
     const database = openDatabase({
       path: path.join(dir, "state.db"),
       migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
-      nowMs,
+      nowMs: () => now,
     });
     try {
-      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
-      let now = nowMs();
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
       const flows = new DeviceFlowService(accounts, {
         async requestDeviceCode() {
           return {
@@ -187,12 +208,689 @@ describe("device flow", () => {
         },
       }, () => now);
       const started = await flows.start("ghe.example.com");
-      flows.cancel(started.flowId);
+      await flows.cancel(started.flowId);
       await expect(flows.poll(started.flowId)).rejects.toBeInstanceOf(DeviceFlowError);
       const second = await flows.start("ghe.example.com");
       now += 2_000;
       await expect(flows.poll(second.flowId)).resolves.toEqual({ status: "expired" });
-      await expect(flows.poll(second.flowId)).rejects.toBeInstanceOf(DeviceFlowError);
+      await expect(flows.poll(second.flowId)).resolves.toEqual({ status: "expired" });
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("enforces cadence and propagates slow_down updates", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      let exchanges = 0;
+      const flows = new DeviceFlowService(accounts, {
+        async requestDeviceCode() {
+          return {
+            deviceCode: "device",
+            userCode: "CODE",
+            verificationUri: "https://github.com/login/device",
+            intervalSec: 5,
+            expiresInSec: 900,
+          };
+        },
+        async exchangeDeviceCode() {
+          exchanges += 1;
+          return exchanges === 1
+            ? { status: "slow_down", pollIntervalSeconds: 8 }
+            : { status: "pending" };
+        },
+      }, () => now);
+
+      const started = await flows.start("github.com");
+      await expect(flows.poll(started.flowId)).resolves.toMatchObject({ status: "pending" });
+      expect(exchanges).toBe(0);
+      now += 5_000;
+      await expect(flows.poll(started.flowId)).resolves.toEqual({
+        status: "pending",
+        pollIntervalSeconds: 10,
+        nextPollAtMs: now + 10_000,
+      });
+      expect(exchanges).toBe(1);
+      now += 9_999;
+      await expect(flows.poll(started.flowId)).resolves.toMatchObject({ status: "pending" });
+      expect(exchanges).toBe(1);
+      now += 1;
+      await expect(flows.poll(started.flowId)).resolves.toMatchObject({
+        status: "pending",
+        pollIntervalSeconds: 10,
+      });
+      expect(exchanges).toBe(2);
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("keeps network failures cadence-bound and settles an issued token during cancellation", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      let exchanges = 0;
+      let release = (): void => undefined;
+      const flows = new DeviceFlowService(accounts, {
+        async requestDeviceCode() {
+          return {
+            deviceCode: "device",
+            userCode: "CODE",
+            verificationUri: "https://github.com/login/device",
+            intervalSec: 5,
+            expiresInSec: 900,
+          };
+        },
+        async exchangeDeviceCode() {
+          exchanges += 1;
+          if (exchanges === 1) throw new Error("network failure");
+          await new Promise<void>((resolve) => { release = resolve; });
+          return { status: "complete", accessToken: "token", user: { id: "42", login: "octo" } };
+        },
+      }, () => now);
+
+      const started = await flows.start("github.com");
+      now += 5_000;
+      await expect(flows.poll(started.flowId)).rejects.toThrow("network failure");
+      await expect(flows.poll(started.flowId)).resolves.toMatchObject({ status: "pending" });
+      expect(exchanges).toBe(1);
+      now += 5_000;
+      const completion = flows.poll(started.flowId);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const canceled = flows.cancel(started.flowId);
+      release();
+      await expect(completion).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      await expect(canceled).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      expect(accounts.list()).toHaveLength(1);
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("cancels an exchange before a token is issued", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      let exchangeStarted = (): void => undefined;
+      const startedExchange = new Promise<void>((resolve) => { exchangeStarted = resolve; });
+      const flows = new DeviceFlowService(accounts, {
+        async requestDeviceCode() {
+          return {
+            deviceCode: "device",
+            userCode: "CODE",
+            verificationUri: "https://github.com/login/device",
+            intervalSec: 5,
+            expiresInSec: 900,
+          };
+        },
+        async exchangeDeviceCode(_environment, _deviceCode, signal) {
+          exchangeStarted();
+          await new Promise<void>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          });
+          return { status: "pending" };
+        },
+      }, () => now);
+      const started = await flows.start("github.com");
+      now += 5_000;
+      const poll = flows.poll(started.flowId);
+      await startedExchange;
+      const canceled = flows.cancel(started.flowId);
+
+      await expect(poll).rejects.toMatchObject({ name: "AbortError" });
+      await expect(canceled).resolves.toEqual({ status: "canceled" });
+      expect(accounts.list()).toHaveLength(0);
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("retries identity lookup without re-exchanging an issued token", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(nowMs());
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: Date.now,
+    });
+
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), Date.now);
+      let exchanges = 0;
+      let userRequests = 0;
+      const flows = new DeviceFlowService(accounts, {
+        async requestDeviceCode() {
+          return {
+            deviceCode: "device",
+            userCode: "CODE",
+            verificationUri: "https://github.com/login/device",
+            intervalSec: 5,
+            expiresInSec: 900,
+          };
+        },
+        async exchangeDeviceCode() {
+          exchanges += 1;
+          return { status: "authorized", accessToken: "token" };
+        },
+        async fetchUser() {
+          userRequests += 1;
+          if (userRequests === 1) throw new Error("temporary user lookup failure");
+          return { id: "42", login: "octo" };
+        },
+      }, Date.now);
+      const started = await flows.start("github.com");
+      await vi.advanceTimersByTimeAsync(5_000);
+      const completion = flows.poll(started.flowId);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(completion).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      expect(exchanges).toBe(1);
+      expect(userRequests).toBe(2);
+    } finally {
+      closeDatabase(database);
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails immediately on a permanent identity lookup error", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      let userRequests = 0;
+      const flows = new DeviceFlowService(accounts, {
+        async requestDeviceCode() {
+          return {
+            deviceCode: "device",
+            userCode: "CODE",
+            verificationUri: "https://github.com/login/device",
+            intervalSec: 5,
+            expiresInSec: 900,
+          };
+        },
+        async exchangeDeviceCode() {
+          return { status: "authorized", accessToken: "token" };
+        },
+        async fetchUser() {
+          userRequests += 1;
+          throw new DeviceOAuthError(false);
+        },
+      }, () => now);
+      const started = await flows.start("github.com");
+      now += 5_000;
+      await expect(flows.poll(started.flowId)).resolves.toEqual({ status: "failed" });
+      expect(userRequests).toBe(1);
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("settles credential persistence after token issuance when a flow is canceled", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+
+    try {
+      const credentials = new MemoryCredentialStore();
+      const putGeneration = credentials.putGeneration.bind(credentials);
+      let persistenceStarted = (): void => undefined;
+      let releasePersistence = (): void => undefined;
+      const startedPersisting = new Promise<void>((resolve) => { persistenceStarted = resolve; });
+      const persistenceRelease = new Promise<void>((resolve) => { releasePersistence = resolve; });
+      credentials.putGeneration = async (...args) => {
+        persistenceStarted();
+        await persistenceRelease;
+        await putGeneration(...args);
+      };
+      const accounts = new AccountDirectory(database, credentials, () => now);
+      const flows = new DeviceFlowService(accounts, scriptedClient(), () => now);
+      const started = await flows.start("github.com");
+      now += 5_000;
+      const completion = flows.poll(started.flowId);
+      await startedPersisting;
+      const canceled = flows.cancel(started.flowId);
+      releasePersistence();
+
+      await expect(completion).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      await expect(canceled).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      expect(accounts.list()).toHaveLength(1);
+      await expect(credentials.readGeneration("github.com/42", 1)).resolves.not.toBeNull();
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("replays completion when cancellation arrives after the account commit", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      const upsertAuthenticated = accounts.upsertAuthenticated.bind(accounts);
+      let committed = (): void => undefined;
+      let release = (): void => undefined;
+      const accountCommitted = new Promise<void>((resolve) => { committed = resolve; });
+      const commitRelease = new Promise<void>((resolve) => { release = resolve; });
+      accounts.upsertAuthenticated = async (...args) => {
+        const bound = await upsertAuthenticated(...args);
+        committed();
+        await commitRelease;
+        return bound;
+      };
+      let exchanges = 0;
+      const oauth = scriptedClient();
+      const flows = new DeviceFlowService(accounts, {
+        ...oauth,
+        async exchangeDeviceCode(...args) {
+          exchanges += 1;
+          return await oauth.exchangeDeviceCode(...args);
+        },
+      }, () => now);
+      const started = await flows.start("github.com");
+      now += 5_000;
+      const completion = flows.poll(started.flowId);
+      await accountCommitted;
+      const canceled = flows.cancel(started.flowId);
+      release();
+
+      await expect(completion).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      await expect(flows.poll(started.flowId)).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      await expect(canceled).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      expect(exchanges).toBe(1);
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("does not publish expiry while an account commit is settling", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      const upsertAuthenticated = accounts.upsertAuthenticated.bind(accounts);
+      let committed = (): void => undefined;
+      let release = (): void => undefined;
+      const accountCommitted = new Promise<void>((resolve) => { committed = resolve; });
+      const commitRelease = new Promise<void>((resolve) => { release = resolve; });
+      accounts.upsertAuthenticated = async (...args) => {
+        const bound = await upsertAuthenticated(...args);
+        committed();
+        await commitRelease;
+        return bound;
+      };
+      const flows = new DeviceFlowService(accounts, scriptedClient(), () => now);
+      const started = await flows.start("github.com");
+      now += 5_000;
+      const completion = flows.poll(started.flowId);
+      await accountCommitted;
+      now = started.expiresAtMs;
+      await expect(flows.poll(started.flowId)).resolves.toMatchObject({ status: "pending" });
+      release();
+
+      await expect(completion).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      await expect(flows.poll(started.flowId)).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("reports completion when post-commit credential cleanup fails", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+    try {
+      const credentials = new MemoryCredentialStore();
+      let cleanupAttempts = 0;
+      let cleanupStarted = (): void => undefined;
+      let releaseCleanup = (): void => undefined;
+      const startedCleanup = new Promise<void>((resolve) => { cleanupStarted = resolve; });
+      const cleanupRelease = new Promise<void>((resolve) => { releaseCleanup = resolve; });
+      credentials.prune = async () => {
+        cleanupAttempts += 1;
+        cleanupStarted();
+        await cleanupRelease;
+        if (cleanupAttempts < 3) throw new Error("cleanup failed");
+      };
+      const accounts = new AccountDirectory(database, credentials, () => now);
+      const flows = new DeviceFlowService(accounts, scriptedClient(), () => now);
+      const started = await flows.start("github.com");
+      now += 5_000;
+      const completion = flows.poll(started.flowId);
+      await startedCleanup;
+      const canceled = flows.cancel(started.flowId);
+      releaseCleanup();
+
+      await expect(completion).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      await expect(canceled).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      await expect(flows.poll(started.flowId)).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      expect(accounts.list()).toHaveLength(1);
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("expires and aborts a hanging exchange at the flow deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(nowMs());
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: Date.now,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), Date.now);
+      let exchanges = 0;
+      const flows = new DeviceFlowService(accounts, {
+        async requestDeviceCode() {
+          return {
+            deviceCode: "device",
+            userCode: "CODE",
+            verificationUri: "https://github.com/login/device",
+            intervalSec: 1,
+            expiresInSec: 2,
+          };
+        },
+        async exchangeDeviceCode(_environment, _deviceCode, signal) {
+          exchanges += 1;
+          await new Promise<void>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          });
+          return { status: "pending" };
+        },
+      }, Date.now);
+      const started = await flows.start("github.com");
+      await vi.advanceTimersByTimeAsync(1_000);
+      const poll = flows.poll(started.flowId);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(poll).resolves.toEqual({ status: "expired" });
+      expect(exchanges).toBe(1);
+      await expect(flows.poll(started.flowId)).resolves.toEqual({ status: "expired" });
+      await vi.advanceTimersByTimeAsync(60_000);
+      await expect(flows.poll(started.flowId)).rejects.toMatchObject({ code: "not_found" });
+    } finally {
+      closeDatabase(database);
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not count completed replay snapshots against active capacity", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      const flows = new DeviceFlowService(accounts, scriptedClient(), () => now);
+      for (let index = 0; index < MAX_DEVICE_FLOWS + 1; index += 1) {
+        const started = await flows.start("github.com");
+        now += 5_000;
+        await expect(flows.poll(started.flowId)).resolves.toMatchObject({ status: "complete" });
+      }
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("bounds a hanging device-code request and releases its reservation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(nowMs());
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: Date.now,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), Date.now);
+      const flows = new DeviceFlowService(accounts, {
+        async requestDeviceCode(_environment, signal) {
+          await new Promise<void>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          });
+          throw new Error("unreachable");
+        },
+        async exchangeDeviceCode() {
+          return { status: "pending" };
+        },
+      }, Date.now);
+      const start = flows.start("github.com");
+      const bounded = expect(start).rejects.toMatchObject({ name: "AbortError" });
+      await vi.advanceTimersByTimeAsync(DEVICE_FLOW_TTL_MS);
+      await bounded;
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      closeDatabase(database);
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears flow timers when the service closes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(nowMs());
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: Date.now,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), Date.now);
+      const flows = new DeviceFlowService(accounts, scriptedClient(), Date.now);
+      const started = await flows.start("github.com");
+      expect(vi.getTimerCount()).toBe(1);
+      await flows.close();
+      expect(vi.getTimerCount()).toBe(0);
+      await expect(flows.poll(started.flowId)).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      closeDatabase(database);
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not recreate state when close races with start or committed completion", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      const upsertAuthenticated = accounts.upsertAuthenticated.bind(accounts);
+      let committed = (): void => undefined;
+      let releaseCommit = (): void => undefined;
+      const accountCommitted = new Promise<void>((resolve) => { committed = resolve; });
+      const commitRelease = new Promise<void>((resolve) => { releaseCommit = resolve; });
+      accounts.upsertAuthenticated = async (...args) => {
+        const bound = await upsertAuthenticated(...args);
+        committed();
+        await commitRelease;
+        return bound;
+      };
+      const flows = new DeviceFlowService(accounts, scriptedClient(), () => now);
+      const started = await flows.start("github.com");
+      now += 5_000;
+      const completion = flows.poll(started.flowId);
+      await accountCommitted;
+      const closing = flows.close();
+      releaseCommit();
+      await expect(completion).resolves.toEqual({
+        status: "complete",
+        accountId: "github.com/42",
+      });
+      await closing;
+      expect(flows.has(started.flowId)).toBe(false);
+
+      await expect(flows.start("github.com")).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("aborts a device-code request when the service closes", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+      let requestStarted = (): void => undefined;
+      const startedRequest = new Promise<void>((resolve) => { requestStarted = resolve; });
+      const flows = new DeviceFlowService(accounts, {
+        async requestDeviceCode(_environment, signal) {
+          requestStarted();
+          await new Promise<void>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          });
+          throw new Error("unreachable");
+        },
+        async exchangeDeviceCode() {
+          return { status: "pending" };
+        },
+      }, nowMs);
+      const start = flows.start("github.com");
+      await startedRequest;
+      await flows.close();
+      await expect(start).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      closeDatabase(database);
+    }
+  });
+
+  it("force close interrupts a hanging graceful settlement", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-flow-"));
+    let now = nowMs();
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs: () => now,
+    });
+    try {
+      const accounts = new AccountDirectory(database, new MemoryCredentialStore(), () => now);
+      let userRequestStarted = (): void => undefined;
+      const startedUserRequest = new Promise<void>((resolve) => { userRequestStarted = resolve; });
+      const flows = new DeviceFlowService(accounts, {
+        async requestDeviceCode() {
+          return {
+            deviceCode: "device",
+            userCode: "CODE",
+            verificationUri: "https://github.com/login/device",
+            intervalSec: 5,
+            expiresInSec: 900,
+          };
+        },
+        async exchangeDeviceCode() {
+          return { status: "authorized", accessToken: "token" };
+        },
+        async fetchUser(_environment, _accessToken, signal) {
+          userRequestStarted();
+          await new Promise<void>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          });
+          return { id: "42", login: "octo" };
+        },
+      }, () => now);
+      const started = await flows.start("github.com");
+      now += 5_000;
+      const poll = flows.poll(started.flowId);
+      await startedUserRequest;
+      const closing = flows.close();
+      flows.forceClose();
+
+      await expect(poll).rejects.toMatchObject({ name: "AbortError" });
+      await closing;
+      expect(flows.has(started.flowId)).toBe(false);
     } finally {
       closeDatabase(database);
     }

--- a/tests/unit/daemon_oauth.test.ts
+++ b/tests/unit/daemon_oauth.test.ts
@@ -21,9 +21,13 @@ describe("HTTP device OAuth client", () => {
     const client = new HttpDeviceOAuthClient(fetch);
 
     await expect(client.exchangeDeviceCode(environment, "test-device-code")).resolves.toEqual({
-      status: "complete",
+      status: "authorized",
       accessToken: "test-access-token",
-      user: { id: 42, login: "octocat", name: "Octo Cat" },
+    });
+    await expect(client.fetchUser(environment, "test-access-token")).resolves.toEqual({
+      id: 42,
+      login: "octocat",
+      name: "Octo Cat",
     });
     expect(requests).toEqual([
       { url: "https://ghe.example.com/login/oauth/access_token", authorization: null },
@@ -70,10 +74,17 @@ describe("HTTP device OAuth client", () => {
       requests += 1;
       return requests === 1
         ? jsonResponse({ access_token: "test-access-token" })
-        : jsonResponse([]);
+        : jsonResponse({ id: null, login: "" });
     });
 
-    await expect(client.exchangeDeviceCode(environment, "test-device-code")).rejects.toBeInstanceOf(DeviceOAuthError);
+    await expect(client.exchangeDeviceCode(environment, "test-device-code")).resolves.toEqual({
+      status: "authorized",
+      accessToken: "test-access-token",
+    });
+    await expect(client.fetchUser(environment, "test-access-token")).rejects.toMatchObject({
+      name: "DeviceOAuthError",
+      retryable: false,
+    });
     expect(requests).toBe(2);
   });
 
@@ -85,6 +96,67 @@ describe("HTTP device OAuth client", () => {
     });
 
     await expect(client.requestDeviceCode(environment, controller.signal)).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("preserves pending, slow_down cadence, expiry, and denial results", async () => {
+    const responses = [
+      { error: "authorization_pending" },
+      { error: "slow_down", interval: 12 },
+      { error: "expired_token" },
+      { error: "access_denied" },
+    ];
+    const client = new HttpDeviceOAuthClient(async () => jsonResponse(responses.shift()));
+
+    await expect(client.exchangeDeviceCode(environment, "device")).resolves.toEqual({ status: "pending" });
+    await expect(client.exchangeDeviceCode(environment, "device")).resolves.toEqual({
+      status: "slow_down",
+      pollIntervalSeconds: 12,
+    });
+    await expect(client.exchangeDeviceCode(environment, "device")).resolves.toEqual({ status: "expired" });
+    await expect(client.exchangeDeviceCode(environment, "device")).resolves.toEqual({ status: "denied" });
+  });
+
+  it("finishes identity lookup after cancellation once a token is issued", async () => {
+    let userRequestStarted = (): void => undefined;
+    let releaseUser = (): void => undefined;
+    const started = new Promise<void>((resolve) => { userRequestStarted = resolve; });
+    const release = new Promise<void>((resolve) => { releaseUser = resolve; });
+    let requests = 0;
+    const client = new HttpDeviceOAuthClient(async () => {
+      requests += 1;
+      if (requests === 1) return jsonResponse({ access_token: "test-access-token" });
+      userRequestStarted();
+      await release;
+      return jsonResponse({ id: 42, login: "octocat" });
+    });
+
+    const controller = new AbortController();
+    await expect(client.exchangeDeviceCode(environment, "device", controller.signal)).resolves.toEqual({
+      status: "authorized",
+      accessToken: "test-access-token",
+    });
+    const exchange = client.fetchUser(environment, "test-access-token");
+    await started;
+    controller.abort();
+    releaseUser();
+
+    await expect(exchange).resolves.toEqual({
+      id: 42,
+      login: "octocat",
+    });
+  });
+
+  it("classifies GitHub rate-limit 403 responses as retryable", async () => {
+    const client = new HttpDeviceOAuthClient(async () => new Response(null, {
+      status: 403,
+      headers: { "retry-after": "7" },
+    }));
+
+    await expect(client.fetchUser(environment, "test-access-token")).rejects.toMatchObject({
+      name: "DeviceOAuthError",
+      retryable: true,
+      retryAfterMs: 7_000,
+    });
   });
 });
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -56,9 +56,17 @@ export class AdminClient {
   events(cursor?: string): Promise<AdminEventPage> {
     return this.request(`/events?limit=500${cursor === undefined ? "" : `&cursor=${encodeURIComponent(cursor)}`}`);
   }
-  startDeviceFlow(host: string): Promise<DeviceFlow> { return this.mutate("/device-flows", "POST", { host }); }
-  pollDeviceFlow(flowId: string): Promise<DeviceFlowPoll> {
-    return this.request(`/device-flows/${encodeURIComponent(flowId)}`);
+  startDeviceFlow(host: string, signal?: AbortSignal): Promise<DeviceFlow> {
+    return this.mutate("/device-flows", "POST", { host }, signal);
+  }
+  pollDeviceFlow(flowId: string, signal?: AbortSignal): Promise<DeviceFlowPoll> {
+    return this.request(`/device-flows/${encodeURIComponent(flowId)}`, signal === undefined ? undefined : { signal });
+  }
+  cancelDeviceFlow(flowId: string, signal?: AbortSignal): Promise<
+    | { readonly state: "canceled" | "not_found" }
+    | { readonly state: "complete"; readonly account: AdminAccount }
+  > {
+    return this.mutate(`/device-flows/${encodeURIComponent(flowId)}`, "DELETE", undefined, signal);
   }
   useAccount(accountId: string, expectedRevision: number): Promise<{ defaultAccountId: string; defaultRevision: number }> {
     return this.mutate("/accounts/default", "PUT", { accountId, expectedRevision });
@@ -80,13 +88,23 @@ export class AdminClient {
   }
   async logout(): Promise<void> { await this.mutate("/auth/logout", "POST"); }
 
-  private mutate<T>(path: string, method: "POST" | "PUT" | "DELETE", body?: object): Promise<T> {
+  private mutate<T>(
+    path: string,
+    method: "POST" | "PUT" | "DELETE",
+    body?: object,
+    signal?: AbortSignal,
+  ): Promise<T> {
     if (this.csrfToken === null) {
       return Promise.reject(new ApiError(401, "unauthenticated", null));
     }
     const headers: Record<string, string> = { "X-GHCG-CSRF": this.csrfToken };
     if (body !== undefined) headers["Content-Type"] = "application/json";
-    return this.request(path, { method, headers, ...(body === undefined ? {} : { body: JSON.stringify(body) }) });
+    return this.request(path, {
+      method,
+      headers,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      ...(signal === undefined ? {} : { signal }),
+    });
   }
 
   private async request<T>(path: string, init?: RequestInit): Promise<T> {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,6 +1,8 @@
 export type {
   AdminAccount,
   AdminAccounts,
+  AdminDeviceFlow as DeviceFlow,
+  AdminDeviceFlowPoll as DeviceFlowPoll,
   AdminHistorySummary,
   AdminModels,
   AdminPerformanceMetric,
@@ -14,18 +16,5 @@ export type {
   AdminOperationalEvent,
   AdminUsagePage,
 } from "../../src/telemetry/admin.js";
-import type { AdminAccount } from "../../src/admin/api.js";
-
-export interface DeviceFlow {
-  readonly flowId: string;
-  readonly userCode: string;
-  readonly verificationUri: string;
-  readonly expiresAt: string;
-  readonly pollIntervalSeconds: number;
-}
-
-export type DeviceFlowPoll =
-  | { readonly state: "pending" | "expired" | "failed" }
-  | { readonly state: "complete"; readonly account: AdminAccount };
 
 export type StreamState = "connecting" | "live" | "reconnecting";

--- a/web/src/views/Accounts.svelte
+++ b/web/src/views/Accounts.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { errorMessage, type AdminClient } from "../api.js";
+  import { ApiError, errorMessage, type AdminClient } from "../api.js";
   import type { AdminAccounts, DeviceFlow } from "../types.js";
 
   let { client }: { client: AdminClient } = $props();
@@ -11,54 +11,272 @@
   let busy = $state("");
   let message = $state("");
   let failure = $state("");
+  let pollState: "idle" | "waiting" | "checking" | "retrying" = $state("idle");
   let hostInput: HTMLInputElement | null = null;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let expiryTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollAbort: AbortController | null = null;
+  let pollGeneration = 0;
+  let loadGeneration = 0;
+  let nextPollAtMs = 0;
+  let pollIntervalSeconds = 1;
 
-  onMount(load);
+  onMount(() => {
+    void load();
+    return dispose;
+  });
 
-  async function load(preserveFailure = false): Promise<void> {
+  async function load(
+    preserveFailure = false,
+    expectedGeneration?: number,
+  ): Promise<AdminAccounts | null> {
+    const requestGeneration = ++loadGeneration;
     loading = true;
     if (!preserveFailure) failure = "";
     try {
-      data = await client.accounts();
+      const loaded = await client.accounts();
+      if (
+        requestGeneration !== loadGeneration
+        || (expectedGeneration !== undefined && expectedGeneration !== pollGeneration)
+      ) return null;
+      data = loaded;
+      return loaded;
     } catch (error: unknown) {
+      if (
+        requestGeneration !== loadGeneration
+        || (expectedGeneration !== undefined && expectedGeneration !== pollGeneration)
+      ) return null;
       failure = errorMessage(error);
+      return null;
     } finally {
-      loading = false;
+      if (requestGeneration === loadGeneration) loading = false;
     }
   }
 
   async function start(): Promise<void> {
+    const replacedFlowId = flow?.flowId;
+    clearFlow();
+    loadGeneration += 1;
+    loading = false;
     busy = "login";
     failure = "";
+    message = "";
+    const generation = pollGeneration;
+    const controller = new AbortController();
+    pollAbort = controller;
     try {
-      flow = await client.startDeviceFlow(host);
+      if (replacedFlowId !== undefined) {
+        const canceled = await client.cancelDeviceFlow(replacedFlowId, controller.signal);
+        if (generation !== pollGeneration) return;
+        if (canceled.state === "complete") {
+          const refreshed = await load();
+          if (generation !== pollGeneration) return;
+          message = connectedMessage(canceled.account, refreshed);
+          return;
+        }
+      }
+      const started = await client.startDeviceFlow(host, controller.signal);
+      if (generation !== pollGeneration) return;
+      flow = started;
+      pollIntervalSeconds = started.pollIntervalSeconds;
+      nextPollAtMs = Date.parse(started.nextPollAt);
+      pollState = "waiting";
+      scheduleExpiry(generation);
+      schedulePoll(generation);
     } catch (error: unknown) {
+      if (generation !== pollGeneration || isAbort(error)) return;
       failure = errorMessage(error);
       hostInput?.focus();
     } finally {
-      busy = "";
+      if (generation === pollGeneration) {
+        pollAbort = null;
+        busy = "";
+      }
     }
   }
 
-  async function poll(): Promise<void> {
-    if (!flow) return;
-    busy = "poll";
+  function schedulePoll(generation: number): void {
+    if (generation !== pollGeneration || flow === null) return;
+    if (pollTimer !== null) clearTimeout(pollTimer);
+    const wakeAtMs = nextPollAtMs;
+    pollTimer = setTimeout(() => {
+      pollTimer = null;
+      void poll(generation);
+    }, Math.max(0, wakeAtMs - Date.now()));
+  }
+
+  function scheduleExpiry(generation: number): void {
+    if (generation !== pollGeneration || flow === null) return;
+    if (expiryTimer !== null) clearTimeout(expiryTimer);
+    expiryTimer = setTimeout(() => {
+      expiryTimer = null;
+      void settleExpiry(generation);
+    }, Math.max(0, Date.parse(flow.expiresAt) - Date.now()));
+  }
+
+  async function settleExpiry(generation: number): Promise<void> {
+    const expiringFlow = flow;
+    if (generation !== pollGeneration || expiringFlow === null) return;
+    pollState = "checking";
     try {
-      const result = await client.pollDeviceFlow(flow.flowId);
+      const result = await client.cancelDeviceFlow(expiringFlow.flowId);
+      if (generation !== pollGeneration) return;
       if (result.state === "complete") {
-        flow = null;
-        message = "Account connected.";
-        await load();
+        clearFlow();
+        const completionGeneration = pollGeneration;
+        const refreshed = await load(false, completionGeneration);
+        if (completionGeneration !== pollGeneration) return;
+        message = connectedMessage(result.account, refreshed);
+        return;
+      }
+      finishFlow(generation, "Authorization expired. Start a new login.");
+    } catch (error: unknown) {
+      if (generation !== pollGeneration) return;
+      finishFlow(generation, `Authorization expired: ${errorMessage(error)}`);
+    }
+  }
+
+  async function poll(generation: number): Promise<void> {
+    const activeFlow = flow;
+    if (generation !== pollGeneration || activeFlow === null) return;
+    const expiresAtMs = Date.parse(activeFlow.expiresAt);
+    if (Date.now() >= expiresAtMs) {
+      await settleExpiry(generation);
+      return;
+    }
+    if (Date.now() < nextPollAtMs) {
+      pollState = "waiting";
+      schedulePoll(generation);
+      return;
+    }
+    pollState = "checking";
+    const controller = new AbortController();
+    pollAbort = controller;
+    nextPollAtMs = Math.min(expiresAtMs, Date.now() + pollIntervalSeconds * 1000);
+    try {
+      const result = await client.pollDeviceFlow(activeFlow.flowId, controller.signal);
+      if (generation !== pollGeneration || flow?.flowId !== activeFlow.flowId) return;
+      if (result.state === "complete") {
+        clearFlow();
+        const completionGeneration = pollGeneration;
+        const refreshed = await load(false, completionGeneration);
+        if (completionGeneration !== pollGeneration) return;
+        message = connectedMessage(result.account, refreshed);
+      } else if (result.state === "pending") {
+        pollIntervalSeconds = result.pollIntervalSeconds;
+        nextPollAtMs = Date.parse(result.nextPollAt);
+        pollState = "waiting";
+        failure = "";
+        schedulePoll(generation);
       } else {
-        message = result.state === "pending"
-          ? "Authorization is still pending."
-          : `The flow ${result.state}.`;
+        finishFlow(
+          generation,
+          result.state === "expired"
+            ? "Authorization expired. Start a new login."
+            : result.state === "denied"
+              ? "Authorization was denied in GitHub."
+              : "Authorization could not be completed.",
+        );
       }
     } catch (error: unknown) {
+      if (generation !== pollGeneration || isAbort(error)) return;
       failure = errorMessage(error);
+      if (error instanceof ApiError && (error.status === 401 || error.status === 404)) {
+        clearFlow();
+        return;
+      }
+      pollState = "retrying";
+      message = "Automatic checking will retry at the allowed interval.";
+      nextPollAtMs = Math.max(nextPollAtMs, Date.now() + pollIntervalSeconds * 1000);
+      schedulePoll(generation);
     } finally {
-      busy = "";
+      if (generation === pollGeneration) pollAbort = null;
     }
+  }
+
+  function checkNow(): void {
+    if (flow === null) return;
+    if (Date.now() < nextPollAtMs) {
+      message = `The next check is available at ${new Date(nextPollAtMs).toLocaleTimeString()}.`;
+      schedulePoll(pollGeneration);
+      return;
+    }
+    if (pollState !== "checking") void poll(pollGeneration);
+  }
+
+  async function cancelFlow(): Promise<void> {
+    const canceledFlowId = flow?.flowId;
+    clearFlow();
+    message = "Authorization canceled in this view.";
+    failure = "";
+    const cancellationGeneration = pollGeneration;
+    if (canceledFlowId === undefined) return;
+    try {
+      const canceled = await client.cancelDeviceFlow(canceledFlowId);
+      if (canceled.state === "complete") {
+        const refreshed = await load();
+        if (cancellationGeneration !== pollGeneration) return;
+        message = connectedMessage(canceled.account, refreshed);
+      }
+    } catch (error: unknown) {
+      if (cancellationGeneration !== pollGeneration) return;
+      failure = `The local flow will expire automatically: ${errorMessage(error)}`;
+    }
+  }
+
+  function finishFlow(generation: number, text: string): void {
+    if (generation !== pollGeneration) return;
+    clearFlow();
+    message = "";
+    failure = text;
+  }
+
+  function stopPolling(): void {
+    pollGeneration += 1;
+    if (pollTimer !== null) clearTimeout(pollTimer);
+    pollTimer = null;
+    if (expiryTimer !== null) clearTimeout(expiryTimer);
+    expiryTimer = null;
+    pollAbort?.abort();
+    pollAbort = null;
+  }
+
+  function clearFlow(): void {
+    stopPolling();
+    flow = null;
+    pollState = "idle";
+  }
+
+  function dispose(): void {
+    const disposedFlowId = flow?.flowId;
+    stopPolling();
+    if (disposedFlowId !== undefined) {
+      void client.cancelDeviceFlow(disposedFlowId).catch(() => {
+        console.warn("Could not cancel device authorization during view disposal.");
+      });
+    }
+  }
+
+  function connectedMessage(
+    account: NonNullable<AdminAccounts["items"][number]>,
+    refreshed: AdminAccounts | null,
+  ): string {
+    const identity = account.login === null ? account.numericUserId : `@${account.login}`;
+    if (refreshed === null) {
+      return `Connected ${identity}. Refresh accounts to confirm the current default.`;
+    }
+    if (refreshed.defaultAccountId === account.accountId) {
+      return `Connected ${identity}; it is the default account.`;
+    }
+    const currentDefault = refreshed.items.find((item) => item.accountId === refreshed.defaultAccountId);
+    const defaultIdentity = currentDefault?.login ?? currentDefault?.numericUserId;
+    return defaultIdentity === undefined
+      ? `Connected ${identity}. No default account is currently selected.`
+      : `Connected ${identity}. Current default is ${currentDefault?.login === null ? defaultIdentity : `@${defaultIdentity}`}.`;
+  }
+
+  function isAbort(error: unknown): boolean {
+    return error instanceof DOMException && error.name === "AbortError";
   }
 
   async function useAccount(id: string): Promise<void> {
@@ -126,26 +344,35 @@
         placeholder="github.com or github.example.com"
       />
       <button class="primary" disabled={busy === "login"}>
-        {busy === "login" ? "Starting..." : "Start login"}
+        {busy === "login" ? "Starting..." : flow === null ? "Start login" : "Replace login"}
       </button>
     </div>
   </form>
 </section>
 
 {#if flow}
-  <section class="device-flow" aria-labelledby="device-title">
+  <section class="device-flow" aria-labelledby="device-title" aria-live="polite">
     <div>
       <p class="eyebrow">ONE-TIME CODE</p>
       <h2 id="device-title">Continue in GitHub</h2>
       <code>{flow.userCode}</code>
+      <p>
+        {pollState === "checking"
+          ? "Checking GitHub now..."
+          : pollState === "retrying"
+            ? "The last check failed; retrying automatically."
+            : "Waiting for GitHub approval; checking automatically."}
+      </p>
+      <small>Expires {new Date(flow.expiresAt).toLocaleString()}. Keep this view open to finish connecting.</small>
     </div>
     <div>
       <a class="button primary" href={flow.verificationUri} target="_blank" rel="noreferrer">
         Open verification page
       </a>
-      <button onclick={poll} disabled={busy === "poll"}>
-        {busy === "poll" ? "Checking..." : "I've authorized"}
+      <button onclick={checkNow} disabled={pollState === "checking"}>
+        {pollState === "checking" ? "Checking..." : "Check now"}
       </button>
+      <button class="quiet" onclick={() => void cancelFlow()}>Cancel</button>
     </div>
   </section>
 {/if}


### PR DESCRIPTION
Closes #100

## Summary

- make the Admin Accounts view poll device authorization automatically with one in-flight request, server-provided deadlines, manual cadence enforcement, explicit waiting/checking/retry/expiry/denial/completion states, and stale-response/view-disposal/replacement cleanup
- preserve `slow_down`, enforce shared server cadence, retain bounded terminal results for retry-safe delivery, and keep issued tokens in bounded in-memory settlement through identity/persistence without browser storage or logging
- bind Admin flows to their Admin Session with CSRF-protected cancellation and cleanup on logout, expiry, disposal, flow deadline, graceful shutdown, and forced shutdown
- update interactive CLI scheduling to honor authoritative deadlines and `slow_down`, preserve older-daemon interval fallback and JSON orchestration, cancel interrupted flows promptly, and report terminal outcomes distinctly
- preserve GitHub.com/GHES handling and existing default-account behavior; completion identifies the connected account and current default

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test` — 423 passed, 4 skipped
- `npx playwright test -c playwright.config.ts tests/e2e/admin.spec.ts` — 11 passed

## Review gate

Repeated `/code-review` standards and issue-spec passes after each important finding, including cadence, cancellation/commit races, session ownership, stale UI loads, terminal replay, shutdown, post-token settlement, persistence cleanup, cross-version CLI compatibility, and timeout bounds. The final Standards and Spec passes both reported no significant issues.

## Evidence boundary

No live GitHub authorization or official SDK suite was run; both require separate explicit authorization and are not required by #100's deterministic verification plan. All automated credentials and device codes are synthetic.

## macOS CI follow-up

- **Cause:** the stale-response E2E mixed Playwright's fake browser clock with a real 100 ms fixture timer. After fake time started the poll, Playwright still had to complete normal click actionability checks; on slower macOS the real completion could remove the flow and detach **Cancel** first.
- **Fix:** replace the timing race with a fixture-owned held poll. The test waits until the GET is in flight, clicks the accessible **Cancel** control normally, observes the cancellation DELETE, releases and awaits the stale completion attempt, then proves the fixture completed while the canceled UI did not settle it. Release is protected by `finally`.
- **Validation:** targeted regression 10/10 repeated; full `tests/e2e/admin.spec.ts` 11/11; `npm run web:typecheck`; `npm run lint`; `tests/unit/daemon_oauth.test.ts` 11/11.
- **Review:** three `/code-review` iterations. Early lifecycle findings (failure-safe release, awaiting route settlement, cleanup coverage) were fixed; final Standards and Spec reviews reported zero important findings.

Follow-up commit: `317cbaf96f49cc6d2915d41678b580c101e07efb`.
