### PR TITLE
Normalize retained protocol failures

### DIFF
--- a/src/copilot/backend.ts
+++ b/src/copilot/backend.ts
@@ -37,6 +37,7 @@ export interface CopilotBackend {
 }
 
 export interface ScriptedCopilotHandlers {
+  bindError?: unknown;
   chat?: ChatResponse | ((request: ChatRequest) => ChatResponse | Promise<ChatResponse>);
   chatStream?: Uint8Array[] | AsyncIterable<Uint8Array> | ((request: ChatRequest) => Uint8Array[] | AsyncIterable<Uint8Array>);
   responses?: UpstreamByteResponse | ((request: NativeResponsesUpstreamRequest) => UpstreamByteResponse | Promise<UpstreamByteResponse>);
@@ -58,6 +59,9 @@ export class ScriptedCopilotBackend implements CopilotBackend {
   async bind(account: Readonly<BoundAccount>, _signal: AbortSignal): Promise<BoundCopilot> {
     if (this.closed) {
       throw new DOMException("closed", "AbortError");
+    }
+    if (this.handlers.bindError !== undefined) {
+      throw this.handlers.bindError;
     }
     const target = { endpoint: this.endpoint, token: this.token };
     const captured = this.captured;

--- a/src/copilot/failures.ts
+++ b/src/copilot/failures.ts
@@ -1,0 +1,214 @@
+import { AccountDirectoryError } from "../accounts/account_directory.js";
+import {
+  failureFromSignal,
+  failureFromUnknown,
+  failureWithOrigin,
+  GatewayFailureError,
+  isGatewayFailureError,
+  safeRetryAfter,
+  type GatewayFailureOrigin,
+} from "../gateway/failures.js";
+import { ChatSseError } from "./chat_sse.js";
+import type { ChatStreamFrame } from "../protocols/chat_completions/types.js";
+import { CapiFetchError } from "./models_source.js";
+import { TokenRefreshError } from "./token_refresh.js";
+import {
+  InvalidUpstreamResponseError,
+  mapTokenRefreshError,
+  UpstreamBodyLimitError,
+  UpstreamTimeoutError,
+} from "./transport.js";
+import { InferencePoolAcquireTimeoutError } from "./inference_pool.js";
+
+const ACCOUNT_BIND_ORIGIN = { source: "account", phase: "bind" } as const;
+const CATALOG_ORIGIN = { source: "catalog", phase: "discover" } as const;
+const CREDENTIAL_ORIGIN = { source: "credential", phase: "refresh" } as const;
+
+export function normalizeAccountBindingFailure(error: unknown): GatewayFailureError {
+  if (isGatewayFailureError(error)) {
+    return new GatewayFailureError(failureWithOrigin(error.failure, ACCOUNT_BIND_ORIGIN));
+  }
+  if (error instanceof AccountDirectoryError && (error.code === "no_default" || error.code === "not_found")) {
+    return new GatewayFailureError({ kind: "authentication", ...ACCOUNT_BIND_ORIGIN, cause: error });
+  }
+  return new GatewayFailureError(failureFromUnknown(error, ACCOUNT_BIND_ORIGIN));
+}
+
+export function normalizeCatalogFailure(error: unknown, signal: AbortSignal): GatewayFailureError {
+  if (isGatewayFailureError(error)) {
+    return new GatewayFailureError(failureWithOrigin(error.failure, CATALOG_ORIGIN));
+  }
+  if (error instanceof TokenRefreshError) {
+    return tokenRefreshFailure(error);
+  }
+  if (error instanceof CapiFetchError) {
+    if (error.failureKind === "upstream_http") {
+      const retryAfter = error.status === 429 ? safeRetryAfter(error.retryAfter) : undefined;
+      return new GatewayFailureError({
+        kind: "upstream_http",
+        status: error.status,
+        ...CATALOG_ORIGIN,
+        ...(retryAfter === undefined ? {} : { retryAfter }),
+      });
+    }
+    return new GatewayFailureError({
+      kind: error.failureKind,
+      ...CATALOG_ORIGIN,
+      cause: error,
+    });
+  }
+  if (isAbortError(error)) {
+    return new GatewayFailureError(failureFromSignal(signal, CATALOG_ORIGIN));
+  }
+  return new GatewayFailureError({
+    kind: "internal",
+    source: "gateway",
+    phase: "internal",
+    cause: error,
+  });
+}
+
+export function normalizeCopilotBindingFailure(error: unknown, signal: AbortSignal): GatewayFailureError {
+  if (isGatewayFailureError(error)) {
+    return new GatewayFailureError(failureWithOrigin(error.failure, CREDENTIAL_ORIGIN));
+  }
+  if (error instanceof TokenRefreshError) {
+    return tokenRefreshFailure(error);
+  }
+  if (isAbortError(error)) {
+    return new GatewayFailureError(failureFromSignal(signal, CREDENTIAL_ORIGIN));
+  }
+  const transport = recognizedTransportFailure(error);
+  if (transport !== undefined) {
+    return new GatewayFailureError({
+      kind: transport,
+      source: "transport",
+      phase: "connect",
+      ...(transport === "aborted" ? {} : { cause: error }),
+    });
+  }
+  return new GatewayFailureError({
+    kind: "internal",
+    source: "gateway",
+    phase: "internal",
+    cause: error,
+  });
+}
+
+export function normalizeTransportFailure(
+  error: unknown,
+  signal: AbortSignal,
+  origin: Readonly<GatewayFailureOrigin>,
+): GatewayFailureError {
+  if (isGatewayFailureError(error)) {
+    return new GatewayFailureError(failureWithOrigin(error.failure, origin));
+  }
+  if (isAbortError(error)) {
+    return new GatewayFailureError(failureFromSignal(signal, origin));
+  }
+  const kind = recognizedTransportFailure(error);
+  if (kind === undefined) {
+    return new GatewayFailureError({
+      kind: "internal",
+      source: "gateway",
+      phase: "internal",
+      cause: error,
+    });
+  }
+  return new GatewayFailureError({
+    kind,
+    ...origin,
+    ...(kind === "aborted" ? {} : { cause: error }),
+  });
+}
+
+export function normalizeChatStreamFailure(
+  error: unknown,
+  signal: AbortSignal,
+  phase: "stream" | "parse" = "parse",
+): GatewayFailureError {
+  const origin = { source: "parser", phase } as const;
+  if (isGatewayFailureError(error)) {
+    return new GatewayFailureError(failureWithOrigin(error.failure, origin));
+  }
+  if (isAbortError(error)) {
+    return new GatewayFailureError(failureFromSignal(signal, origin));
+  }
+  if (error instanceof ChatSseError) {
+    const kind = error.code === "truncated" ? "upstream_stream_truncated" : "invalid_upstream_response";
+    return new GatewayFailureError({ kind, ...origin, cause: error });
+  }
+  const transport = recognizedTransportFailure(error);
+  if (transport !== undefined) {
+    return new GatewayFailureError({
+      kind: transport,
+      source: "transport",
+      phase: "stream",
+      ...(transport === "aborted" ? {} : { cause: error }),
+    });
+  }
+  return new GatewayFailureError({
+    kind: "internal",
+    source: "gateway",
+    phase: "internal",
+    cause: error,
+  });
+}
+
+export function upstreamStreamEventFailure(): GatewayFailureError {
+  return new GatewayFailureError({
+    kind: "upstream_stream_error",
+    source: "parser",
+    phase: "stream",
+  });
+}
+
+export async function* normalizeChatFrames(
+  frames: AsyncIterable<ChatStreamFrame>,
+  signal: AbortSignal,
+): AsyncIterable<ChatStreamFrame> {
+  try {
+    yield* frames;
+  } catch (error: unknown) {
+    throw normalizeChatStreamFailure(error, signal);
+  }
+}
+
+function tokenRefreshFailure(error: TokenRefreshError): GatewayFailureError {
+  return new GatewayFailureError({
+    kind: mapTokenRefreshError(error),
+    ...CREDENTIAL_ORIGIN,
+    cause: error,
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function recognizedTransportFailure(
+  error: unknown,
+): "aborted" | "invalid_upstream_response" | "upstream_timeout" | "upstream_network" | undefined {
+  if (isAbortError(error)) {
+    return "aborted";
+  }
+  if (error instanceof UpstreamBodyLimitError || error instanceof InvalidUpstreamResponseError) {
+    return "invalid_upstream_response";
+  }
+  if (error instanceof UpstreamTimeoutError || error instanceof InferencePoolAcquireTimeoutError) {
+    return "upstream_timeout";
+  }
+  if (error instanceof TypeError || hasNetworkErrorCode(error)) {
+    return "upstream_network";
+  }
+  return undefined;
+}
+
+function hasNetworkErrorCode(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) {
+    return false;
+  }
+  const code = (error as Error & { readonly code?: unknown }).code;
+  return typeof code === "string"
+    && /^(?:UND_ERR_|ECONN|ENET|EHOST|EAI_)/u.test(code);
+}

--- a/src/gateway/failures.ts
+++ b/src/gateway/failures.ts
@@ -1,23 +1,103 @@
+export type GatewayFailureSource =
+  | "request"
+  | "account"
+  | "credential"
+  | "catalog"
+  | "transport"
+  | "parser"
+  | "converter"
+  | "continuation"
+  | "gateway";
+
+export type GatewayFailurePhase =
+  | "decode"
+  | "bind"
+  | "refresh"
+  | "discover"
+  | "connect"
+  | "headers"
+  | "body"
+  | "stream"
+  | "parse"
+  | "convert"
+  | "resume"
+  | "admission"
+  | "deadline"
+  | "internal";
+
+export interface GatewayFailureOrigin {
+  readonly source: GatewayFailureSource;
+  readonly phase: GatewayFailurePhase;
+}
+
+interface GatewayFailureDetails {
+  readonly source?: GatewayFailureSource;
+  readonly phase?: GatewayFailurePhase;
+  readonly cause?: unknown;
+}
+
 export type GatewayFailure =
-  | { readonly kind: "invalid_request"; readonly cause?: unknown }
-  | { readonly kind: "body_too_large"; readonly cause?: unknown }
-  | { readonly kind: "unsupported_media_type"; readonly cause?: unknown }
-  | { readonly kind: "unsupported_semantics"; readonly cause?: unknown }
-  | { readonly kind: "authentication"; readonly cause?: unknown }
-  | { readonly kind: "permission"; readonly cause?: unknown }
-  | { readonly kind: "model_not_found"; readonly cause?: unknown }
-  | { readonly kind: "queue_full" }
-  | { readonly kind: "queue_timeout" }
-  | { readonly kind: "upstream_http"; readonly status: number; readonly retryAfter?: string }
-  | { readonly kind: "upstream_timeout"; readonly cause?: unknown }
-  | { readonly kind: "upstream_network"; readonly cause?: unknown }
-  | { readonly kind: "upstream_stream_error"; readonly cause?: unknown }
-  | { readonly kind: "upstream_stream_truncated"; readonly cause?: unknown }
-  | { readonly kind: "invalid_upstream_response"; readonly cause?: unknown }
-  | { readonly kind: "invalid_tool_arguments"; readonly cause?: unknown }
-  | { readonly kind: "invalid_logprobs"; readonly cause?: unknown }
-  | { readonly kind: "aborted" }
-  | { readonly kind: "internal"; readonly cause?: unknown };
+  | ({ readonly kind: "invalid_request" } & GatewayFailureDetails)
+  | ({ readonly kind: "body_too_large" } & GatewayFailureDetails)
+  | ({ readonly kind: "unsupported_media_type" } & GatewayFailureDetails)
+  | ({ readonly kind: "unsupported_semantics" } & GatewayFailureDetails)
+  | ({ readonly kind: "authentication" } & GatewayFailureDetails)
+  | ({ readonly kind: "permission" } & GatewayFailureDetails)
+  | ({ readonly kind: "model_not_found" } & GatewayFailureDetails)
+  | ({ readonly kind: "queue_full" } & GatewayFailureDetails)
+  | ({ readonly kind: "queue_timeout" } & GatewayFailureDetails)
+  | ({
+    readonly kind: "upstream_http";
+    readonly status: number;
+    readonly retryAfter?: string;
+  } & GatewayFailureDetails)
+  | ({ readonly kind: "upstream_timeout" } & GatewayFailureDetails)
+  | ({ readonly kind: "upstream_network" } & GatewayFailureDetails)
+  | ({ readonly kind: "upstream_stream_error" } & GatewayFailureDetails)
+  | ({ readonly kind: "upstream_stream_truncated" } & GatewayFailureDetails)
+  | ({ readonly kind: "invalid_upstream_response" } & GatewayFailureDetails)
+  | ({ readonly kind: "invalid_tool_arguments" } & GatewayFailureDetails)
+  | ({ readonly kind: "invalid_logprobs" } & GatewayFailureDetails)
+  | ({ readonly kind: "aborted" } & GatewayFailureDetails)
+  | ({ readonly kind: "internal" } & GatewayFailureDetails);
+
+export type GatewayFailureOutcome =
+  | "client_error"
+  | "authentication_error"
+  | "overloaded"
+  | "upstream_error"
+  | "timeout"
+  | "aborted"
+  | "internal_error";
+
+type StaticGatewayFailureKind = Exclude<GatewayFailure["kind"], "upstream_http">;
+
+interface GatewayFailurePolicy {
+  readonly status: number;
+  readonly message: string;
+  readonly outcome: GatewayFailureOutcome;
+}
+
+const FAILURE_POLICY: Readonly<Record<StaticGatewayFailureKind, GatewayFailurePolicy>> = {
+  invalid_request: { status: 400, message: "invalid request", outcome: "client_error" },
+  body_too_large: { status: 413, message: "request body too large", outcome: "client_error" },
+  unsupported_media_type: { status: 415, message: "unsupported media type", outcome: "client_error" },
+  unsupported_semantics: { status: 422, message: "unsupported semantics", outcome: "client_error" },
+  authentication: { status: 401, message: "authentication failed", outcome: "authentication_error" },
+  permission: { status: 403, message: "permission denied", outcome: "authentication_error" },
+  model_not_found: { status: 404, message: "model not found", outcome: "client_error" },
+  queue_full: { status: 503, message: "server overloaded", outcome: "overloaded" },
+  queue_timeout: { status: 503, message: "server overloaded", outcome: "overloaded" },
+  upstream_timeout: { status: 504, message: "upstream timeout", outcome: "timeout" },
+  upstream_network: { status: 502, message: "upstream request failed", outcome: "upstream_error" },
+  upstream_stream_error: { status: 502, message: "upstream request failed", outcome: "upstream_error" },
+  upstream_stream_truncated: { status: 502, message: "upstream request failed", outcome: "upstream_error" },
+  invalid_upstream_response: { status: 502, message: "invalid upstream response", outcome: "upstream_error" },
+  invalid_tool_arguments: { status: 502, message: "invalid upstream response", outcome: "upstream_error" },
+  invalid_logprobs: { status: 502, message: "invalid upstream response", outcome: "upstream_error" },
+  aborted: { status: 500, message: "internal error", outcome: "aborted" },
+  internal: { status: 500, message: "internal error", outcome: "internal_error" },
+};
 
 export class GatewayFailureError extends Error {
   constructor(readonly failure: GatewayFailure) {
@@ -30,12 +110,76 @@ export function isGatewayFailureError(error: unknown): error is GatewayFailureEr
   return error instanceof GatewayFailureError;
 }
 
-export function failureFromUnknown(error: unknown): GatewayFailure {
+export function failureWithOrigin(
+  failure: Readonly<GatewayFailure>,
+  origin: Readonly<GatewayFailureOrigin>,
+): GatewayFailure {
+  if (failure.source !== undefined && failure.phase !== undefined) {
+    return failure;
+  }
+  return {
+    ...failure,
+    source: failure.source ?? origin.source,
+    phase: failure.phase ?? origin.phase,
+  };
+}
+
+export function failureFromSignal(
+  signal: AbortSignal,
+  origin: Readonly<GatewayFailureOrigin>,
+): GatewayFailure {
+  if (!signal.aborted) {
+    return { kind: "internal", ...origin };
+  }
+  const reason = signal.reason;
+  if (isGatewayFailureError(reason)) {
+    return failureWithOrigin(reason.failure, origin);
+  }
+  return { kind: "aborted", ...origin };
+}
+
+export function failureFromUnknown(
+  error: unknown,
+  origin: Readonly<GatewayFailureOrigin> = { source: "gateway", phase: "internal" },
+): GatewayFailure {
   if (isGatewayFailureError(error)) {
-    return error.failure;
+    return failureWithOrigin(error.failure, origin);
   }
-  if (error instanceof Error && error.name === "AbortError") {
-    return { kind: "aborted" };
+  return { kind: "internal", ...origin, cause: error };
+}
+
+export function failureOutcome(failure: Readonly<GatewayFailure>): GatewayFailureOutcome {
+  if (failure.kind === "upstream_http") {
+    return "upstream_error";
   }
-  return { kind: "internal", cause: error };
+  return FAILURE_POLICY[failure.kind].outcome;
+}
+
+export function defaultFailureStatus(failure: Readonly<GatewayFailure>): number {
+  if (failure.kind === "upstream_http") {
+    return Number.isInteger(failure.status) && failure.status >= 400 && failure.status <= 599
+      ? failure.status
+      : 502;
+  }
+  return FAILURE_POLICY[failure.kind].status;
+}
+
+export function safeFailureMessage(failure: Readonly<GatewayFailure>): string {
+  if (failure.kind === "upstream_http") {
+    return "upstream request failed";
+  }
+  return FAILURE_POLICY[failure.kind].message;
+}
+
+export function safeRetryAfter(value: string | undefined): string | undefined {
+  if (value === undefined || value.length === 0) {
+    return undefined;
+  }
+  if (/^\d+$/u.test(value)) {
+    return value;
+  }
+  if (/^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/u.test(value) && !Number.isNaN(Date.parse(value))) {
+    return value;
+  }
+  return undefined;
 }

--- a/src/gateway/hono_app.ts
+++ b/src/gateway/hono_app.ts
@@ -31,6 +31,7 @@ export type ProtocolEndpoint = (
 export type FailurePresenter = (
   failure: Readonly<GatewayFailure>,
   requestId: string,
+  request: Request,
 ) => Response;
 
 export interface RouteRegistration {
@@ -39,6 +40,7 @@ export interface RouteRegistration {
   readonly admission: "none" | "inference";
   readonly body: "none" | "wire-json-object";
   readonly presentFailure: FailurePresenter;
+  readonly observeFailure?: (failure: Readonly<GatewayFailure>, requestId: string) => void;
   readonly endpoint: ProtocolEndpoint;
 }
 
@@ -173,7 +175,8 @@ async function handleRoute(
     if (controller.signal.aborted) {
       const timeoutFailure = upstreamTimeoutFromSignal(controller.signal);
       if (timeoutFailure !== undefined && !request.signal.aborted) {
-        return route.presentFailure(timeoutFailure, requestId);
+        observeRouteFailure(route, timeoutFailure, requestId);
+        return route.presentFailure(timeoutFailure, requestId, request);
       }
       return new Response(null);
     }
@@ -182,7 +185,8 @@ async function handleRoute(
     if (controller.signal.aborted) {
       const timeoutFailure = upstreamTimeoutFromSignal(controller.signal);
       if (timeoutFailure !== undefined && !request.signal.aborted) {
-        return route.presentFailure(timeoutFailure, requestId);
+        observeRouteFailure(route, timeoutFailure, requestId);
+        return route.presentFailure(timeoutFailure, requestId, request);
       }
       return new Response(null);
     }
@@ -194,19 +198,33 @@ async function handleRoute(
     return attachLifecycle(response, controller, cleanup, stream ? dependencies.streamFinished : undefined);
   } catch (error: unknown) {
     const failure = failureFromUnknown(error);
-    if (failure.kind === "aborted" || request.signal.aborted) {
-      const timeoutFailure = upstreamTimeoutFromSignal(controller.signal);
-      if (timeoutFailure !== undefined && !request.signal.aborted) {
-        return route.presentFailure(timeoutFailure, requestId);
-      }
+    const timeoutFailure = upstreamTimeoutFromSignal(controller.signal);
+    if (timeoutFailure !== undefined && !request.signal.aborted) {
+      observeRouteFailure(route, timeoutFailure, requestId);
+      return route.presentFailure(timeoutFailure, requestId, request);
+    }
+    if (request.signal.aborted || (failure.kind === "aborted" && controller.signal.aborted)) {
       return new Response(null);
     }
     holdUntilBody = true;
-    return attachLifecycle(route.presentFailure(failure, requestId), controller, cleanup);
+    observeRouteFailure(route, failure, requestId);
+    return attachLifecycle(route.presentFailure(failure, requestId, request), controller, cleanup);
   } finally {
     if (!holdUntilBody) {
       cleanup();
     }
+  }
+}
+
+function observeRouteFailure(
+  route: Readonly<RouteRegistration>,
+  failure: Readonly<GatewayFailure>,
+  requestId: string,
+): void {
+  try {
+    route.observeFailure?.(failure, requestId);
+  } catch (_error: unknown) {
+    // Observability cannot alter public failure bytes.
   }
 }
 

--- a/src/gateway/timeouts.ts
+++ b/src/gateway/timeouts.ts
@@ -34,6 +34,10 @@ export function armTimeout(
 
 export function abortWithTimeout(controller: AbortController): void {
   if (!controller.signal.aborted) {
-    controller.abort(new GatewayFailureError({ kind: "upstream_timeout" }));
+    controller.abort(new GatewayFailureError({
+      kind: "upstream_timeout",
+      source: "gateway",
+      phase: "deadline",
+    }));
   }
 }

--- a/src/protocols/anthropic_messages/endpoint.ts
+++ b/src/protocols/anthropic_messages/endpoint.ts
@@ -1,9 +1,20 @@
-import { AccountDirectoryError, type AccountDirectory } from "../../accounts/account_directory.js";
+import type { AccountDirectory } from "../../accounts/account_directory.js";
 import type { AccountModelPreferences } from "../../accounts/model_preferences.js";
-import type { CopilotBackend } from "../../copilot/backend.js";
+import type { BoundCopilot, CopilotBackend } from "../../copilot/backend.js";
 import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
-import { CapiFetchError } from "../../copilot/models_source.js";
-import { failureFromUnknown, GatewayFailureError, type GatewayFailure } from "../../gateway/failures.js";
+import {
+  normalizeAccountBindingFailure,
+  normalizeCatalogFailure,
+  normalizeCopilotBindingFailure,
+  normalizeTransportFailure,
+} from "../../copilot/failures.js";
+import {
+  failureFromSignal,
+  failureFromUnknown,
+  failureOutcome,
+  GatewayFailureError,
+  safeRetryAfter,
+} from "../../gateway/failures.js";
 import type { DecodedHttpRequest, RouteRegistration } from "../../gateway/hono_app.js";
 import type { RequestScope } from "../../gateway/request_scope.js";
 import { memberValues, type WireJsonObject } from "../../serialization/wire_json.js";
@@ -12,9 +23,9 @@ import { resolveModel } from "../model_catalog/resolver.js";
 import { convertChatResponse } from "./bridge.js";
 import { convertAnthropicRequest } from "./request.js";
 import { createAnthropicStreamResponse } from "./stream.js";
-import { anthropicErrorBody, type AnthropicErrorType } from "./wire.js";
 import type { TelemetryRecorder, UsageUpdate } from "../../telemetry/recorder.js";
 import type { ProtocolPerformanceObserver } from "../../telemetry/runtime.js";
+import { presentAnthropicFailure } from "./failure_presenter.js";
 
 export interface AnthropicMessagesRouteDependencies {
   readonly directory: AccountDirectory;
@@ -39,11 +50,11 @@ export function createAnthropicMessagesRoute(dependencies: AnthropicMessagesRout
     path: "/v1/messages",
     admission: "inference",
     body: "wire-json-object",
-    presentFailure: (failure, requestId) => {
+    presentFailure: presentAnthropicFailure,
+    observeFailure: (failure, requestId) => {
       const usage = attempts.get(requestId) ?? createUsageAttempt(dependencies, new AbortController().signal);
       usage.failure(new GatewayFailureError(failure));
       attempts.delete(requestId);
-      return presentAnthropicFailure(failure, requestId);
     },
     endpoint: (request, scope) => executeAnthropicMessages(dependencies, request, scope, attempts),
   };
@@ -77,7 +88,7 @@ async function executeAnthropicMessages(
   usage.setModel(resolved.upstreamModel);
   const chatBody = convertAnthropicRequest(request.body, resolved.upstreamModel, requestedModel.value);
   const stream = chatBody.stream === true;
-  const copilot = await dependencies.copilot.bind(account, scope.signal);
+  const copilot = await bindCopilot(dependencies.copilot, account, scope.signal);
   const chatRequest: ChatRequest = {
     model: resolved.upstreamModel,
     body: new TextEncoder().encode(JSON.stringify(chatBody)),
@@ -90,13 +101,13 @@ async function executeAnthropicMessages(
   };
 
   if (!stream) {
-    const upstream = await copilot.completeChat(chatRequest);
+    const upstream = await completeChat(copilot, chatRequest);
     throwIfUpstreamHttp(upstream);
     if (upstream.body.byteLength > scope.config.limits.nonstreamBodyBytes) {
       throw new GatewayFailureError({ kind: "invalid_upstream_response" });
     }
     return measureBuffered(dependencies, () => {
-      const body = convertChatResponse(upstream);
+      const body = convertBufferedChatResponse(upstream);
       usage.success(anthropicUsageTokens(body));
       return new Response(JSON.stringify(body), {
         headers: { ...JSON_HEADERS, "request-id": scope.requestId },
@@ -104,7 +115,23 @@ async function executeAnthropicMessages(
     });
   }
 
-  const upstream = await copilot.openChatStream(chatRequest);
+  function convertBufferedChatResponse(upstream: Parameters<typeof convertChatResponse>[0]) {
+    try {
+      return convertChatResponse(upstream);
+    } catch (error: unknown) {
+      if (error instanceof GatewayFailureError) {
+        throw error;
+      }
+      throw new GatewayFailureError({
+        kind: "invalid_upstream_response",
+        source: "converter",
+        phase: "convert",
+        cause: error,
+      });
+    }
+  }
+
+  const upstream = await openChatStream(copilot, chatRequest);
   throwIfUpstreamHttp(upstream);
   return createAnthropicStreamResponse({
     upstream,
@@ -124,97 +151,6 @@ function measureBuffered<T>(dependencies: AnthropicMessagesRouteDependencies, wo
   return dependencies.performanceObserver === undefined
     ? work()
     : dependencies.performanceObserver.measure("buffered", work);
-}
-
-function presentAnthropicFailure(failure: Readonly<GatewayFailure>, requestId: string): Response {
-  const mapped = mapAnthropicFailure(failure);
-  const headers = new Headers({ ...JSON_HEADERS, "request-id": requestId });
-  if (failure.kind === "upstream_http" && failure.retryAfter !== undefined) {
-    headers.set("retry-after", failure.retryAfter);
-  }
-  return new Response(anthropicErrorBody(mapped.type, mapped.message, requestId), {
-    status: mapped.status,
-    headers,
-  });
-}
-
-function mapAnthropicFailure(failure: Readonly<GatewayFailure>): {
-  readonly status: number;
-  readonly type: AnthropicErrorType;
-  readonly message: string;
-} {
-  if (failure.kind === "upstream_http") {
-    return {
-      status: failure.status,
-      type: upstreamAnthropicErrorType(failure.status),
-      message: "upstream request failed",
-    };
-  }
-  if (failure.kind === "body_too_large") {
-    return { status: 413, type: "request_too_large", message: "request body too large" };
-  }
-  if (failure.kind === "unsupported_media_type") {
-    return { status: 415, type: "invalid_request_error", message: "unsupported media type" };
-  }
-  if (failure.kind === "unsupported_semantics") {
-    return { status: 400, type: "invalid_request_error", message: "unsupported semantics" };
-  }
-  if (failure.kind === "authentication") {
-    return { status: 401, type: "authentication_error", message: "authentication failed" };
-  }
-  if (failure.kind === "permission") {
-    return { status: 403, type: "permission_error", message: "permission denied" };
-  }
-  if (failure.kind === "model_not_found") {
-    return { status: 404, type: "not_found_error", message: "model not found" };
-  }
-  if (failure.kind === "queue_full" || failure.kind === "queue_timeout") {
-    return { status: 529, type: "overloaded_error", message: "server overloaded" };
-  }
-  if (failure.kind === "upstream_timeout") {
-    return { status: 504, type: "timeout_error", message: "upstream timeout" };
-  }
-  if (failure.kind === "upstream_network") {
-    return { status: 502, type: "api_error", message: "upstream request failed" };
-  }
-  if (failure.kind === "invalid_upstream_response") {
-    return { status: 502, type: "api_error", message: "invalid upstream response" };
-  }
-  if (failure.kind === "internal") {
-    return { status: 500, type: "api_error", message: "internal error" };
-  }
-  return { status: 400, type: "invalid_request_error", message: "invalid request" };
-}
-
-function upstreamAnthropicErrorType(status: number): AnthropicErrorType {
-  if (status === 400 || status === 415 || status === 422) {
-    return "invalid_request_error";
-  }
-  if (status === 401) {
-    return "authentication_error";
-  }
-  if (status === 402) {
-    return "billing_error";
-  }
-  if (status === 403) {
-    return "permission_error";
-  }
-  if (status === 404) {
-    return "not_found_error";
-  }
-  if (status === 413) {
-    return "request_too_large";
-  }
-  if (status === 429) {
-    return "rate_limit_error";
-  }
-  if (status === 504) {
-    return "timeout_error";
-  }
-  if (status === 529) {
-    return "overloaded_error";
-  }
-  return "api_error";
 }
 
 function assertAnthropicVersion(headers: Headers): void {
@@ -243,10 +179,7 @@ async function bindAccount(
   try {
     return await dependencies.directory.bindDefault(signal);
   } catch (error: unknown) {
-    if (error instanceof AccountDirectoryError && (error.code === "no_default" || error.code === "not_found")) {
-      throw new GatewayFailureError({ kind: "authentication" });
-    }
-    throw error;
+    throw normalizeAccountBindingFailure(error);
   }
 }
 
@@ -264,23 +197,41 @@ async function loadCatalog(
     );
     return catalog;
   } catch (error: unknown) {
-    if (error instanceof CapiFetchError) {
-      if (error.failureKind === "upstream_timeout") {
-        throw new GatewayFailureError({ kind: "upstream_timeout", cause: error });
-      }
-      if (error.failureKind === "upstream_network") {
-        throw new GatewayFailureError({ kind: "upstream_network", cause: error });
-      }
-      if (error.failureKind === "invalid_upstream_response") {
-        throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
-      }
-      throw new GatewayFailureError({
-        kind: "upstream_http",
-        status: error.status,
-        ...(error.retryAfter === undefined ? {} : { retryAfter: error.retryAfter }),
-      });
-    }
-    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+    throw normalizeCatalogFailure(error, signal);
+  }
+}
+
+async function bindCopilot(
+  copilot: CopilotBackend,
+  account: Awaited<ReturnType<AccountDirectory["bindDefault"]>>,
+  signal: AbortSignal,
+): Promise<BoundCopilot> {
+  try {
+    return await copilot.bind(account, signal);
+  } catch (error: unknown) {
+    throw normalizeCopilotBindingFailure(error, signal);
+  }
+}
+
+async function completeChat(
+  copilot: BoundCopilot,
+  request: Readonly<ChatRequest>,
+) {
+  try {
+    return await copilot.completeChat(request);
+  } catch (error: unknown) {
+    throw normalizeTransportFailure(error, request.signal, { source: "transport", phase: "headers" });
+  }
+}
+
+async function openChatStream(
+  copilot: BoundCopilot,
+  request: Readonly<ChatRequest>,
+) {
+  try {
+    return await copilot.openChatStream(request);
+  } catch (error: unknown) {
+    throw normalizeTransportFailure(error, request.signal, { source: "transport", phase: "headers" });
   }
 }
 
@@ -300,17 +251,7 @@ function retryAfterHeader(status: number, headers: Headers): string | undefined 
   if (status !== 429) {
     return undefined;
   }
-  const value = headers.get("retry-after");
-  if (value === null || value.length === 0) {
-    return undefined;
-  }
-  if (/^\d+$/u.test(value)) {
-    return value;
-  }
-  if (value.includes(",") && !/^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT$/u.test(value)) {
-    return undefined;
-  }
-  return Number.isNaN(Date.parse(value)) ? undefined : value;
+  return safeRetryAfter(headers.get("retry-after") ?? undefined);
 }
 
 function hasVisionInput(messages: unknown[]): boolean {
@@ -411,46 +352,9 @@ function usageOutcome(error: unknown, signal: AbortSignal): UsageUpdate["outcome
   if (signal.aborted) {
     return abortOutcome(signal);
   }
-  if (error instanceof Error && error.name === "AbortError") {
-    return "aborted";
-  }
-  if (error instanceof AccountDirectoryError) {
-    return "authentication_error";
-  }
-  const failure = failureFromUnknown(error);
-  switch (failure.kind) {
-  case "invalid_request":
-  case "body_too_large":
-  case "unsupported_media_type":
-  case "unsupported_semantics":
-  case "model_not_found":
-    return "client_error";
-  case "authentication":
-  case "permission":
-    return "authentication_error";
-  case "queue_full":
-  case "queue_timeout":
-    return "overloaded";
-  case "upstream_timeout":
-    return "timeout";
-  case "upstream_http":
-  case "upstream_network":
-  case "upstream_stream_error":
-  case "upstream_stream_truncated":
-  case "invalid_upstream_response":
-  case "invalid_tool_arguments":
-  case "invalid_logprobs":
-    return "upstream_error";
-  case "aborted":
-    return "aborted";
-  case "internal":
-    return "internal_error";
-  }
+  return failureOutcome(failureFromUnknown(error, { source: "gateway", phase: "internal" }));
 }
 
 function abortOutcome(signal: AbortSignal): UsageUpdate["outcome"] {
-  const reason = signal.reason;
-  return reason instanceof GatewayFailureError && reason.failure.kind === "upstream_timeout"
-    ? "timeout"
-    : "aborted";
+  return failureOutcome(failureFromSignal(signal, { source: "gateway", phase: "deadline" }));
 }

--- a/src/protocols/anthropic_messages/failure_presenter.ts
+++ b/src/protocols/anthropic_messages/failure_presenter.ts
@@ -1,0 +1,68 @@
+import {
+  defaultFailureStatus,
+  safeFailureMessage,
+  safeRetryAfter,
+  type GatewayFailure,
+} from "../../gateway/failures.js";
+import { anthropicErrorBody, type AnthropicErrorType } from "./wire.js";
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+} as const;
+
+export function presentAnthropicFailure(failure: Readonly<GatewayFailure>, requestId: string): Response {
+  const status = anthropicStatus(failure);
+  const headers = new Headers({ ...JSON_HEADERS, "request-id": requestId });
+  const retryAfter = failure.kind === "upstream_http" && failure.status === 429
+    ? safeRetryAfter(failure.retryAfter)
+    : undefined;
+  if (retryAfter !== undefined) {
+    headers.set("retry-after", retryAfter);
+  }
+  return new Response(
+    anthropicErrorBody(anthropicErrorType(status), safeFailureMessage(failure), requestId),
+    { status, headers },
+  );
+}
+
+function anthropicStatus(failure: Readonly<GatewayFailure>): number {
+  if (failure.kind === "unsupported_semantics") {
+    return 400;
+  }
+  if (failure.kind === "queue_full" || failure.kind === "queue_timeout") {
+    return 529;
+  }
+  return defaultFailureStatus(failure);
+}
+
+function anthropicErrorType(status: number): AnthropicErrorType {
+  if (status === 400 || status === 415 || status === 422) {
+    return "invalid_request_error";
+  }
+  if (status === 401) {
+    return "authentication_error";
+  }
+  if (status === 402) {
+    return "billing_error";
+  }
+  if (status === 403) {
+    return "permission_error";
+  }
+  if (status === 404) {
+    return "not_found_error";
+  }
+  if (status === 413) {
+    return "request_too_large";
+  }
+  if (status === 429) {
+    return "rate_limit_error";
+  }
+  if (status === 504) {
+    return "timeout_error";
+  }
+  if (status === 529) {
+    return "overloaded_error";
+  }
+  return "api_error";
+}

--- a/src/protocols/anthropic_messages/stream.ts
+++ b/src/protocols/anthropic_messages/stream.ts
@@ -1,5 +1,9 @@
 import { iterateChatFrames } from "../../copilot/backend.js";
-import { GatewayFailureError } from "../../gateway/failures.js";
+import {
+  normalizeChatStreamFailure,
+  upstreamStreamEventFailure,
+} from "../../copilot/failures.js";
+import { failureFromSignal, GatewayFailureError } from "../../gateway/failures.js";
 import type { RequestScope } from "../../gateway/request_scope.js";
 import { createStreamResponseWriter } from "../../gateway/stream_response.js";
 import type { UpstreamByteStream } from "../../copilot/upstream_types.js";
@@ -68,7 +72,7 @@ export function createAnthropicStreamResponse(input: {
         }
         observeTerminal(input.onTerminal, {
           kind: "failure",
-          error: new GatewayFailureError({ kind: "upstream_stream_error" }),
+          error: upstreamStreamEventFailure(),
         });
         writer.close();
         return;
@@ -81,12 +85,21 @@ export function createAnthropicStreamResponse(input: {
       observeTerminal(input.onTerminal, { kind: "success", usage: observedUsage });
       writer.close();
     } catch (error: unknown) {
-      observeTerminal(input.onTerminal, { kind: "failure", error });
+      observeTerminal(input.onTerminal, {
+        kind: "failure",
+        error: normalizeChatStreamFailure(error, input.scope.signal),
+      });
       writer.abort();
     }
   })();
   input.scope.signal.addEventListener("abort", () => {
-    observeTerminal(input.onTerminal, { kind: "failure", error: new GatewayFailureError({ kind: "aborted" }) });
+    observeTerminal(input.onTerminal, {
+      kind: "failure",
+      error: new GatewayFailureError(failureFromSignal(input.scope.signal, {
+        source: "parser",
+        phase: "stream",
+      })),
+    });
   }, { once: true });
   return writer.response;
 }

--- a/src/protocols/model_catalog/failure_presenter.ts
+++ b/src/protocols/model_catalog/failure_presenter.ts
@@ -1,0 +1,55 @@
+import {
+  defaultFailureStatus,
+  safeFailureMessage,
+  safeRetryAfter,
+  type GatewayFailure,
+} from "../../gateway/failures.js";
+import { anthropicErrorBody, type AnthropicErrorType } from "../anthropic_messages/wire.js";
+import { serializeOpenAiModelsError } from "./wire.js";
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+} as const;
+
+export function presentModelCatalogFailure(
+  failure: Readonly<GatewayFailure>,
+  requestId: string,
+  request: Request,
+): Response {
+  const status = defaultFailureStatus(failure);
+  const anthropic = request.headers.has("anthropic-version");
+  const headers = new Headers({
+    ...JSON_HEADERS,
+    [anthropic ? "request-id" : "x-request-id"]: requestId,
+  });
+  const retryAfter = failure.kind === "upstream_http" && failure.status === 429
+    ? safeRetryAfter(failure.retryAfter)
+    : undefined;
+  if (retryAfter !== undefined) {
+    headers.set("retry-after", retryAfter);
+  }
+  const body = anthropic
+    ? anthropicErrorBody(anthropicErrorType(status), safeFailureMessage(failure), requestId)
+    : serializeOpenAiModelsError(status);
+  return new Response(body, { status, headers });
+}
+
+function anthropicErrorType(status: number): AnthropicErrorType {
+  if (status === 401) {
+    return "authentication_error";
+  }
+  if (status === 403) {
+    return "permission_error";
+  }
+  if (status === 404) {
+    return "not_found_error";
+  }
+  if (status === 429) {
+    return "rate_limit_error";
+  }
+  if (status === 504) {
+    return "timeout_error";
+  }
+  return "api_error";
+}

--- a/src/protocols/model_catalog/routes.ts
+++ b/src/protocols/model_catalog/routes.ts
@@ -1,15 +1,17 @@
-import { AccountDirectoryError, type AccountDirectory } from "../../accounts/account_directory.js";
-import { GatewayFailureError, type GatewayFailure } from "../../gateway/failures.js";
-import { CapiFetchError } from "../../copilot/models_source.js";
+import type { AccountDirectory } from "../../accounts/account_directory.js";
+import {
+  normalizeAccountBindingFailure,
+  normalizeCatalogFailure,
+} from "../../copilot/failures.js";
 import type { AccountModelPreferences } from "../../accounts/model_preferences.js";
 import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
-import type { FailurePresenter, RouteRegistration } from "../../gateway/hono_app.js";
+import type { RouteRegistration } from "../../gateway/hono_app.js";
 import {
   serializeAnthropicModels,
   serializeOpenAiModels,
-  serializeOpenAiModelsError,
   type ModelMetadata,
 } from "./wire.js";
+import { presentModelCatalogFailure } from "./failure_presenter.js";
 
 export interface ModelCatalogRouteDependencies {
   readonly directory: AccountDirectory;
@@ -24,21 +26,13 @@ const JSON_HEADERS = {
 } as const;
 
 export function createModelCatalogRoutes(dependencies: ModelCatalogRouteDependencies): readonly RouteRegistration[] {
-  const modelsPresenter: FailurePresenter = (failure, requestId) => {
-    const status = statusFor(failure.kind, failure);
-    const headers = new Headers({ ...JSON_HEADERS, "x-request-id": requestId });
-    if (failure.kind === "upstream_http" && failure.retryAfter !== undefined) {
-      headers.set("retry-after", failure.retryAfter);
-    }
-    return new Response(serializeOpenAiModelsError(status), { status, headers });
-  };
   return [
     {
       method: "GET",
       path: "/v1/models",
       admission: "none",
       body: "none",
-      presentFailure: modelsPresenter,
+      presentFailure: presentModelCatalogFailure,
       endpoint: async (request, scope) => {
         const catalog = await loadCatalog(dependencies, scope.signal);
         const anthropic = request.headers.has("anthropic-version");
@@ -62,10 +56,7 @@ async function loadCatalog(
   try {
     account = await dependencies.directory.bindDefault(signal);
   } catch (error: unknown) {
-    if (error instanceof AccountDirectoryError && (error.code === "no_default" || error.code === "not_found")) {
-      throw new GatewayFailureError({ kind: "authentication" });
-    }
-    throw error;
+    throw normalizeAccountBindingFailure(error);
   }
   try {
     const catalog = await dependencies.catalog.get(account.accountId, signal);
@@ -73,38 +64,6 @@ async function loadCatalog(
     dependencies.preferences.markInvalidIfMissing(account.accountId, visible, catalog.generation);
     return catalog;
   } catch (error: unknown) {
-    if (error instanceof CapiFetchError) {
-      if (error.failureKind === "upstream_timeout") {
-        throw new GatewayFailureError({ kind: "upstream_timeout", cause: error });
-      }
-      if (error.failureKind === "upstream_network") {
-        throw new GatewayFailureError({ kind: "upstream_network", cause: error });
-      }
-      if (error.failureKind === "invalid_upstream_response") {
-        throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
-      }
-      throw new GatewayFailureError({
-        kind: "upstream_http",
-        status: error.status,
-        ...(error.retryAfter === undefined ? {} : { retryAfter: error.retryAfter }),
-      });
-    }
-    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+    throw normalizeCatalogFailure(error, signal);
   }
-}
-
-function statusFor(kind: GatewayFailure["kind"], failure?: GatewayFailure): number {
-  if (kind === "authentication") {
-    return 401;
-  }
-  if (kind === "permission") {
-    return 403;
-  }
-  if (kind === "upstream_http" && failure !== undefined && "status" in failure) {
-    return failure.status;
-  }
-  if (kind === "internal") {
-    return 500;
-  }
-  return 502;
 }

--- a/src/protocols/openai_chat/endpoint.ts
+++ b/src/protocols/openai_chat/endpoint.ts
@@ -1,15 +1,22 @@
-import { AccountDirectoryError, type AccountDirectory } from "../../accounts/account_directory.js";
+import type { AccountDirectory } from "../../accounts/account_directory.js";
 import type { AccountModelPreferences, ModelPreference } from "../../accounts/model_preferences.js";
 import type { BoundCopilot, CopilotBackend } from "../../copilot/backend.js";
-import { CapiFetchError } from "../../copilot/models_source.js";
 import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
 import { parseChatSse } from "../../copilot/chat_sse.js";
-import { TokenRefreshError } from "../../copilot/token_refresh.js";
 import {
-  classifyCopilotTransportError,
-  mapTokenRefreshError,
-} from "../../copilot/transport.js";
-import { GatewayFailureError, type GatewayFailure } from "../../gateway/failures.js";
+  normalizeAccountBindingFailure,
+  normalizeCatalogFailure,
+  normalizeChatStreamFailure,
+  normalizeCopilotBindingFailure,
+  normalizeTransportFailure,
+  upstreamStreamEventFailure,
+} from "../../copilot/failures.js";
+import {
+  failureFromSignal,
+  failureOutcome,
+  GatewayFailureError,
+  safeRetryAfter,
+} from "../../gateway/failures.js";
 import type { RouteRegistration } from "../../gateway/hono_app.js";
 import type { RequestScope } from "../../gateway/request_scope.js";
 import {
@@ -24,9 +31,10 @@ import {
 } from "../../serialization/wire_json.js";
 import { resolveModel, type ResolvedModel } from "../model_catalog/resolver.js";
 import type { ChatRequest, ChatStreamFrame } from "../chat_completions/types.js";
-import type { TelemetryOutcome, TelemetryRecorder, UsageUpdate } from "../../telemetry/recorder.js";
+import type { TelemetryRecorder, UsageUpdate } from "../../telemetry/recorder.js";
 import type { ProtocolPerformanceObserver } from "../../telemetry/runtime.js";
-import { encodeOpenAiChatDone, encodeOpenAiChatSseChunk, serializeOpenAiErrorBody } from "./wire.js";
+import { encodeOpenAiChatDone, encodeOpenAiChatSseChunk } from "./wire.js";
+import { presentOpenAiChatFailure } from "./failure_presenter.js";
 
 export interface OpenAiChatRouteDependencies {
   readonly directory: AccountDirectory;
@@ -52,24 +60,20 @@ interface PreparedOpenAiChatRequest {
   readonly resolvedModel: string;
 }
 
-const JSON_HEADERS = {
-  "Content-Type": "application/json; charset=utf-8",
-  "Cache-Control": "no-store",
-} as const;
-
 export function createOpenAiChatRoute(dependencies: OpenAiChatRouteDependencies): RouteRegistration {
   return {
     method: "POST",
     path: "/v1/chat/completions",
     admission: "inference",
     body: "wire-json-object",
-    presentFailure: (failure, requestId) => {
+    presentFailure: presentOpenAiChatFailure,
+    observeFailure: (failure) => {
       recordUsageSample(dependencies, {
         occurredAtMs: (dependencies.nowMs ?? Date.now)(),
         accountId: "unbound",
         protocol: "openai_chat",
         resolvedModel: "unresolved",
-        outcome: telemetryOutcome(failure),
+        outcome: failureOutcome(failure),
         requestCount: 1,
         errorCount: failure.kind === "aborted" ? 0 : 1,
         inputTokens: 0,
@@ -77,7 +81,6 @@ export function createOpenAiChatRoute(dependencies: OpenAiChatRouteDependencies)
         cacheTokens: 0,
         latencyMs: 0,
       });
-      return presentOpenAiFailure(failure, requestId);
     },
     endpoint: async (request, scope) => {
       const startedAtMs = (dependencies.nowMs ?? Date.now)();
@@ -174,7 +177,7 @@ export function createOpenAiChatRoute(dependencies: OpenAiChatRouteDependencies)
         upstreamController.abort();
         await upstream.cancel();
         void frames.return(undefined).catch(() => undefined);
-        throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+        throw upstreamStreamEventFailure();
       }
 
       return openAiChatStreamResponse({
@@ -193,37 +196,6 @@ export function createOpenAiChatRoute(dependencies: OpenAiChatRouteDependencies)
       });
     },
   };
-}
-
-function telemetryOutcome(failure: Readonly<GatewayFailure>): TelemetryOutcome {
-  switch (failure.kind) {
-  case "invalid_request":
-  case "body_too_large":
-  case "unsupported_media_type":
-  case "unsupported_semantics":
-  case "model_not_found":
-    return "client_error";
-  case "authentication":
-  case "permission":
-    return "authentication_error";
-  case "queue_full":
-  case "queue_timeout":
-    return "overloaded";
-  case "upstream_timeout":
-    return "timeout";
-  case "aborted":
-    return "aborted";
-  case "upstream_http":
-  case "upstream_network":
-  case "upstream_stream_error":
-  case "upstream_stream_truncated":
-  case "invalid_upstream_response":
-  case "invalid_tool_arguments":
-  case "invalid_logprobs":
-    return "upstream_error";
-  case "internal":
-    return "internal_error";
-  }
 }
 
 export function decodeOpenAiChatRequest(body: WireJsonObject): DecodedOpenAiChatRequest {
@@ -312,10 +284,7 @@ async function bindAccount(directory: AccountDirectory, signal: AbortSignal) {
   try {
     return await directory.bindDefault(signal);
   } catch (error: unknown) {
-    if (error instanceof AccountDirectoryError && (error.code === "no_default" || error.code === "not_found")) {
-      throw new GatewayFailureError({ kind: "authentication" });
-    }
-    throw error;
+    throw normalizeAccountBindingFailure(error);
   }
 }
 
@@ -323,30 +292,7 @@ async function loadCatalog(catalog: CopilotModelCatalog, accountId: string, sign
   try {
     return await catalog.get(accountId, signal);
   } catch (error: unknown) {
-    if (error instanceof CapiFetchError) {
-      const retry = validRetryAfterValue(error.retryAfter);
-      if (error.failureKind === "upstream_timeout") {
-        throw new GatewayFailureError({ kind: "upstream_network", cause: error });
-      }
-      if (error.failureKind === "upstream_network") {
-        throw new GatewayFailureError({ kind: "upstream_network", cause: error });
-      }
-      if (error.failureKind === "invalid_upstream_response") {
-        throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
-      }
-      throw new GatewayFailureError({
-        kind: "upstream_http",
-        status: error.status,
-        ...(retry === undefined ? {} : { retryAfter: retry }),
-      });
-    }
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new GatewayFailureError({ kind: "aborted" });
-    }
-    if (error instanceof TypeError) {
-      throw new GatewayFailureError({ kind: "upstream_network", cause: error });
-    }
-    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+    throw normalizeCatalogFailure(error, signal);
   }
 }
 
@@ -357,7 +303,7 @@ async function completeChat(
   try {
     return await copilot.completeChat(request);
   } catch (error: unknown) {
-    throw upstreamCallFailure(error);
+    throw upstreamCallFailure(error, request.signal);
   }
 }
 
@@ -369,16 +315,7 @@ async function bindCopilot(
   try {
     return await withOperationTimeout(scope, scope.config.timeouts.connectMs, (signal) => copilot.bind(account, signal));
   } catch (error: unknown) {
-    if (error instanceof GatewayFailureError) {
-      throw error;
-    }
-    if (error instanceof TokenRefreshError) {
-      throw new GatewayFailureError({ kind: mapTokenRefreshError(error), cause: error });
-    }
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new GatewayFailureError({ kind: "aborted" });
-    }
-    throw new GatewayFailureError({ kind: "upstream_network", cause: error });
+    throw normalizeCopilotBindingFailure(error, scope.signal);
   }
 }
 
@@ -400,7 +337,10 @@ async function withOperationTimeout<T>(
   }, ms);
   const onAbort = (): void => {
     timeoutController.abort();
-    rejectTimeout(new GatewayFailureError({ kind: "aborted" }));
+    rejectTimeout(new GatewayFailureError(failureFromSignal(scope.signal, {
+      source: "transport",
+      phase: "connect",
+    })));
   };
   scope.signal.addEventListener("abort", onAbort, { once: true });
   try {
@@ -427,19 +367,16 @@ async function openChatStream(
   try {
     return await copilot.openChatStream(request);
   } catch (error: unknown) {
-    throw upstreamCallFailure(error);
+    throw upstreamCallFailure(error, request.signal);
   }
 }
 
-function upstreamCallFailure(error: unknown): GatewayFailureError {
-  if (error instanceof GatewayFailureError) {
-    return error;
-  }
-  const kind = classifyCopilotTransportError(error);
-  if (kind === "aborted") {
-    return new GatewayFailureError({ kind });
-  }
-  return new GatewayFailureError({ kind, cause: error });
+function upstreamCallFailure(error: unknown, signal: AbortSignal): GatewayFailureError {
+  return normalizeTransportFailure(
+    error,
+    signal,
+    { source: "transport", phase: "headers" },
+  );
 }
 
 function parseUpstreamObject(body: Uint8Array, maxBytes: number): WireJsonObject {
@@ -524,34 +461,22 @@ function assertUpstreamSuccess(status: number, headers: Headers): void {
 }
 
 function retryAfter(headers: Headers): string | undefined {
-  return validRetryAfterValue(headers.get("retry-after") ?? undefined);
+  return safeRetryAfter(headers.get("retry-after") ?? undefined);
 }
 
-function validRetryAfterValue(value: string | undefined): string | undefined {
-  if (value === undefined || value.length === 0) {
-    return undefined;
-  }
-  if (/^\d+$/u.test(value)) {
-    return value;
-  }
-  if (/^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT$/u.test(value) && !Number.isNaN(Date.parse(value))) {
-    return value;
-  }
-  return undefined;
-}
-
-async function nextFrame(frames: AsyncGenerator<ChatStreamFrame>): Promise<ChatStreamFrame> {
+async function nextFrame(frames: AsyncGenerator<ChatStreamFrame>, signal: AbortSignal): Promise<ChatStreamFrame> {
   try {
     const next = await frames.next();
     if (next.done === true) {
-      throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+      throw new GatewayFailureError({
+        kind: "upstream_stream_truncated",
+        source: "parser",
+        phase: "stream",
+      });
     }
     return next.value;
   } catch (error: unknown) {
-    if (error instanceof GatewayFailureError) {
-      throw error;
-    }
-    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+    throw normalizeChatStreamFailure(error, signal);
   }
 }
 
@@ -568,7 +493,10 @@ async function firstFrameWithTimeout(
       timedOut = true;
       reject(new GatewayFailureError({ kind: "upstream_timeout" }));
     }, ms);
-    const onAbort = (): void => reject(new GatewayFailureError({ kind: "aborted" }));
+    const onAbort = (): void => reject(new GatewayFailureError(failureFromSignal(scope.signal, {
+      source: "parser",
+      phase: "stream",
+    })));
     scope.signal.addEventListener("abort", onAbort, { once: true });
     clear = () => {
       clearTimeout(timer);
@@ -576,7 +504,7 @@ async function firstFrameWithTimeout(
     };
   });
   try {
-    return await Promise.race([nextFrame(frames), timeout]);
+    return await Promise.race([nextFrame(frames, scope.signal), timeout]);
   } catch (error: unknown) {
     if (timedOut) {
       onTimeout();
@@ -633,13 +561,19 @@ function bodyTimeout(ms: number, signal: AbortSignal): {
   let clear = (): void => undefined;
   const promise = new Promise<IteratorResult<Uint8Array>>((_resolve, reject) => {
     if (signal.aborted) {
-      reject(new GatewayFailureError({ kind: "aborted" }));
+      reject(new GatewayFailureError(failureFromSignal(signal, {
+        source: "parser",
+        phase: "stream",
+      })));
       return;
     }
     const timer = setTimeout(() => reject(new GatewayFailureError({ kind: "upstream_timeout" })), ms);
     const onAbort = (): void => {
       clearTimeout(timer);
-      reject(new GatewayFailureError({ kind: "aborted" }));
+      reject(new GatewayFailureError(failureFromSignal(signal, {
+        source: "parser",
+        phase: "stream",
+      })));
     };
     signal.addEventListener("abort", onAbort, { once: true });
     clear = () => {
@@ -683,7 +617,7 @@ function openAiChatStreamResponse(input: {
         return;
       }
       try {
-        const frame = pending ?? await nextFrame(input.frames);
+        const frame = pending ?? await nextFrame(input.frames, input.signal);
         pending = undefined;
         if (frame.kind === "chunk") {
           measure(input.dependencies.performanceObserver, "event", () => {
@@ -710,10 +644,12 @@ function openAiChatStreamResponse(input: {
           return;
         }
         closeFrames();
-        controller.error(new Error("upstream stream error"));
-      } catch (_error) {
+        controller.error(new Error("upstream stream error", { cause: upstreamStreamEventFailure() }));
+      } catch (error: unknown) {
         closeFrames();
-        controller.error(new Error("upstream stream error"));
+        controller.error(new Error("upstream stream error", {
+          cause: normalizeChatStreamFailure(error, input.signal),
+        }));
       }
     },
     cancel(): void {
@@ -808,107 +744,4 @@ function measure<T>(
   work: () => T,
 ): T {
   return observer === undefined ? work() : observer.measure(measurement, work);
-}
-
-function presentOpenAiFailure(failure: Readonly<GatewayFailure>, requestId: string): Response {
-  const status = statusForFailure(failure);
-  const headers = new Headers({ ...JSON_HEADERS, "x-request-id": requestId });
-  if (failure.kind === "upstream_http" && failure.status === 429 && failure.retryAfter !== undefined) {
-    headers.set("retry-after", failure.retryAfter);
-  }
-  return new Response(serializeOpenAiErrorBody(messageForFailure(failure), errorTypeForStatus(status)), {
-    status,
-    headers,
-  });
-}
-
-function statusForFailure(failure: Readonly<GatewayFailure>): number {
-  switch (failure.kind) {
-  case "invalid_request":
-    return 400;
-  case "body_too_large":
-    return 413;
-  case "unsupported_media_type":
-    return 415;
-  case "unsupported_semantics":
-    return 422;
-  case "authentication":
-    return 401;
-  case "permission":
-    return 403;
-  case "model_not_found":
-    return 404;
-  case "queue_full":
-  case "queue_timeout":
-    return 503;
-  case "upstream_network":
-  case "upstream_stream_error":
-  case "upstream_stream_truncated":
-  case "invalid_upstream_response":
-  case "invalid_tool_arguments":
-  case "invalid_logprobs":
-    return 502;
-  case "upstream_timeout":
-    return 504;
-  case "upstream_http":
-    return failure.status;
-  case "internal":
-  case "aborted":
-    return 500;
-  }
-}
-
-function messageForFailure(failure: Readonly<GatewayFailure>): string {
-  switch (failure.kind) {
-  case "invalid_request":
-    return "invalid request";
-  case "body_too_large":
-    return "request body too large";
-  case "unsupported_media_type":
-    return "unsupported media type";
-  case "unsupported_semantics":
-    return "unsupported semantics";
-  case "authentication":
-    return "authentication failed";
-  case "permission":
-    return "permission denied";
-  case "model_not_found":
-    return "model not found";
-  case "queue_full":
-  case "queue_timeout":
-    return "server overloaded";
-  case "upstream_timeout":
-    return "upstream timeout";
-  case "invalid_upstream_response":
-  case "upstream_stream_error":
-  case "upstream_stream_truncated":
-  case "invalid_tool_arguments":
-  case "invalid_logprobs":
-    return "invalid upstream response";
-  case "upstream_http":
-  case "upstream_network":
-    return "upstream request failed";
-  case "internal":
-  case "aborted":
-    return "internal error";
-  }
-}
-
-function errorTypeForStatus(status: number): string {
-  if (status === 401) {
-    return "authentication_error";
-  }
-  if (status === 403) {
-    return "permission_error";
-  }
-  if (status === 404) {
-    return "not_found_error";
-  }
-  if (status === 429) {
-    return "rate_limit_error";
-  }
-  if (status === 400 || status === 409 || status === 413 || status === 415 || status === 422) {
-    return "invalid_request_error";
-  }
-  return "api_error";
 }

--- a/src/protocols/openai_chat/failure_presenter.ts
+++ b/src/protocols/openai_chat/failure_presenter.ts
@@ -1,0 +1,46 @@
+import {
+  defaultFailureStatus,
+  safeFailureMessage,
+  safeRetryAfter,
+  type GatewayFailure,
+} from "../../gateway/failures.js";
+import { serializeOpenAiErrorBody } from "./wire.js";
+
+const JSON_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "no-store",
+} as const;
+
+export function presentOpenAiChatFailure(failure: Readonly<GatewayFailure>, requestId: string): Response {
+  const status = defaultFailureStatus(failure);
+  const headers = new Headers({ ...JSON_HEADERS, "x-request-id": requestId });
+  const retryAfter = failure.kind === "upstream_http" && failure.status === 429
+    ? safeRetryAfter(failure.retryAfter)
+    : undefined;
+  if (retryAfter !== undefined) {
+    headers.set("retry-after", retryAfter);
+  }
+  return new Response(serializeOpenAiErrorBody(safeFailureMessage(failure), errorTypeForStatus(status)), {
+    status,
+    headers,
+  });
+}
+
+function errorTypeForStatus(status: number): string {
+  if (status === 401) {
+    return "authentication_error";
+  }
+  if (status === 403) {
+    return "permission_error";
+  }
+  if (status === 404) {
+    return "not_found_error";
+  }
+  if (status === 429) {
+    return "rate_limit_error";
+  }
+  if (status === 400 || status === 409 || status === 413 || status === 415 || status === 422) {
+    return "invalid_request_error";
+  }
+  return "api_error";
+}

--- a/src/protocols/responses/bridge_stream.ts
+++ b/src/protocols/responses/bridge_stream.ts
@@ -8,6 +8,7 @@ import {
   type WireJsonArray,
   type WireJsonObject,
 } from "../../serialization/wire_json.js";
+import { GatewayFailureError } from "../../gateway/failures.js";
 import type { ChatChunk, ChatStreamFrame } from "../chat_completions/types.js";
 import type { ResponsesRequest } from "./dto.js";
 import type { ResponsesHistoryRecord } from "./history.js";
@@ -959,8 +960,12 @@ function chatChunk(input: ResponsesBridgeStreamInput): ChatChunk {
   return isChunkFrame(input) ? input.chunk : input as ChatChunk;
 }
 
-function streamFrameError(value: WireJson | string): Error {
-  return value instanceof Error ? value : new Error(typeof value === "string" ? value : "Chat stream error");
+function streamFrameError(_value: WireJson | string): Error {
+  return new GatewayFailureError({
+    kind: "upstream_stream_error",
+    source: "parser",
+    phase: "stream",
+  });
 }
 
 function isManagedResponseId(id: string): boolean {

--- a/src/protocols/responses/endpoint.ts
+++ b/src/protocols/responses/endpoint.ts
@@ -1,9 +1,21 @@
-import { AccountDirectoryError, type AccountDirectory } from "../../accounts/account_directory.js";
+import type { AccountDirectory } from "../../accounts/account_directory.js";
 import type { AccountModelPreferences } from "../../accounts/model_preferences.js";
 import { iterateChatFrames, type BoundCopilot, type CopilotBackend } from "../../copilot/backend.js";
 import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
-import { CapiFetchError } from "../../copilot/models_source.js";
-import { failureFromUnknown, GatewayFailureError, type GatewayFailure } from "../../gateway/failures.js";
+import {
+  normalizeAccountBindingFailure,
+  normalizeCatalogFailure,
+  normalizeChatFrames,
+  normalizeCopilotBindingFailure,
+  normalizeTransportFailure,
+} from "../../copilot/failures.js";
+import {
+  failureFromSignal,
+  failureFromUnknown,
+  failureOutcome,
+  GatewayFailureError,
+  safeRetryAfter,
+} from "../../gateway/failures.js";
 import type { DecodedHttpRequest, RouteRegistration } from "../../gateway/hono_app.js";
 import type { RequestScope } from "../../gateway/request_scope.js";
 import { createStreamResponseWriter } from "../../gateway/stream_response.js";
@@ -22,10 +34,10 @@ import {
   encodeResponsesSseEvent,
   RESPONSES_JSON_HEADERS,
   RESPONSES_STREAM_HEADERS,
-  serializeResponsesErrorBody,
 } from "./wire.js";
 import type { TelemetryProtocol, TelemetryRecorder, UsageUpdate } from "../../telemetry/recorder.js";
 import type { ProtocolPerformanceObserver } from "../../telemetry/runtime.js";
+import { presentResponsesFailure } from "./failure_presenter.js";
 
 export interface ResponsesRouteDependencies {
   readonly directory: AccountDirectory;
@@ -47,11 +59,11 @@ export function createResponsesRoute(dependencies: ResponsesRouteDependencies): 
     path: "/v1/responses",
     admission: "inference",
     body: "wire-json-object",
-    presentFailure: (failure, requestId) => {
+    presentFailure: presentResponsesFailure,
+    observeFailure: (failure, requestId) => {
       const usage = attempts.get(requestId) ?? createUsageAttempt(dependencies, new AbortController().signal);
       usage.failure(new GatewayFailureError(failure));
       attempts.delete(requestId);
-      return presentResponsesFailure(failure, requestId);
     },
     endpoint: (request, scope) => executeResponses(dependencies, request, scope, attempts),
   };
@@ -82,7 +94,7 @@ async function executeResponses(
     throw new GatewayFailureError({ kind: resolved.kind });
   }
   usage.setModel(resolved.upstreamModel);
-  const bound = await dependencies.copilot.bind(account, scope.signal);
+  const bound = await bindCopilot(dependencies.copilot, account, scope.signal);
   const plan = planResponsesExecution(decoded, resolved, bound.target);
   usage.setProtocol(plan.kind === "native_responses" ? "openai_responses_native" : "openai_responses_bridge");
   if (plan.kind === "native_responses") {
@@ -112,7 +124,10 @@ async function nativeNonstreamResponse(
   scope: Readonly<RequestScope>,
   usage: UsageAttempt,
 ): Promise<Response> {
-  const upstream = await completeNativeResponses(bound, plan, nativeOptions(scope));
+  const upstream = await transportCall(
+    () => completeNativeResponses(bound, plan, nativeOptions(scope)),
+    scope.signal,
+  );
   assertUpstreamSuccess(upstream);
   if (usage.enabled) {
     const payload = parseUpstreamObject(upstream.body, scope.config.limits.nonstreamBodyBytes);
@@ -131,7 +146,10 @@ async function nativeStreamResponse(
   usage: UsageAttempt,
   performanceObserver?: ProtocolPerformanceObserver,
 ): Promise<Response> {
-  const upstream = await openNativeResponsesStream(bound, plan, nativeOptions(scope));
+  const upstream = await transportCall(
+    () => openNativeResponsesStream(bound, plan, nativeOptions(scope)),
+    scope.signal,
+  );
   if (upstream.status < 200 || upstream.status >= 300) {
     await upstream.cancel();
   }
@@ -157,7 +175,8 @@ async function bridgeNonstreamResponse(
     reasoningConfig: null,
     ...promptCacheContext(bound.target.endpoint),
   }, scope.signal);
-  const upstream = await bound.completeChat(chatRequest(prepared.body, plan.resolvedModel.upstreamModel, false, scope));
+  const request = chatRequest(prepared.body, plan.resolvedModel.upstreamModel, false, scope);
+  const upstream = await transportCall(() => bound.completeChat(request), request.signal);
   assertUpstreamSuccess(upstream);
   const measured = measure(dependencies.performanceObserver, "buffered", () => {
     const chat = parseUpstreamObject(upstream.body, scope.config.limits.nonstreamBodyBytes);
@@ -188,13 +207,14 @@ async function bridgeStreamResponse(
     reasoningConfig: null,
     ...promptCacheContext(bound.target.endpoint),
   }, scope.signal);
-  const upstream = await bound.openChatStream(chatRequest(prepared.body, plan.resolvedModel.upstreamModel, true, scope));
+  const request = chatRequest(prepared.body, plan.resolvedModel.upstreamModel, true, scope);
+  const upstream = await transportCall(() => bound.openChatStream(request), request.signal);
   if (upstream.status < 200 || upstream.status >= 300) {
     await upstream.cancel();
   }
   assertUpstreamSuccess(upstream);
   const timedUpstream = { ...upstream, bytes: withStreamTimeouts(upstream.bytes, upstream, scope) };
-  const emissions = convertChatStream(iterateChatFrames(timedUpstream), {
+  const emissions = convertChatStream(normalizeChatFrames(iterateChatFrames(timedUpstream), scope.signal), {
     originalRequest: plan.originalRequest,
     toolContext: prepared.toolContext,
     model: plan.resolvedModel.upstreamModel,
@@ -242,7 +262,10 @@ async function nextWithTimeout(
   upstream: UpstreamByteStream,
 ): Promise<IteratorResult<Uint8Array>> {
   if (signal.aborted) {
-    throw new DOMException("aborted", "AbortError");
+    throw new GatewayFailureError(failureFromSignal(signal, {
+      source: "parser",
+      phase: "stream",
+    }));
   }
   let timedOut = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -254,7 +277,10 @@ async function nextWithTimeout(
     }, timeoutMs);
   });
   const abort = new Promise<never>((_resolve, reject) => {
-    onAbort = () => reject(new DOMException("aborted", "AbortError"));
+    onAbort = () => reject(new GatewayFailureError(failureFromSignal(signal, {
+      source: "parser",
+      phase: "stream",
+    })));
     signal.addEventListener("abort", onAbort, { once: true });
   });
   try {
@@ -344,9 +370,10 @@ async function streamBytesResponse(
     headers: { ...RESPONSES_STREAM_HEADERS, "x-request-id": scope.requestId },
   });
   scope.signal.addEventListener("abort", () => {
-    onFailure(scope.signal.reason instanceof GatewayFailureError
-      ? scope.signal.reason
-      : new GatewayFailureError({ kind: "aborted" }));
+    onFailure(new GatewayFailureError(failureFromSignal(scope.signal, {
+      source: "parser",
+      phase: "stream",
+    })));
   }, { once: true });
   void (async () => {
     try {
@@ -435,10 +462,30 @@ async function bindAccount(directory: AccountDirectory, signal: AbortSignal) {
   try {
     return await directory.bindDefault(signal);
   } catch (error: unknown) {
-    if (error instanceof AccountDirectoryError && (error.code === "no_default" || error.code === "not_found")) {
-      throw new GatewayFailureError({ kind: "authentication", cause: error });
-    }
-    throw error;
+    throw normalizeAccountBindingFailure(error);
+  }
+}
+
+async function bindCopilot(
+  copilot: CopilotBackend,
+  account: Awaited<ReturnType<AccountDirectory["bindDefault"]>>,
+  signal: AbortSignal,
+): Promise<BoundCopilot> {
+  try {
+    return await copilot.bind(account, signal);
+  } catch (error: unknown) {
+    throw normalizeCopilotBindingFailure(error, signal);
+  }
+}
+
+async function transportCall<T>(
+  work: () => Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  try {
+    return await work();
+  } catch (error: unknown) {
+    throw normalizeTransportFailure(error, signal, { source: "transport", phase: "headers" });
   }
 }
 
@@ -452,23 +499,7 @@ async function loadCatalog(
     dependencies.preferences.markInvalidIfMissing(accountId, new Set(catalog.models.map((model) => model.id)), catalog.generation);
     return catalog;
   } catch (error: unknown) {
-    if (error instanceof CapiFetchError) {
-      if (error.failureKind === "upstream_timeout") {
-        throw new GatewayFailureError({ kind: "upstream_timeout", cause: error });
-      }
-      if (error.failureKind === "upstream_network") {
-        throw new GatewayFailureError({ kind: "upstream_network", cause: error });
-      }
-      if (error.failureKind === "invalid_upstream_response") {
-        throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
-      }
-      throw new GatewayFailureError({
-        kind: "upstream_http",
-        status: error.status,
-        ...(error.retryAfter === undefined ? {} : { retryAfter: error.retryAfter }),
-      });
-    }
-    throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
+    throw normalizeCatalogFailure(error, signal);
   }
 }
 
@@ -481,121 +512,11 @@ function promptCacheContext(endpoint: string): { readonly upstreamHost?: string;
   }
 }
 
-function presentResponsesFailure(failure: Readonly<GatewayFailure>, requestId: string): Response {
-  const status = statusForFailure(failure);
-  const headers = new Headers({ ...RESPONSES_JSON_HEADERS, "x-request-id": requestId });
-  if (failure.kind === "upstream_http" && failure.status === 429 && failure.retryAfter !== undefined) {
-    headers.set("retry-after", failure.retryAfter);
-  }
-  return new Response(serializeResponsesErrorBody(messageForFailure(failure), errorTypeForStatus(status)), { status, headers });
-}
-
-function statusForFailure(failure: Readonly<GatewayFailure>): number {
-  switch (failure.kind) {
-  case "invalid_request":
-    return 400;
-  case "body_too_large":
-    return 413;
-  case "unsupported_media_type":
-    return 415;
-  case "unsupported_semantics":
-    return 422;
-  case "authentication":
-    return 401;
-  case "permission":
-    return 403;
-  case "model_not_found":
-    return 404;
-  case "queue_full":
-  case "queue_timeout":
-    return 503;
-  case "upstream_timeout":
-    return 504;
-  case "upstream_http":
-    return failure.status;
-  case "upstream_network":
-  case "upstream_stream_error":
-  case "upstream_stream_truncated":
-  case "invalid_upstream_response":
-  case "invalid_tool_arguments":
-  case "invalid_logprobs":
-    return 502;
-  case "internal":
-  case "aborted":
-    return 500;
-  }
-}
-
-function messageForFailure(failure: Readonly<GatewayFailure>): string {
-  if (failure.kind === "upstream_http") {
-    return "upstream request failed";
-  }
-  if (failure.kind === "body_too_large") {
-    return "request body too large";
-  }
-  if (failure.kind === "unsupported_media_type") {
-    return "unsupported media type";
-  }
-  if (failure.kind === "unsupported_semantics") {
-    return "unsupported semantics";
-  }
-  if (failure.kind === "authentication") {
-    return "authentication failed";
-  }
-  if (failure.kind === "permission") {
-    return "permission denied";
-  }
-  if (failure.kind === "model_not_found") {
-    return "model not found";
-  }
-  if (failure.kind === "queue_full" || failure.kind === "queue_timeout") {
-    return "server overloaded";
-  }
-  if (failure.kind === "upstream_timeout") {
-    return "upstream timeout";
-  }
-  if (failure.kind === "invalid_upstream_response" || failure.kind === "invalid_tool_arguments" || failure.kind === "invalid_logprobs") {
-    return "invalid upstream response";
-  }
-  if (failure.kind === "upstream_network" || failure.kind === "upstream_stream_error" || failure.kind === "upstream_stream_truncated") {
-    return "upstream request failed";
-  }
-  return failure.kind === "invalid_request" ? "invalid request" : "internal error";
-}
-
-function errorTypeForStatus(status: number): string {
-  if (status === 401) {
-    return "authentication_error";
-  }
-  if (status === 403) {
-    return "permission_error";
-  }
-  if (status === 404) {
-    return "not_found_error";
-  }
-  if (status === 429) {
-    return "rate_limit_error";
-  }
-  return status === 400 || status === 409 || status === 413 || status === 415 || status === 422
-    ? "invalid_request_error"
-    : "api_error";
-}
-
 function retryAfterHeader(status: number, headers: Headers): string | undefined {
   if (status !== 429) {
     return undefined;
   }
-  const value = headers.get("retry-after");
-  if (value === null || value.length === 0) {
-    return undefined;
-  }
-  if (/^\d+$/u.test(value)) {
-    return value;
-  }
-  if (/^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/u.test(value) && !Number.isNaN(Date.parse(value))) {
-    return value;
-  }
-  return undefined;
+  return safeRetryAfter(headers.get("retry-after") ?? undefined);
 }
 
 interface UsageTokens {
@@ -784,46 +705,9 @@ function usageOutcome(error: unknown, signal: AbortSignal): UsageUpdate["outcome
   if (signal.aborted) {
     return abortOutcome(signal);
   }
-  if (error instanceof Error && error.name === "AbortError") {
-    return "aborted";
-  }
-  if (error instanceof AccountDirectoryError) {
-    return "authentication_error";
-  }
-  const failure = failureFromUnknown(error);
-  switch (failure.kind) {
-  case "invalid_request":
-  case "body_too_large":
-  case "unsupported_media_type":
-  case "unsupported_semantics":
-  case "model_not_found":
-    return "client_error";
-  case "authentication":
-  case "permission":
-    return "authentication_error";
-  case "queue_full":
-  case "queue_timeout":
-    return "overloaded";
-  case "upstream_timeout":
-    return "timeout";
-  case "upstream_http":
-  case "upstream_network":
-  case "upstream_stream_error":
-  case "upstream_stream_truncated":
-  case "invalid_upstream_response":
-  case "invalid_tool_arguments":
-  case "invalid_logprobs":
-    return "upstream_error";
-  case "aborted":
-    return "aborted";
-  case "internal":
-    return "internal_error";
-  }
+  return failureOutcome(failureFromUnknown(error, { source: "gateway", phase: "internal" }));
 }
 
 function abortOutcome(signal: AbortSignal): UsageUpdate["outcome"] {
-  const reason = signal.reason;
-  return reason instanceof GatewayFailureError && reason.failure.kind === "upstream_timeout"
-    ? "timeout"
-    : "aborted";
+  return failureOutcome(failureFromSignal(signal, { source: "gateway", phase: "deadline" }));
 }

--- a/src/protocols/responses/failure_presenter.ts
+++ b/src/protocols/responses/failure_presenter.ts
@@ -1,0 +1,40 @@
+import {
+  defaultFailureStatus,
+  safeFailureMessage,
+  safeRetryAfter,
+  type GatewayFailure,
+} from "../../gateway/failures.js";
+import { RESPONSES_JSON_HEADERS, serializeResponsesErrorBody } from "./wire.js";
+
+export function presentResponsesFailure(failure: Readonly<GatewayFailure>, requestId: string): Response {
+  const status = defaultFailureStatus(failure);
+  const headers = new Headers({ ...RESPONSES_JSON_HEADERS, "x-request-id": requestId });
+  const retryAfter = failure.kind === "upstream_http" && failure.status === 429
+    ? safeRetryAfter(failure.retryAfter)
+    : undefined;
+  if (retryAfter !== undefined) {
+    headers.set("retry-after", retryAfter);
+  }
+  return new Response(serializeResponsesErrorBody(safeFailureMessage(failure), errorTypeForStatus(status)), {
+    status,
+    headers,
+  });
+}
+
+function errorTypeForStatus(status: number): string {
+  if (status === 401) {
+    return "authentication_error";
+  }
+  if (status === 403) {
+    return "permission_error";
+  }
+  if (status === 404) {
+    return "not_found_error";
+  }
+  if (status === 429) {
+    return "rate_limit_error";
+  }
+  return status === 400 || status === 409 || status === 413 || status === 415 || status === 422
+    ? "invalid_request_error"
+    : "api_error";
+}

--- a/src/protocols/responses/native.ts
+++ b/src/protocols/responses/native.ts
@@ -143,7 +143,11 @@ export async function* normalizeNativeResponsesStream(
     }
   }
   if (!terminal) {
-    throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+    throw new GatewayFailureError({
+      kind: "upstream_stream_truncated",
+      source: "parser",
+      phase: "stream",
+    });
   }
 }
 
@@ -213,13 +217,24 @@ async function* parseResponsesSse(
     if (error instanceof GatewayFailureError) {
       throw error;
     }
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new GatewayFailureError({
+        kind: "aborted",
+        source: "parser",
+        phase: "stream",
+      });
+    }
     if (error instanceof ChatSseError) {
       throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
     }
     throw new GatewayFailureError({ kind: "invalid_upstream_response", cause: error });
   }
   if (pending.length > 0) {
-    throw new GatewayFailureError({ kind: "invalid_upstream_response" });
+    throw new GatewayFailureError({
+      kind: "upstream_stream_truncated",
+      source: "parser",
+      phase: "stream",
+    });
   }
 }
 

--- a/tests/contract/anthropic_request.test.ts
+++ b/tests/contract/anthropic_request.test.ts
@@ -2,9 +2,36 @@ import { describe, expect, it } from "vitest";
 import { anthropicGateway, anthropicRequest, decodeChatBody } from "./anthropic_harness.js";
 import { ScriptedCopilotBackend } from "../../src/copilot/backend.js";
 import { CapiFetchError } from "../../src/copilot/models_source.js";
+import { TokenRefreshError } from "../../src/copilot/token_refresh.js";
+import { UpstreamTimeoutError } from "../../src/copilot/transport.js";
 import type { ChatRequest } from "../../src/protocols/chat_completions/types.js";
+import type { UsageUpdate } from "../../src/telemetry/recorder.js";
 
 describe("Anthropic request route", () => {
+  it("observes pre-endpoint body failures once without coupling accounting to the presenter", async () => {
+    const usageUpdates: UsageUpdate[] = [];
+    const { gw, close } = await anthropicGateway({ usageUpdates });
+    try {
+      const response = await gw.fetch(new Request("http://127.0.0.1:31400/v1/messages", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "anthropic-version": "2023-06-01",
+        },
+        body: "{\"messages\":",
+      }));
+      expect(response.status).toBe(400);
+      expect(usageUpdates).toMatchObject([{
+        protocol: "anthropic",
+        outcome: "client_error",
+        requestCount: 1,
+        errorCount: 1,
+      }]);
+    } finally {
+      await close();
+    }
+  });
+
   it("requires the exact Messages version header and never forwards it to Chat", async () => {
     const { gw, capturedRequests, close } = await anthropicGateway();
     try {
@@ -75,6 +102,72 @@ describe("Anthropic request route", () => {
       } finally {
         await close();
       }
+    }
+  });
+
+  it.each([
+    [new TokenRefreshError("missing", "secret-token"), 401, "authentication_error"],
+    [new TokenRefreshError("unauthorized", "secret-token"), 401, "authentication_error"],
+    [new TokenRefreshError("network", "private upstream URL"), 502, "upstream_error"],
+    [new TokenRefreshError("timeout", "private upstream URL"), 504, "timeout"],
+  ])("normalizes bind failure %# for Messages", async (bindError, status, outcome) => {
+    const usageUpdates: UsageUpdate[] = [];
+    const backend = new ScriptedCopilotBackend({ bindError });
+    const { gw, close } = await anthropicGateway({ backend, usageUpdates });
+    try {
+      const response = await gw.fetch(anthropicRequest({
+        model: "gpt",
+        max_tokens: 1,
+        messages: [{ role: "user", content: "hi" }],
+      }));
+      expect(response.status).toBe(status);
+      expect(response.headers.get("request-id")).toBe("req_test_1");
+      expect(await response.text()).not.toContain("secret-token");
+      expect(usageUpdates).toMatchObject([{ outcome }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("normalizes transport timeout and malformed buffered output before commitment", async () => {
+    const timeoutGateway = await anthropicGateway({
+      backend: new ScriptedCopilotBackend({
+        chat() {
+          throw new UpstreamTimeoutError();
+        },
+      }),
+    });
+    try {
+      const response = await timeoutGateway.gw.fetch(anthropicRequest({
+        model: "gpt",
+        max_tokens: 1,
+        messages: [{ role: "user", content: "hi" }],
+      }));
+      expect(response.status).toBe(504);
+      expect(await response.text()).toContain("\"type\":\"timeout_error\"");
+    } finally {
+      await timeoutGateway.close();
+    }
+
+    const parserGateway = await anthropicGateway({
+      backend: new ScriptedCopilotBackend({
+        chat: {
+          status: 200,
+          headers: new Headers(),
+          body: new TextEncoder().encode("{\"choices\":"),
+        },
+      }),
+    });
+    try {
+      const response = await parserGateway.gw.fetch(anthropicRequest({
+        model: "gpt",
+        max_tokens: 1,
+        messages: [{ role: "user", content: "hi" }],
+      }));
+      expect(response.status).toBe(502);
+      expect(await response.text()).toContain("\"message\":\"invalid upstream response\"");
+    } finally {
+      await parserGateway.close();
     }
   });
 

--- a/tests/contract/anthropic_stream.test.ts
+++ b/tests/contract/anthropic_stream.test.ts
@@ -128,13 +128,14 @@ describe("Anthropic stream lifecycle", () => {
     }
   });
 
-  it("closes natural exhaustion with message_stop and propagates post-commit exceptions without synthetic success", async () => {
+  it("classifies post-commit parser failures without synthetic success terminals", async () => {
+    const usageUpdates: UsageUpdate[] = [];
     async function* brokenStream(): AsyncIterable<Uint8Array> {
       yield sse({ id: "chunk_1", choices: [{ delta: { content: "partial" } }] });
-      throw new Error("boom");
+      throw new TypeError("network failed");
     }
     const backend = new ScriptedCopilotBackend({ chatStream: brokenStream() });
-    const { gw, close } = await anthropicGateway({ backend });
+    const { gw, close } = await anthropicGateway({ backend, usageUpdates });
     try {
       const response = await gw.fetch(anthropicRequest({ model: "gpt", max_tokens: 16, messages: [{ role: "user", content: "hi" }], stream: true }));
       const reader = response.body?.getReader();
@@ -154,6 +155,10 @@ describe("Anthropic stream lifecycle", () => {
       expect(text).toContain("event: content_block_delta");
       expect(text).not.toContain("event: message_stop");
       expect(text).not.toContain("event: error");
+      expect(usageUpdates).toMatchObject([{
+        protocol: "anthropic",
+        outcome: "upstream_error",
+      }]);
     } finally {
       await close();
     }

--- a/tests/contract/failure_presenters.test.ts
+++ b/tests/contract/failure_presenters.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  failureOutcome,
+  type GatewayFailure,
+} from "../../src/gateway/failures.js";
+import {
+  createOpenAiChatRoute,
+  type OpenAiChatRouteDependencies,
+} from "../../src/protocols/openai_chat/endpoint.js";
+import { presentOpenAiChatFailure } from "../../src/protocols/openai_chat/failure_presenter.js";
+import {
+  createAnthropicMessagesRoute,
+  type AnthropicMessagesRouteDependencies,
+} from "../../src/protocols/anthropic_messages/endpoint.js";
+import { presentAnthropicFailure } from "../../src/protocols/anthropic_messages/failure_presenter.js";
+import {
+  createResponsesRoute,
+  type ResponsesRouteDependencies,
+} from "../../src/protocols/responses/endpoint.js";
+import { presentResponsesFailure } from "../../src/protocols/responses/failure_presenter.js";
+import { presentModelCatalogFailure } from "../../src/protocols/model_catalog/failure_presenter.js";
+
+const requestId = "req_failure_matrix";
+const openAiModelsRequest = new Request("http://127.0.0.1:31400/v1/models");
+const anthropicModelsRequest = new Request("http://127.0.0.1:31400/v1/models", {
+  headers: { "anthropic-version": "2023-06-01" },
+});
+
+describe("semantic failure presenters", () => {
+  it.each([
+    [{ kind: "invalid_request" }, 400, 400, "client_error", "invalid request", "invalid_request_error", "invalid_request_error"],
+    [{ kind: "body_too_large" }, 413, 413, "client_error", "request body too large", "invalid_request_error", "request_too_large"],
+    [{ kind: "unsupported_media_type" }, 415, 415, "client_error", "unsupported media type", "invalid_request_error", "invalid_request_error"],
+    [{ kind: "unsupported_semantics" }, 422, 400, "client_error", "unsupported semantics", "invalid_request_error", "invalid_request_error"],
+    [{ kind: "authentication" }, 401, 401, "authentication_error", "authentication failed", "authentication_error", "authentication_error"],
+    [{ kind: "permission" }, 403, 403, "authentication_error", "permission denied", "permission_error", "permission_error"],
+    [{ kind: "model_not_found" }, 404, 404, "client_error", "model not found", "not_found_error", "not_found_error"],
+    [{ kind: "queue_full" }, 503, 529, "overloaded", "server overloaded", "api_error", "overloaded_error"],
+    [{ kind: "queue_timeout" }, 503, 529, "overloaded", "server overloaded", "api_error", "overloaded_error"],
+    [{ kind: "upstream_timeout" }, 504, 504, "timeout", "upstream timeout", "api_error", "timeout_error"],
+    [{ kind: "upstream_network" }, 502, 502, "upstream_error", "upstream request failed", "api_error", "api_error"],
+    [{ kind: "upstream_stream_error" }, 502, 502, "upstream_error", "upstream request failed", "api_error", "api_error"],
+    [{ kind: "upstream_stream_truncated" }, 502, 502, "upstream_error", "upstream request failed", "api_error", "api_error"],
+    [{ kind: "invalid_upstream_response" }, 502, 502, "upstream_error", "invalid upstream response", "api_error", "api_error"],
+    [{ kind: "invalid_tool_arguments" }, 502, 502, "upstream_error", "invalid upstream response", "api_error", "api_error"],
+    [{ kind: "internal" }, 500, 500, "internal_error", "internal error", "api_error", "api_error"],
+  ] satisfies ReadonlyArray<readonly [
+    GatewayFailure,
+    number,
+    number,
+    ReturnType<typeof failureOutcome>,
+    string,
+    string,
+    string,
+  ]>)(
+    "projects $0 without changing protocol exceptions",
+    async (failure, openAiStatus, anthropicStatus, outcome, message, openAiType, anthropicType) => {
+      const chat = presentOpenAiChatFailure(failure, requestId);
+      const messages = presentAnthropicFailure(failure, requestId);
+      const responses = presentResponsesFailure(failure, requestId);
+
+      expect(chat.status).toBe(openAiStatus);
+      expect(messages.status).toBe(anthropicStatus);
+      expect(responses.status).toBe(openAiStatus);
+      expect(chat.headers.get("x-request-id")).toBe(requestId);
+      expect(messages.headers.get("request-id")).toBe(requestId);
+      expect(responses.headers.get("x-request-id")).toBe(requestId);
+      expect(failureOutcome(failure)).toBe(outcome);
+
+      const openAiBody = `{"error":{"message":${JSON.stringify(message)},"type":${JSON.stringify(openAiType)},"param":null,"code":null}}`;
+      const anthropicBody = `{"type":"error","error":{"type":${JSON.stringify(anthropicType)},"message":${JSON.stringify(message)}},"request_id":"${requestId}"}`;
+      expect(await chat.text()).toBe(openAiBody);
+      expect(await messages.text()).toBe(anthropicBody);
+      expect(await responses.text()).toBe(openAiBody);
+
+      for (const body of [openAiBody, anthropicBody]) {
+        expect(body).not.toContain("secret-token");
+        expect(body).not.toContain("https://unsafe.example/private");
+        expect(body).not.toContain("stack trace");
+        expect(body).not.toContain("reasoning");
+      }
+    },
+  );
+
+  it("keeps model-list protocol envelopes and safe headers distinct", async () => {
+    const failure: GatewayFailure = {
+      kind: "upstream_http",
+      status: 429,
+      retryAfter: "120",
+      source: "catalog",
+      phase: "discover",
+      cause: new Error("secret-token https://unsafe.example/private stack trace reasoning"),
+    };
+    const openai = presentModelCatalogFailure(failure, requestId, openAiModelsRequest);
+    const anthropic = presentModelCatalogFailure(failure, requestId, anthropicModelsRequest);
+
+    expect(openai.status).toBe(429);
+    expect(openai.headers.get("x-request-id")).toBe(requestId);
+    expect(openai.headers.get("request-id")).toBeNull();
+    expect(JSON.parse(await openai.text())).toMatchObject({
+      error: { type: "rate_limit_error", code: "429" },
+    });
+
+    expect(anthropic.status).toBe(429);
+    expect(anthropic.headers.get("request-id")).toBe(requestId);
+    expect(anthropic.headers.get("x-request-id")).toBeNull();
+    expect(JSON.parse(await anthropic.text())).toMatchObject({
+      type: "error",
+      error: { type: "rate_limit_error", message: "upstream request failed" },
+      request_id: requestId,
+    });
+  });
+
+  it("drops unsafe Retry-After values in every presenter", () => {
+    const failure: GatewayFailure = {
+      kind: "upstream_http",
+      status: 429,
+      retryAfter: "120, https://unsafe.example/private",
+    };
+    expect(presentOpenAiChatFailure(failure, requestId).headers.get("retry-after")).toBeNull();
+    expect(presentAnthropicFailure(failure, requestId).headers.get("retry-after")).toBeNull();
+    expect(presentResponsesFailure(failure, requestId).headers.get("retry-after")).toBeNull();
+    expect(presentModelCatalogFailure(failure, requestId, openAiModelsRequest).headers.get("retry-after")).toBeNull();
+  });
+
+  it("does not record usage when presenters are invoked directly", () => {
+    const recordUsage = vi.fn();
+    const request = new Request("http://127.0.0.1:31400/");
+    const failure: GatewayFailure = { kind: "upstream_timeout" };
+    const chat = createOpenAiChatRoute({
+      usageRecorder: { recordUsage },
+    } as unknown as OpenAiChatRouteDependencies);
+    const messages = createAnthropicMessagesRoute({
+      usageRecorder: { recordUsage },
+    } as unknown as AnthropicMessagesRouteDependencies);
+    const responses = createResponsesRoute({
+      usageRecorder: { recordUsage },
+    } as unknown as ResponsesRouteDependencies);
+
+    chat.presentFailure(failure, requestId, request);
+    messages.presentFailure(failure, requestId, request);
+    responses.presentFailure(failure, requestId, request);
+
+    expect(recordUsage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/contract/openai_chat_endpoint.test.ts
+++ b/tests/contract/openai_chat_endpoint.test.ts
@@ -8,6 +8,7 @@ import type { BoundCopilot, CopilotBackend, CopilotTarget } from "../../src/copi
 import { CapiFetchError } from "../../src/copilot/models_source.js";
 import { CopilotModelCatalog, type CapiModelsResponse } from "../../src/copilot/model_catalog.js";
 import { InvalidUpstreamResponseError, UpstreamTimeoutError } from "../../src/copilot/transport.js";
+import { TokenRefreshError } from "../../src/copilot/token_refresh.js";
 import { defaultRuntimeConfigSnapshot, type RuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
 import { createGateway, type Gateway } from "../../src/gateway/create_gateway.js";
@@ -33,6 +34,7 @@ class CapturingCopilotBackend implements CopilotBackend {
 
   constructor(
     private readonly options: {
+      readonly bindError?: unknown;
       readonly chat?: ChatResponse;
       readonly chatError?: unknown;
       readonly chatPromise?: Promise<ChatResponse>;
@@ -41,6 +43,9 @@ class CapturingCopilotBackend implements CopilotBackend {
   ) {}
 
   async bind(account: Readonly<BoundAccount>, _signal: AbortSignal): Promise<BoundCopilot> {
+    if (this.options.bindError !== undefined) {
+      throw this.options.bindError;
+    }
     const target: CopilotTarget = { endpoint: "https://api.githubcopilot.com", token: "scripted-token" };
     return {
       accountId: account.accountId,
@@ -392,14 +397,15 @@ describe("OpenAI Chat endpoint", () => {
     const backend = new CapturingCopilotBackend({
       chat: { status: 200, headers: new Headers(), body: encoder.encode("{}") },
     });
+
     const timeoutGateway = await openAiGateway(backend, {
       capiError: new CapiFetchError(502, undefined, "upstream_timeout"),
     });
     try {
       const response = await timeoutGateway.gw.fetch(jsonRequest("{\"model\":\"gpt\"}"));
-      expect(response.status).toBe(502);
+      expect(response.status).toBe(504);
       expect(await response.text()).toBe(
-        "{\"error\":{\"message\":\"upstream request failed\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
+        "{\"error\":{\"message\":\"upstream timeout\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
       );
     } finally {
       await timeoutGateway.close();
@@ -416,6 +422,45 @@ describe("OpenAI Chat endpoint", () => {
       );
     } finally {
       await invalidGateway.close();
+    }
+  });
+
+  it.each([
+    ["missing", 401, "authentication_error", "authentication failed", "authentication_error"],
+    ["unauthorized", 401, "authentication_error", "authentication failed", "authentication_error"],
+    ["network", 502, "api_error", "upstream request failed", "upstream_error"],
+    ["timeout", 504, "api_error", "upstream timeout", "timeout"],
+  ] as const)("normalizes %s credential refresh failures at bind", async (code, status, type, message, outcome) => {
+    const usageUpdates: Array<{ outcome?: string }> = [];
+    const backend = new CapturingCopilotBackend({
+      bindError: new TokenRefreshError(code, "secret-token https://unsafe.example/private"),
+    });
+    const { gw, close } = await openAiGateway(backend, { usageUpdates });
+    try {
+      const response = await gw.fetch(jsonRequest("{\"model\":\"gpt\"}"));
+      expect(response.status).toBe(status);
+      expect(await response.text()).toBe(JSON.stringify({
+        error: { message, type, param: null, code: null },
+      }));
+      expect(usageUpdates).toMatchObject([{ outcome }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("does not mistake an unowned AbortError for a client disconnect", async () => {
+    const backend = new CapturingCopilotBackend({
+      chatError: new DOMException("upstream aborted", "AbortError"),
+    });
+    const { gw, close } = await openAiGateway(backend);
+    try {
+      const response = await gw.fetch(jsonRequest("{\"model\":\"gpt\"}"));
+      expect(response.status).toBe(500);
+      expect(await response.text()).toBe(
+        "{\"error\":{\"message\":\"internal error\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
+      );
+    } finally {
+      await close();
     }
   });
 

--- a/tests/contract/responses_endpoint.test.ts
+++ b/tests/contract/responses_endpoint.test.ts
@@ -6,6 +6,9 @@ import { AccountDirectory } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import { ScriptedCopilotBackend } from "../../src/copilot/backend.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
+import { CapiFetchError } from "../../src/copilot/models_source.js";
+import { TokenRefreshError } from "../../src/copilot/token_refresh.js";
+import { UpstreamTimeoutError } from "../../src/copilot/transport.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
 import { createGateway, type Gateway } from "../../src/gateway/create_gateway.js";
@@ -23,6 +26,27 @@ import type { UsageUpdate } from "../../src/telemetry/recorder.js";
 const nowMs = (): number => 1_700_000_000_000;
 
 describe("Responses endpoint", () => {
+  it("observes pre-endpoint body failures once without coupling accounting to the presenter", async () => {
+    const usageUpdates: UsageUpdate[] = [];
+    const { gw, close } = await responsesGateway({ usageUpdates });
+    try {
+      const response = await gw.fetch(new Request("http://127.0.0.1:31400/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{\"input\":",
+      }));
+      expect(response.status).toBe(400);
+      expect(usageUpdates).toMatchObject([{
+        protocol: "openai_responses_bridge",
+        outcome: "client_error",
+        requestCount: 1,
+        errorCount: 1,
+      }]);
+    } finally {
+      await close();
+    }
+  });
+
   it("registers only /v1/responses and rejects explicit unknown models before upstream", async () => {
     const usageUpdates: UsageUpdate[] = [];
     const { gw, backend, close } = await responsesGateway({ usageUpdates });
@@ -185,9 +209,138 @@ describe("Responses endpoint", () => {
     }
   });
 
+  it("normalizes catalog timeout and bind authentication with safe Responses errors", async () => {
+    const timeoutUsage: UsageUpdate[] = [];
+    const timeoutGateway = await responsesGateway({
+      catalogError: new CapiFetchError(502, undefined, "upstream_timeout"),
+      usageUpdates: timeoutUsage,
+    });
+    try {
+      const response = await timeoutGateway.gw.fetch(responsesRequest({ model: "native", input: "hi" }));
+      expect(response.status).toBe(504);
+      expect(response.headers.get("x-request-id")).toBe("req_responses");
+      expect(await response.text()).toBe(
+        "{\"error\":{\"message\":\"upstream timeout\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
+      );
+      expect(timeoutUsage).toMatchObject([{ outcome: "timeout" }]);
+    } finally {
+      await timeoutGateway.close();
+    }
+
+    const authUsage: UsageUpdate[] = [];
+    const authGateway = await responsesGateway({
+      backend: new ScriptedCopilotBackend({
+        bindError: new TokenRefreshError("unauthorized", "secret-token https://unsafe.example/private"),
+      }),
+      usageUpdates: authUsage,
+    });
+    try {
+      const response = await authGateway.gw.fetch(responsesRequest({ model: "native", input: "hi" }));
+      expect(response.status).toBe(401);
+      expect(await response.text()).toBe(
+        "{\"error\":{\"message\":\"authentication failed\",\"type\":\"authentication_error\",\"param\":null,\"code\":null}}",
+      );
+      expect(authUsage).toMatchObject([{ outcome: "authentication_error" }]);
+    } finally {
+      await authGateway.close();
+    }
+  });
+
+  it.each(["native", "chat"] as const)("normalizes %s transport timeout before commitment", async (model) => {
+    const timeout = (): never => {
+      throw new UpstreamTimeoutError();
+    };
+    const backend = new ScriptedCopilotBackend({
+      responses: timeout,
+      chat: timeout,
+    });
+    const { gw, close } = await responsesGateway({ backend });
+    try {
+      const response = await gw.fetch(responsesRequest({ model, input: "hi" }));
+      expect(response.status).toBe(504);
+      expect(await response.text()).toBe(
+        "{\"error\":{\"message\":\"upstream timeout\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("normalizes native truncation and bridge error events before commitment", async () => {
+    const nativeGateway = await responsesGateway({
+      backend: new ScriptedCopilotBackend({ responsesStream: [] }),
+    });
+    try {
+      const response = await nativeGateway.gw.fetch(responsesRequest({ model: "native", input: "hi", stream: true }));
+      expect(response.status).toBe(502);
+      expect(await response.text()).toContain("\"message\":\"upstream request failed\"");
+    } finally {
+      await nativeGateway.close();
+    }
+
+    const bridgeGateway = await responsesGateway({
+      backend: new ScriptedCopilotBackend({
+        chatStream: [text("event: error\ndata: {\"error\":{\"message\":\"secret-token https://unsafe.example/private\"}}\n\n")],
+      }),
+    });
+    try {
+      const response = await bridgeGateway.gw.fetch(responsesRequest({ model: "chat", input: "hi", stream: true }));
+      expect(response.status).toBe(502);
+      expect(await response.text()).toBe(
+        "{\"error\":{\"message\":\"upstream request failed\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
+      );
+    } finally {
+      await bridgeGateway.close();
+    }
+  });
+
+  it.each(["native", "chat"] as const)("keeps %s internal deadline distinct from client abort before commitment", async (model) => {
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.timeouts.totalMs = 1;
+    const timedOutGateway = await responsesGateway({
+      runtime,
+      backend: new ScriptedCopilotBackend({
+        responsesStream: (request) => stalledStream(request.signal),
+        chatStream: (request) => stalledStream(request.signal),
+      }),
+    });
+    try {
+      const response = await timedOutGateway.gw.fetch(responsesRequest({ model, input: "hi", stream: true }));
+      expect(response.status).toBe(504);
+      expect(response.headers.get("x-request-id")).toBe("req_responses");
+      expect(await response.text()).toBe(
+        "{\"error\":{\"message\":\"upstream timeout\",\"type\":\"api_error\",\"param\":null,\"code\":null}}",
+      );
+    } finally {
+      await timedOutGateway.close();
+    }
+
+    const clientGateway = await responsesGateway({
+      backend: new ScriptedCopilotBackend({
+        responsesStream: (request) => stalledStream(request.signal),
+        chatStream: (request) => stalledStream(request.signal),
+      }),
+    });
+    try {
+      const controller = new AbortController();
+      const pending = clientGateway.gw.fetch(responsesRequest(
+        { model, input: "hi", stream: true },
+        controller.signal,
+      ));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      controller.abort();
+      const response = await pending;
+      expect(response.body).toBeNull();
+    } finally {
+      await clientGateway.close();
+    }
+  });
+
   async function responsesGateway(options: {
     readonly backend?: ScriptedCopilotBackend;
     readonly usageUpdates?: UsageUpdate[];
+    readonly catalogError?: unknown;
+    readonly runtime?: ReturnType<typeof defaultRuntimeConfigSnapshot>;
   } = {}): Promise<{
     readonly gw: Gateway;
     readonly backend: ScriptedCopilotBackend;
@@ -212,6 +365,9 @@ describe("Responses endpoint", () => {
     });
     const catalog = new CopilotModelCatalog({
       async fetch() {
+        if (options.catalogError !== undefined) {
+          throw options.catalogError;
+        }
         return {
           data: [
             { id: "native", name: "Native", vendor: "github", model_picker_enabled: true, model_info: { mode: "responses" } },
@@ -227,7 +383,7 @@ describe("Responses endpoint", () => {
     });
     const gw = await createGateway({
       startup: parseStartupConfig([], {}, { homedir: dir }),
-      runtime: defaultRuntimeConfigSnapshot(),
+      runtime: options.runtime ?? defaultRuntimeConfigSnapshot(),
     }, [createResponsesRoute({
       directory: accounts,
       catalog,
@@ -251,12 +407,20 @@ describe("Responses endpoint", () => {
     };
   }
 
-  function responsesRequest(body: unknown): Request {
+  function responsesRequest(body: unknown, signal?: AbortSignal): Request {
     return new Request("http://127.0.0.1:31400/v1/responses", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
+      ...(signal === undefined ? {} : { signal }),
     });
+  }
+
+  async function* stalledStream(signal: AbortSignal): AsyncIterable<Uint8Array> {
+    await new Promise<void>((_resolve, reject) => {
+      signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+    });
+    yield text("");
   }
 
   function text(value: string): Uint8Array {

--- a/tests/integration/model_routes.test.ts
+++ b/tests/integration/model_routes.test.ts
@@ -6,6 +6,7 @@ import { AccountDirectory } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import { CapiFetchError } from "../../src/copilot/models_source.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
+import { TokenRefreshError } from "../../src/copilot/token_refresh.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
 import { createGateway } from "../../src/gateway/create_gateway.js";
@@ -105,6 +106,64 @@ describe("model routes errors and preferences", () => {
       const invalid = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"));
       expect(invalid.status).toBe(429);
       expect(invalid.headers.get("retry-after")).toBeNull();
+    } finally {
+      await gw.close();
+      closeDatabase(database);
+    }
+  });
+
+  it("normalizes model-list credential and timeout failures in both protocol shapes", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-cat-"));
+    const database = openDatabase({
+      path: path.join(dir, "state.db"),
+      migrations: [embedMigration(runtimeConfigMigration), embedMigration(accountsMigration)],
+      nowMs,
+    });
+    const accounts = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+    await accounts.upsertAuthenticated({
+      host: "github.com",
+      userId: "1",
+      secret: { generation: 0, githubToken: "t" },
+    });
+    let error: unknown = new CapiFetchError(502, undefined, "upstream_timeout");
+    const catalog = new CopilotModelCatalog({
+      async fetch() {
+        throw error;
+      },
+    });
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: dir }),
+      runtime: defaultRuntimeConfigSnapshot(),
+    }, createModelCatalogRoutes({
+      directory: accounts,
+      catalog,
+      preferences: accounts.preferences,
+    }), { createRequestId: () => "req_models" });
+    try {
+      const openai = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"));
+      expect(openai.status).toBe(504);
+      expect(openai.headers.get("x-request-id")).toBe("req_models");
+      expect(JSON.parse(await openai.text())).toMatchObject({
+        error: { type: "api_error", code: "504" },
+      });
+
+      catalog.invalidate("github.com/1");
+      const anthropic = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models", {
+        headers: { "anthropic-version": "2023-06-01" },
+      }));
+      expect(anthropic.status).toBe(504);
+      expect(anthropic.headers.get("request-id")).toBe("req_models");
+      expect(JSON.parse(await anthropic.text())).toMatchObject({
+        type: "error",
+        error: { type: "timeout_error", message: "upstream timeout" },
+        request_id: "req_models",
+      });
+
+      error = new TokenRefreshError("missing", "secret-token https://unsafe.example/private");
+      catalog.invalidate("github.com/1");
+      const authentication = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"));
+      expect(authentication.status).toBe(401);
+      expect(await authentication.text()).not.toContain("secret-token");
     } finally {
       await gw.close();
       closeDatabase(database);

--- a/tests/unit/failure_normalization.test.ts
+++ b/tests/unit/failure_normalization.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { AccountDirectoryError } from "../../src/accounts/account_directory.js";
+import { ChatSseError } from "../../src/copilot/chat_sse.js";
+import {
+  normalizeAccountBindingFailure,
+  normalizeCatalogFailure,
+  normalizeChatStreamFailure,
+  normalizeCopilotBindingFailure,
+  normalizeTransportFailure,
+} from "../../src/copilot/failures.js";
+import { CapiFetchError } from "../../src/copilot/models_source.js";
+import { TokenRefreshError } from "../../src/copilot/token_refresh.js";
+import {
+  InvalidUpstreamResponseError,
+  UpstreamTimeoutError,
+} from "../../src/copilot/transport.js";
+import {
+  failureFromSignal,
+  failureFromUnknown,
+  GatewayFailureError,
+} from "../../src/gateway/failures.js";
+
+describe("typed semantic failure normalization", () => {
+  it("preserves source and phase for account, credential, catalog, transport, and parser seams", () => {
+    expect(normalizeAccountBindingFailure(
+      new AccountDirectoryError("no_default", "missing"),
+    ).failure).toMatchObject({
+      kind: "authentication",
+      source: "account",
+      phase: "bind",
+    });
+    expect(normalizeCopilotBindingFailure(
+      new TokenRefreshError("timeout", "private"),
+      new AbortController().signal,
+    ).failure).toMatchObject({
+      kind: "upstream_timeout",
+      source: "credential",
+      phase: "refresh",
+    });
+    expect(normalizeCatalogFailure(
+      new CapiFetchError(502, undefined, "invalid_upstream_response"),
+      new AbortController().signal,
+    ).failure).toMatchObject({
+      kind: "invalid_upstream_response",
+      source: "catalog",
+      phase: "discover",
+    });
+    expect(normalizeTransportFailure(
+      new InvalidUpstreamResponseError(),
+      new AbortController().signal,
+      { source: "transport", phase: "headers" },
+    ).failure).toMatchObject({
+      kind: "invalid_upstream_response",
+      source: "transport",
+      phase: "headers",
+    });
+    expect(normalizeChatStreamFailure(
+      new ChatSseError("truncated", "private"),
+      new AbortController().signal,
+    ).failure).toMatchObject({
+      kind: "upstream_stream_truncated",
+      source: "parser",
+      phase: "parse",
+    });
+    expect(normalizeCatalogFailure(
+      new Error("programmer bug"),
+      new AbortController().signal,
+    ).failure.kind).toBe("internal");
+    expect(normalizeCopilotBindingFailure(
+      new Error("programmer bug"),
+      new AbortController().signal,
+    ).failure.kind).toBe("internal");
+  });
+
+  it("preserves an internal deadline reason without globally treating AbortError as timeout", () => {
+    const deadline = new AbortController();
+    deadline.abort(new GatewayFailureError({
+      kind: "upstream_timeout",
+      source: "gateway",
+      phase: "deadline",
+    }));
+    expect(failureFromSignal(deadline.signal, {
+      source: "transport",
+      phase: "connect",
+    })).toMatchObject({
+      kind: "upstream_timeout",
+      source: "gateway",
+      phase: "deadline",
+    });
+
+    const client = new AbortController();
+    client.abort();
+    expect(failureFromSignal(client.signal, {
+      source: "transport",
+      phase: "connect",
+    })).toMatchObject({
+      kind: "aborted",
+      source: "transport",
+      phase: "connect",
+    });
+    expect(failureFromUnknown(new DOMException("aborted", "AbortError"))).toMatchObject({
+      kind: "internal",
+    });
+    expect(normalizeTransportFailure(
+      new DOMException("upstream aborted", "AbortError"),
+      new AbortController().signal,
+      { source: "transport", phase: "headers" },
+    ).failure.kind).toBe("internal");
+  });
+
+  it("keeps transport timeout distinct from network fallback", () => {
+    expect(normalizeTransportFailure(
+      new UpstreamTimeoutError(),
+      new AbortController().signal,
+      { source: "transport", phase: "headers" },
+    ).failure.kind).toBe("upstream_timeout");
+    expect(normalizeTransportFailure(
+      new TypeError("private URL"),
+      new AbortController().signal,
+      { source: "transport", phase: "headers" },
+    ).failure.kind).toBe("upstream_network");
+    expect(normalizeTransportFailure(
+      new Error("programmer bug"),
+      new AbortController().signal,
+      { source: "transport", phase: "headers" },
+    ).failure).toMatchObject({
+      kind: "internal",
+      source: "gateway",
+      phase: "internal",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add one typed semantic failure policy with source/phase preservation and explicit deadline versus client-cancel ownership
- normalize account, credential refresh, CAPI, transport, parser, stream-event, and invalid-response failures at their owning seams
- extract accounting-free Chat, Messages, Responses, and model-list presenters while preserving protocol envelopes, request IDs, safe Retry-After, Messages 400/529 exceptions, and valid stream commitment behavior
- fix Chat CAPI timeout drift, retained bind authentication 500s, model-list timeout 502 drift, Responses bridge/native parser fallbacks, and standalone AbortError empty-success behavior

## Compatibility and safety
- no credentials, raw URLs, upstream bodies, stacks, tool content, or reasoning are copied into public failures or telemetry projections
- no fallback inference attempt or retry is created by a presenter
- pre-existing usage observation is invoked separately and remains once-only; the shared lifecycle redesign remains in issue 109
- no protocol fixture bytes changed; 50 fixture manifest entries verify unchanged
- intentional contract changes are Chat CAPI timeout 502 to 504, model listing timeout 502 to 504, retained bind failures to 401/502/504 by semantic cause, and parser/stream fallbacks from internal to typed upstream outcomes

## Reference provenance
- LiteLLM: `ae7e50f096a8722bad14d63b6a0d4634d59bf475`, branch `litellm_internal_staging`, clean and 2003 commits behind its upstream. Consulted GitHub Copilot Chat/Messages/Responses transformations and core exception mapping.
- cc-switch: `319ed5ac8b5945d4ea2cdbe177ac818dbdec2b86`, branch `feat/codex-copilot-capability-routing`, locally modified with one untracked SSE trace file. Consulted proxy error/status mapping and SSE/Responses streaming behavior read-only.
- deliberate differences: this gateway uses fixed sanitized diagnostics instead of LiteLLM/cc-switch raw exception or upstream-body forwarding; it preserves native downstream envelope/status exceptions rather than mechanically copying shared 400/422 or 503/529 mappings.

## Validation
- `npm test`: 63 files, 465 passed, 4 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run fixtures:verify`: 50 entries
- `npm run build`
- official SDK and live suites were not run

## Review
- two-axis `/code-review` repeated after fixes
- Standards: no must-fix findings; lifecycle duplication is safely deferred to issue 109
- Spec: no findings in the final pass

## Tracking
Closes #107

Related context: #96, #93, #99.

Ticket recommendation: keep issue 96 and issue 99 open for remaining lifecycle and aggregate acceptance work; issue 93 is already closed after its transport-resource portion, and this PR supplies the retained classification portion.