### PR TITLE
Redesign Admin UI with approved OpenCode directory layout

### DIFF
--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -102,7 +102,7 @@ test("github-and-ghes-account-lifecycle", async ({ page }) => {
   await expect.poll(() => devicePollRequests(fixture).length).toBe(1);
   await advanceDeviceClock(page, fixture, 10_000);
   await expect(page.getByText("Enterprise Admin")).toBeVisible();
-  await expect(page.getByRole("status")).toContainText("Current account in use is @octo");
+  await expect(page.getByRole("status")).toContainText("Account in use is @octo");
   expect(fixture.state.accounts.defaultAccountId).toBe("github:1");
   fixture.state.conflictAccount = true;
   await page.getByRole("button", { name: "Use this account" }).click();
@@ -177,6 +177,7 @@ test("device-flow retries network failures without accepting stale responses", a
   await expect(page.getByText("retrying automatically")).toBeVisible();
   await advanceDeviceClock(page, fixture, 5_000);
   await expect(page.getByText("Enterprise Admin")).toBeVisible();
+  await expect(page.getByRole("alert")).toHaveCount(0);
 
   fixture.state.accounts = {
     ...fixture.state.accounts,
@@ -345,6 +346,7 @@ test("model token override keeps protocol inheritance", async ({ page }) => {
   await card.getByLabel("Default output tokens").fill("2048");
   await card.getByRole("button", { name: "Save capability override" }).click();
   await expect(page.getByText("gpt-alpha capability override saved.")).toBeVisible();
+  await expect(card.getByText("Configured override", { exact: true })).toBeVisible();
   const request = fixture.requests.findLast((candidate) => (
     candidate.url().endsWith("/models/capabilities")
     && candidate.method() === "PUT"
@@ -392,8 +394,8 @@ test("config-revision-and-security-rejection", async ({ page }) => {
   await page.getByRole("button", { name: "Configuration" }).click();
   await expect(page.getByRole("heading", { name: "Configuration", exact: true })).toBeFocused();
   await expect(page.getByText("REVISION 7")).toBeVisible();
-  await expect(page.locator(".config-form fieldset")).toHaveCount(7);
-  await expect(page.locator(".config-form input")).toHaveCount(15);
+  await expect(page.getByRole("group")).toHaveCount(7);
+  await expect(page.getByRole("spinbutton")).toHaveCount(15);
   fixture.state.conflictConfig = true;
   await page.getByRole("button", { name: "Apply configuration" }).click();
   await expect(page.getByRole("alert")).toContainText("changed elsewhere");
@@ -455,11 +457,11 @@ test("events-and-degraded-recovery", async ({ page }) => {
   await expect(page.getByText("EVENT 521", { exact: true })).toHaveCount(0);
   await expect(page.getByText("EVENT 522", { exact: true })).toHaveCount(0);
   await expect(page.getByText("EVENT 523", { exact: true })).toHaveCount(1);
-  await expect(page.locator(".event-list > li")).toHaveCount(501);
+  await expect(page.getByRole("list", { name: "Operational events" }).getByRole("listitem")).toHaveCount(501);
   await expect(page.getByText("EVENT 520", { exact: true })).toHaveCount(0);
   await page.getByRole("button", { name: "Load newer events" }).click();
   await expect(page.getByText("EVENT 520", { exact: true })).toBeVisible();
-  await expect(page.locator(".event-list > li")).toHaveCount(512);
+  await expect(page.getByRole("list", { name: "Operational events" }).getByRole("listitem")).toHaveCount(512);
   await page.getByRole("button", { name: "Overview" }).click();
   await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeFocused();
   await expect(page.getByRole("heading", { name: "Gateway is degraded" })).toHaveCount(0);
@@ -475,7 +477,7 @@ test("daemon-restart-invalidates-session", async ({ page }) => {
 });
 
 test("responsive shell centers the right column and contains long content", async ({ page }) => {
-  test.setTimeout(60_000);
+  test.setTimeout(90_000);
   await page.setViewportSize({ width: 390, height: 900 });
   const fixture = await openAdmin(page);
   const baseAccount = fixture.state.accounts.items[0]!;
@@ -523,7 +525,7 @@ test("responsive shell centers the right column and contains long content", asyn
 
   await assertDocumentShape();
   const menu = page.getByRole("button", { name: "Open navigation" });
-  const sidebar = page.locator(".sidebar");
+  const sidebar = page.locator('[data-layout-region="navigation"]');
   await expect(sidebar).toHaveAttribute("aria-hidden", "true");
   await expect(sidebar).toHaveAttribute("inert", "");
   await menu.click();
@@ -543,19 +545,74 @@ test("responsive shell centers the right column and contains long content", asyn
   for (const width of [900, 1600, 2560, 3440]) {
     await page.setViewportSize({ width, height: 1000 });
     await expect(sidebar).not.toHaveAttribute("aria-hidden", "true");
-    const gaps = await page.evaluate(() => {
-      const column = document.querySelector<HTMLElement>(".main-column")!.getBoundingClientRect();
-      const frame = document.querySelector<HTMLElement>(".content-frame")!.getBoundingClientRect();
-      return {
-        left: frame.left - column.left,
-        right: column.right - frame.right,
-        rootFits: window.scrollX === 0,
-      };
-    });
-    expect(gaps.rootFits).toBe(true);
-    expect(Math.abs(gaps.left - gaps.right)).toBeLessThanOrEqual(1);
-    await assertDocumentShape();
+    for (const view of ["Overview", "Accounts", "Models", "Configuration", "Responses History", "Events"]) {
+      await page.getByRole("button", { name: view }).click();
+      await expect(page.getByRole("heading", { name: view, exact: true })).toBeFocused();
+      const gaps = await page.evaluate(() => {
+        const column = document.querySelector<HTMLElement>('[data-layout-region="main-column"]')!
+          .getBoundingClientRect();
+        const frame = document.querySelector<HTMLElement>('[data-layout-region="content-frame"]')!
+          .getBoundingClientRect();
+        return {
+          left: frame.left - column.left,
+          right: column.right - frame.right,
+        };
+      });
+      expect(Math.abs(gaps.left - gaps.right)).toBeLessThanOrEqual(1);
+      await assertDocumentShape();
+    }
   }
+});
+
+test("responsive authentication, empty, and error states stay contained", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 900 });
+  const fixture = await installAdminFixture(page);
+  await page.goto("/admin/");
+  await expect(page.getByRole("heading", { name: "Admin session closed" })).toBeFocused();
+  await expect(page.getByRole("main")).toHaveCount(1);
+  await expect(page.locator("h1")).toHaveCount(1);
+
+  await page.evaluate(() => {
+    location.hash = "bootstrap_token=state-secret";
+  });
+  await page.getByRole("button", { name: "Try current session" }).click();
+  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
+  fixture.state.accounts = { ...fixture.state.accounts, defaultAccountId: null, items: [] };
+  await page.getByRole("button", { name: "Open navigation" }).click();
+  await page.getByRole("button", { name: "Accounts" }).click();
+  await expect(page.getByRole("heading", { name: "No accounts connected" })).toBeVisible();
+
+  fixture.state.failStatus = true;
+  await page.getByRole("button", { name: "Open navigation" }).click();
+  await page.getByRole("button", { name: "Overview" }).click();
+  await page.getByRole("button", { name: "Refresh" }).click();
+  await expect(page.getByRole("alert")).toContainText("Overview unavailable");
+  const rootScrollX = await page.evaluate(() => {
+    window.scrollTo({ left: 10_000 });
+    return window.scrollX;
+  });
+  expect(rootScrollX).toBe(0);
+});
+
+test("live SSE deduplicates replay before applying the 512 event bound", async ({ page }) => {
+  const fixture = await installAdminFixture(page);
+  fixture.state.events = [];
+  const unique = Array.from({ length: 512 }, (_, index) => {
+    const event = operationalEvent(index + 1);
+    return `id: ${event.eventId}\n${sse("operational", { kind: "operational", event })}`;
+  }).join("");
+  const replayed = operationalEvent(512);
+  fixture.state.streamBodies = [
+    `${unique}id: ${replayed.eventId}\n${sse("operational", { kind: "operational", event: replayed })}`,
+  ];
+  fixture.state.streamHoldsMs = [1_000];
+
+  await page.goto("/admin/#bootstrap_token=dedupe-secret");
+  await page.getByRole("button", { name: "Events" }).click();
+  const eventList = page.getByRole("list", { name: "Operational events" });
+  await expect(eventList.getByRole("listitem")).toHaveCount(512);
+  await expect(page.getByText("EVENT 1", { exact: true })).toBeVisible();
+  await expect(page.getByText("EVENT 512", { exact: true })).toHaveCount(1);
 });
 
 test("production Admin bundle excludes prototype content", async () => {
@@ -565,6 +622,6 @@ test("production Admin bundle excludes prototype content", async () => {
     .filter((file) => /\.(?:css|html|js)$/u.test(file))
     .map((file) => readFile(path.join(root, file), "utf8")))).join("\n");
   expect(text).not.toMatch(
-    /MOCK DATA|Simulate connection|Reset preview|sample-a|sample-b|variant-pick|DESIGN PREVIEW/u,
+    /MOCK DATA|Simulate connection|Reset preview|sample-a|sample-b|ljie-PI|jl87pi|resp_preview_|SIMULATED SESSION|SAMPLE FEED|variant-pick|DESIGN PREVIEW/u,
   );
 });

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   ADMIN_FIXTURE_NOW_MS,
@@ -17,8 +17,7 @@ async function openAdmin(page: Page) {
 }
 
 async function keyboardNavigate(page: Page, name: string): Promise<void> {
-  await page.getByRole("button", { name: "End session" }).focus();
-  await page.keyboard.press("Tab");
+  await page.getByRole("button", { name: "Overview" }).focus();
   await page.keyboard.press("Tab");
   if (name !== "Accounts") throw new Error("keyboardNavigate currently starts at Accounts");
   await expect(page.getByRole("button", { name })).toBeFocused();
@@ -83,7 +82,7 @@ test("bootstrap-and-session-expiry", async ({ page }) => {
   }))).toEqual(expect.objectContaining({ local: 0, session: 0 }));
   fixture.state.authenticated = false;
   await page.getByRole("button", { name: "Refresh" }).click();
-  await expect(page.getByRole("heading", { name: "Control room locked" })).toBeFocused();
+  await expect(page.getByRole("heading", { name: "Admin session closed" })).toBeFocused();
   await expect(page.getByText("admin session ended")).toBeVisible();
   expect(fixture.requests.some((request) => request.url().endsWith("/auth/logout"))).toBe(false);
   expect(fixture.requests.filter((request) => request.url().endsWith("/status"))).toHaveLength(2);
@@ -103,30 +102,30 @@ test("github-and-ghes-account-lifecycle", async ({ page }) => {
   await expect.poll(() => devicePollRequests(fixture).length).toBe(1);
   await advanceDeviceClock(page, fixture, 10_000);
   await expect(page.getByText("Enterprise Admin")).toBeVisible();
-  await expect(page.getByRole("status")).toContainText("Current default is @octo");
+  await expect(page.getByRole("status")).toContainText("Current account in use is @octo");
   expect(fixture.state.accounts.defaultAccountId).toBe("github:1");
   fixture.state.conflictAccount = true;
-  await page.getByRole("button", { name: "Make default" }).click();
+  await page.getByRole("button", { name: "Use this account" }).click();
   await expect(page.getByRole("alert")).toContainText("changed elsewhere");
   await expect(page.getByText("Enterprise Admin")).toBeVisible();
-  await page.getByRole("button", { name: "Make default" }).click();
+  await page.getByRole("button", { name: "Use this account" }).click();
   expect(fixture.requests.find((request) => request.url().endsWith("/accounts/default"))?.headers()["x-ghcg-csrf"])
     .toBe("csrf-memory-only");
   fixture.state.failAccountRemoval = true;
   page.once("dialog", (dialog) => dialog.accept());
-  await page.getByRole("article")
+  await page.getByRole("row")
     .filter({ hasText: "Enterprise Admin" })
     .getByRole("button", { name: "Remove" })
     .click();
   await expect(page.getByRole("alert")).toContainText("internal error");
-  await expect(page.getByRole("article").filter({ hasText: "Enterprise Admin" }).getByText("removing"))
+  await expect(page.getByRole("row").filter({ hasText: "Enterprise Admin" }).getByText("removing"))
     .toBeVisible();
   page.once("dialog", (dialog) => dialog.accept());
-  await page.getByRole("article")
+  await page.getByRole("row")
     .filter({ hasText: "Enterprise Admin" })
     .getByRole("button", { name: "Remove" })
     .click();
-  await expect(page.getByRole("article").filter({ hasText: "Enterprise Admin" }).getByText("removed"))
+  await expect(page.getByRole("row").filter({ hasText: "Enterprise Admin" }).getByText("removed"))
     .toBeVisible();
 });
 
@@ -162,7 +161,7 @@ test("device-flow disposal and terminal failures clean up polling", async ({ pag
   await page.getByRole("button", { name: "Start login" }).click();
   fixture.state.authenticated = false;
   await advanceDeviceClock(page, fixture, 5_000);
-  await expect(page.getByRole("heading", { name: "Control room locked" })).toBeFocused();
+  await expect(page.getByRole("heading", { name: "Admin session closed" })).toBeFocused();
   await advanceDeviceClock(page, fixture, 20_000);
   expect(devicePollRequests(fixture)).toHaveLength(4);
 });
@@ -297,8 +296,9 @@ test("model-capability-override-lifecycle", async ({ page }) => {
   await page.getByRole("button", { name: "Models" }).click();
   await page.getByLabel("Model ID").fill("manual-model");
   await page.getByRole("button", { name: "Add configured model" }).click();
-  const card = page.getByRole("article").filter({ hasText: "manual-model" });
-  await expect(card.getByText(/Configured \/ unverified/)).toBeVisible();
+  const card = page.locator('tbody[data-model-id="manual-model"]');
+  await expect(card.getByText("Configured / unverified", { exact: true })).toBeVisible();
+  await card.getByText("Capability details and override").click();
   await card.getByLabel("messages").check();
   await card.getByLabel("Default output tokens").fill("2048");
   await card.getByRole("button", { name: "Save capability override" }).click();
@@ -306,10 +306,10 @@ test("model-capability-override-lifecycle", async ({ page }) => {
   expect(fixture.requests.find((request) => request.url().endsWith("/models/capabilities")
     && request.method() === "PUT")?.headers()["x-ghcg-csrf"]).toBe("csrf-memory-only");
   await card.getByRole("button", { name: "Reset override" }).click();
-  await expect(page.getByRole("article").filter({ hasText: "manual-model" })).toHaveCount(0);
+  await expect(page.locator('tbody[data-model-id="manual-model"]')).toHaveCount(0);
   await page.getByLabel("Model ID").fill("manual-model");
   await page.getByRole("button", { name: "Add configured model" }).click();
-  await expect(page.getByRole("article").filter({ hasText: "manual-model" })).toBeVisible();
+  await expect(page.locator('tbody[data-model-id="manual-model"]')).toBeVisible();
 });
 
 test("model-account switching ignores stale responses", async ({ page }) => {
@@ -339,10 +339,12 @@ test("model-account switching ignores stale responses", async ({ page }) => {
 test("model token override keeps protocol inheritance", async ({ page }) => {
   const fixture = await openAdmin(page);
   await page.getByRole("button", { name: "Models" }).click();
-  const card = page.getByRole("article").filter({ hasText: "gpt-alpha" });
+  const card = page.locator('tbody[data-model-id="gpt-alpha"]').first();
+  await card.getByText("Capability details and override").click();
   await expect(card.getByLabel("Override native protocols")).not.toBeChecked();
   await card.getByLabel("Default output tokens").fill("2048");
   await card.getByRole("button", { name: "Save capability override" }).click();
+  await expect(page.getByText("gpt-alpha capability override saved.")).toBeVisible();
   const request = fixture.requests.findLast((candidate) => (
     candidate.url().endsWith("/models/capabilities")
     && candidate.method() === "PUT"
@@ -358,6 +360,7 @@ test("model token override keeps protocol inheritance", async ({ page }) => {
     candidate.url().endsWith("/models/capabilities") && candidate.method() === "PUT"
   )).length;
   await card.getByLabel("Default output tokens").fill("");
+  await expect(card.getByLabel("Default output tokens")).toHaveValue("");
   await card.getByRole("button", { name: "Save capability override" }).click();
   await expect.poll(() => fixture.requests.filter((candidate) => (
     candidate.url().endsWith("/models/capabilities") && candidate.method() === "PUT"
@@ -381,7 +384,7 @@ test("models view renders duplicate catalog IDs without crashing", async ({ page
   };
   await page.getByRole("button", { name: "Models" }).click();
   await expect(page.getByText("gpt-alpha", { exact: true })).toHaveCount(2);
-  await expect(page.getByRole("heading", { name: "Duplicate Alpha" })).toBeVisible();
+  await expect(page.getByText("Duplicate Alpha", { exact: true })).toBeVisible();
 });
 
 test("config-revision-and-security-rejection", async ({ page }) => {
@@ -389,6 +392,8 @@ test("config-revision-and-security-rejection", async ({ page }) => {
   await page.getByRole("button", { name: "Configuration" }).click();
   await expect(page.getByRole("heading", { name: "Configuration", exact: true })).toBeFocused();
   await expect(page.getByText("REVISION 7")).toBeVisible();
+  await expect(page.locator(".config-form fieldset")).toHaveCount(7);
+  await expect(page.locator(".config-form input")).toHaveCount(15);
   fixture.state.conflictConfig = true;
   await page.getByRole("button", { name: "Apply configuration" }).click();
   await expect(page.getByRole("alert")).toContainText("changed elsewhere");
@@ -401,12 +406,12 @@ test("responses-history-inspect-and-clear", async ({ page }) => {
   const fixture = await openAdmin(page);
   await page.getByRole("button", { name: "Responses History" }).click();
   await expect(page.getByRole("heading", { name: "Responses History", exact: true })).toBeFocused();
-  await expect(page.getByText("12", { exact: true })).toBeVisible();
+  await expect(page.getByText("12 / 512", { exact: true })).toBeVisible();
   fixture.state.conflictHistory = true;
   page.once("dialog", (dialog) => dialog.accept());
   await page.getByRole("button", { name: "Clear history" }).click();
   await expect(page.getByRole("alert")).toContainText("changed elsewhere");
-  await expect(page.getByText("12", { exact: true })).toBeVisible();
+  await expect(page.getByText("12 / 512", { exact: true })).toBeVisible();
   page.once("dialog", (dialog) => dialog.accept());
   await page.getByRole("button", { name: "Clear history" }).click();
   await expect(page.getByRole("heading", { name: "History is empty" })).toBeVisible();
@@ -435,7 +440,7 @@ test("events-and-degraded-recovery", async ({ page }) => {
   ];
 
   await page.goto("/admin/#bootstrap_token=event-secret");
-  await expect(page.getByText("connecting", { exact: true })).toBeVisible();
+  await expect(page.getByRole("banner").getByText("connecting", { exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Gateway is degraded" })).toBeVisible();
   await expect(page.getByRole("banner").getByText("live", { exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Events" }).click();
@@ -450,11 +455,11 @@ test("events-and-degraded-recovery", async ({ page }) => {
   await expect(page.getByText("EVENT 521", { exact: true })).toHaveCount(0);
   await expect(page.getByText("EVENT 522", { exact: true })).toHaveCount(0);
   await expect(page.getByText("EVENT 523", { exact: true })).toHaveCount(1);
-  await expect(page.locator(".timeline > li")).toHaveCount(501);
+  await expect(page.locator(".event-list > li")).toHaveCount(501);
   await expect(page.getByText("EVENT 520", { exact: true })).toHaveCount(0);
   await page.getByRole("button", { name: "Load newer events" }).click();
   await expect(page.getByText("EVENT 520", { exact: true })).toBeVisible();
-  await expect(page.locator(".timeline > li")).toHaveCount(512);
+  await expect(page.locator(".event-list > li")).toHaveCount(512);
   await page.getByRole("button", { name: "Overview" }).click();
   await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeFocused();
   await expect(page.getByRole("heading", { name: "Gateway is degraded" })).toHaveCount(0);
@@ -463,8 +468,103 @@ test("events-and-degraded-recovery", async ({ page }) => {
 test("daemon-restart-invalidates-session", async ({ page }) => {
   const fixture = await openAdmin(page);
   fixture.state.authenticated = false;
-  await expect(page.getByRole("heading", { name: "Control room locked" })).toBeFocused();
+  await expect(page.getByRole("heading", { name: "Admin session closed" })).toBeFocused();
   await expect(page.getByText("admin session ended")).toBeVisible();
   expect(fixture.requests.some((request) => request.url().endsWith("/auth/session"))).toBe(true);
   expect(await page.evaluate(() => localStorage.length + sessionStorage.length)).toBe(0);
+});
+
+test("responsive shell centers the right column and contains long content", async ({ page }) => {
+  test.setTimeout(60_000);
+  await page.setViewportSize({ width: 390, height: 900 });
+  const fixture = await openAdmin(page);
+  const baseAccount = fixture.state.accounts.items[0]!;
+  fixture.state.accounts = {
+    ...fixture.state.accounts,
+    items: [
+      baseAccount,
+      {
+        ...baseAccount,
+        accountId: "ghes:long",
+        host: `${"enterprise-".repeat(12)}example.test`,
+        numericUserId: "99999999999999999999",
+        login: `${"long-login-".repeat(12)}account`,
+        displayName: `${"Long directory identity ".repeat(8)}`,
+      },
+    ],
+  };
+  fixture.state.models = {
+    ...fixture.state.models,
+    items: fixture.state.models.items.map((model, index) => index === 0
+      ? { ...model, id: `model-${"long-".repeat(40)}` }
+      : model),
+  };
+  fixture.state.events = [{
+    ...operationalEvent(99),
+    metadata: { source: "x".repeat(600) },
+  }];
+
+  const assertDocumentShape = async (): Promise<void> => {
+    await expect(page.getByRole("main")).toHaveCount(1);
+    await expect(page.locator("h1")).toHaveCount(1);
+    const overflow = await page.evaluate(() => {
+      window.scrollTo({ left: 10_000 });
+      const rootScrollX = window.scrollX;
+      window.scrollTo({ left: 0 });
+      return {
+        title: document.querySelector("h1")?.textContent ?? "",
+        rootScrollX,
+        tableContainersFit: [...document.querySelectorAll<HTMLElement>(".table-scroll")]
+          .every((element) => element.getBoundingClientRect().right <= document.documentElement.clientWidth + 1),
+      };
+    });
+    expect(overflow, overflow.title).toEqual({ title: overflow.title, rootScrollX: 0, tableContainersFit: true });
+  };
+
+  await assertDocumentShape();
+  const menu = page.getByRole("button", { name: "Open navigation" });
+  const sidebar = page.locator(".sidebar");
+  await expect(sidebar).toHaveAttribute("aria-hidden", "true");
+  await expect(sidebar).toHaveAttribute("inert", "");
+  await menu.click();
+  await expect(page.getByRole("button", { name: "Overview" })).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(menu).toBeFocused();
+  await expect(sidebar).toHaveAttribute("aria-hidden", "true");
+
+  for (const view of ["Accounts", "Models", "Configuration", "Responses History", "Events", "Overview"]) {
+    await menu.click();
+    await expect(sidebar).toHaveAttribute("aria-hidden", "false");
+    await page.getByRole("button", { name: view }).click();
+    await expect(page.getByRole("heading", { name: view, exact: true })).toBeFocused();
+    await assertDocumentShape();
+  }
+
+  for (const width of [900, 1600, 2560, 3440]) {
+    await page.setViewportSize({ width, height: 1000 });
+    await expect(sidebar).not.toHaveAttribute("aria-hidden", "true");
+    const gaps = await page.evaluate(() => {
+      const column = document.querySelector<HTMLElement>(".main-column")!.getBoundingClientRect();
+      const frame = document.querySelector<HTMLElement>(".content-frame")!.getBoundingClientRect();
+      return {
+        left: frame.left - column.left,
+        right: column.right - frame.right,
+        rootFits: window.scrollX === 0,
+      };
+    });
+    expect(gaps.rootFits).toBe(true);
+    expect(Math.abs(gaps.left - gaps.right)).toBeLessThanOrEqual(1);
+    await assertDocumentShape();
+  }
+});
+
+test("production Admin bundle excludes prototype content", async () => {
+  const root = path.resolve("dist", "admin");
+  const files = await readdir(root, { recursive: true });
+  const text = (await Promise.all(files
+    .filter((file) => /\.(?:css|html|js)$/u.test(file))
+    .map((file) => readFile(path.join(root, file), "utf8")))).join("\n");
+  expect(text).not.toMatch(
+    /MOCK DATA|Simulate connection|Reset preview|sample-a|sample-b|variant-pick|DESIGN PREVIEW/u,
+  );
 });

--- a/tests/e2e/fixtures/admin_fixture.ts
+++ b/tests/e2e/fixtures/admin_fixture.ts
@@ -40,6 +40,7 @@ export interface AdminFixture {
     history: AdminHistorySummary;
     status: AdminStatus;
     events: AdminOperationalEvent[];
+    failStatus: boolean;
     rejectSecurity: boolean;
     conflictAccount: boolean;
     conflictConfig: boolean;
@@ -120,6 +121,7 @@ export async function installAdminFixture(page: Page): Promise<AdminFixture> {
       },
       status: status("healthy"),
       events: [operationalEvent(40, "gateway_started")],
+      failStatus: false,
       rejectSecurity: false,
       conflictAccount: false,
       conflictConfig: false,
@@ -269,7 +271,10 @@ async function handle(
     fixture.state.authenticated = false;
     return route.fulfill({ status: 204 });
   }
-  if (path === "/status") return json(route, 200, fixture.state.status);
+  if (path === "/status") {
+    if (fixture.state.failStatus) return failure(route, 500, "internal_error");
+    return json(route, 200, fixture.state.status);
+  }
   if (path === "/usage") {
     return json(route, 200, {
       items: [],

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -25,14 +25,28 @@
   let liveStatus: AdminStatus | null = $state(null);
   let liveEvents: AdminOperationalEvent[] = $state([]);
   let resetVersion = $state(0);
+  let navOpen = $state(false);
+  let mobileNavigation = $state(false);
   let stream: EventSource | null = null;
   let signedOutPanel: HTMLElement | null = $state(null);
   let workspace: HTMLElement | null = $state(null);
+  let menuButton: HTMLButtonElement | null = $state(null);
+  let navigation: HTMLElement | null = $state(null);
   const client = new AdminClient(teardown);
 
   onMount(() => {
+    const media = matchMedia("(max-width: 850px)");
+    const updateNavigationMode = (): void => {
+      mobileNavigation = media.matches;
+      if (!mobileNavigation) navOpen = false;
+    };
+    updateNavigationMode();
+    media.addEventListener("change", updateNavigationMode);
     void authenticate();
-    return closeStream;
+    return () => {
+      media.removeEventListener("change", updateNavigationMode);
+      closeStream();
+    };
   });
 
   async function authenticate(): Promise<void> {
@@ -45,7 +59,7 @@
       openStream();
     } catch (error: unknown) {
       phase = "signed-out";
-      authError = token === null ? "Open this control room with `ghcg admin open`." : errorMessage(error);
+      authError = token === null ? "Open Admin with `ghcg admin open`." : errorMessage(error);
       requestAnimationFrame(() => signedOutPanel?.focus());
     }
   }
@@ -86,6 +100,7 @@
     session = null;
     liveStatus = null;
     liveEvents = [];
+    navOpen = false;
     phase = "signed-out";
     authError = "Your admin session ended. Run `ghcg admin open` to reconnect.";
     requestAnimationFrame(() => signedOutPanel?.focus());
@@ -102,8 +117,25 @@
 
   async function navigate(next: View): Promise<void> {
     view = next;
+    navOpen = false;
     await tick();
     workspace?.querySelector<HTMLElement>("h1")?.focus();
+  }
+
+  async function openNavigation(): Promise<void> {
+    navOpen = true;
+    await tick();
+    navigation?.querySelector<HTMLElement>('[aria-current="page"]')?.focus();
+  }
+
+  function closeNavigation(restoreFocus = true): void {
+    if (!navOpen) return;
+    navOpen = false;
+    if (restoreFocus) requestAnimationFrame(() => menuButton?.focus());
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape" && navOpen) closeNavigation();
   }
 </script>
 
@@ -111,10 +143,15 @@
   <meta name="description" content="Local ghc-gateway administration" />
 </svelte:head>
 
+<svelte:window onkeydown={handleKeydown} />
+
 {#if phase === "loading"}
   <main class="auth-stage" aria-busy="true">
-    <div class="boot-mark" aria-hidden="true"></div>
-    <p class="eyebrow">LOCAL CONTROL PLANE</p>
+    <svg class="auth-mark" viewBox="0 0 40 40" aria-hidden="true">
+      <rect x="2" y="2" width="36" height="36" rx="4" fill="currentColor" />
+      <path d="m11 13 7 7-7 7m12 0h6" fill="none" stroke="var(--canvas)" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter" />
+    </svg>
+    <p class="eyebrow">LOCAL ADMINISTRATION</p>
     <h1>Establishing a secure session</h1>
     <p class="muted">The one-time bootstrap is being exchanged in memory.</p>
   </main>
@@ -123,41 +160,49 @@
     <section class="signed-out" aria-labelledby="signed-out-title">
       <span class="status-dot stopped" aria-hidden="true"></span>
       <p class="eyebrow">SESSION CLOSED</p>
-      <h1 id="signed-out-title" tabindex="-1" bind:this={signedOutPanel}>Control room locked</h1>
+      <h1 id="signed-out-title" tabindex="-1" bind:this={signedOutPanel}>Admin session closed</h1>
       <p>{authError}</p>
       <button class="primary" onclick={authenticate}>Try current session</button>
     </section>
   </main>
 {:else}
+  <a class="skip-link" href="#admin-content">Skip to content</a>
   <div class="shell">
-    <header class="topbar">
+    <aside
+      id="admin-navigation"
+      class:open={navOpen}
+      class="sidebar"
+      aria-label="Primary navigation"
+      aria-hidden={mobileNavigation && !navOpen}
+      inert={mobileNavigation && !navOpen ? true : undefined}
+    >
       <div class="brand">
-        <span class="brand-glyph">G</span>
-        <div><strong>ghc-gateway</strong><small>CONTROL ROOM</small></div>
+        <svg class="brand-mark" viewBox="0 0 40 40" aria-hidden="true" focusable="false">
+          <rect x="2" y="2" width="36" height="36" rx="4" fill="currentColor" />
+          <path d="m11 13 7 7-7 7m12 0h6" fill="none" stroke="var(--canvas)" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter" />
+        </svg>
+        <strong>ghc-gateway</strong>
       </div>
-      <div class="top-actions">
-        <span class="stream-state" aria-live="polite">
-          <span class:reconnecting={streamState !== "live"} class="status-dot"></span>
-          {streamState}
-        </span>
-        <button class="quiet" onclick={logout}>End session</button>
-      </div>
-    </header>
-    <aside class="rail" aria-label="Primary">
-      <nav>
+      <p class="nav-caption">WORKSPACE</p>
+      <nav bind:this={navigation}>
         {#each views as item, index (item)}
           <button
+            class="nav-item"
             class:active={view === item}
             aria-current={view === item ? "page" : undefined}
             onclick={() => void navigate(item)}
           >
-            <span class="nav-index">0{index + 1}</span>
+            <span class="nav-index">[{String(index + 1).padStart(2, "0")}]</span>
             <span>{item}</span>
           </button>
         {/each}
       </nav>
-      <div class="rail-foot">
-        <span>SESSION</span>
+      <div class="sidebar-foot">
+        <span class="stream-state" aria-live="polite">
+          <span class:reconnecting={streamState !== "live"} class="status-dot"></span>
+          {streamState}
+        </span>
+        <span>Admin Session</span>
         <time datetime={session?.idleExpiresAt}>
           idle until {session
             ? new Date(session.idleExpiresAt).toLocaleTimeString([], {
@@ -168,20 +213,51 @@
         </time>
       </div>
     </aside>
-    <main class="workspace" bind:this={workspace}>
-      {#if view === "Overview"}
-        <Overview {client} {liveStatus} />
-      {:else if view === "Accounts"}
-        <Accounts {client} />
-      {:else if view === "Models"}
-        <Models {client} />
-      {:else if view === "Configuration"}
-        <Configuration {client} />
-      {:else if view === "Responses History"}
-        <ResponsesHistory {client} />
-      {:else}
-        <Events {client} {liveEvents} {resetVersion} {streamState} />
-      {/if}
-    </main>
+    {#if navOpen}
+      <button class="nav-backdrop" aria-label="Close navigation" onclick={() => closeNavigation()}></button>
+    {/if}
+    <div class="main-column">
+      <div class="content-frame">
+        <header class="utility-bar">
+          <div class="utility-location">
+            <button
+              class="mobile-menu"
+              aria-label="Open navigation"
+              aria-expanded={navOpen}
+              aria-controls="admin-navigation"
+              bind:this={menuButton}
+              onclick={() => void openNavigation()}
+            >[=]</button>
+            <span>ADMIN / {view.toUpperCase()}</span>
+          </div>
+          <div class="utility-actions">
+            <span class="desktop-stream stream-state" aria-live="polite">
+              <span class:reconnecting={streamState !== "live"} class="status-dot"></span>
+              {streamState}
+            </span>
+            <button class="text-button" onclick={logout}>End session</button>
+          </div>
+        </header>
+        <main id="admin-content" class="workspace" bind:this={workspace}>
+          {#if view === "Overview"}
+            <Overview {client} {liveStatus} />
+          {:else if view === "Accounts"}
+            <Accounts {client} />
+          {:else if view === "Models"}
+            <Models {client} />
+          {:else if view === "Configuration"}
+            <Configuration {client} />
+          {:else if view === "Responses History"}
+            <ResponsesHistory {client} />
+          {:else}
+            <Events {client} {liveEvents} {resetVersion} {streamState} />
+          {/if}
+        </main>
+        <footer class="footer-note">
+          <span>ghc-gateway / local administration</span>
+          <span>Loopback only · content-free operations</span>
+        </footer>
+      </div>
+    </div>
   </div>
 {/if}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -13,6 +13,7 @@
   import Models from "./views/Models.svelte";
   import Overview from "./views/Overview.svelte";
   import ResponsesHistory from "./views/ResponsesHistory.svelte";
+  import TerminalMark from "./TerminalMark.svelte";
 
   const views = ["Overview", "Accounts", "Models", "Configuration", "Responses History", "Events"] as const;
   type View = typeof views[number];
@@ -32,22 +33,23 @@
   let workspace: HTMLElement | null = $state(null);
   let menuButton: HTMLButtonElement | null = $state(null);
   let navigation: HTMLElement | null = $state(null);
+  let pageNumber = $derived(String(views.indexOf(view) + 1).padStart(2, "0"));
   const client = new AdminClient(teardown);
 
   onMount(() => {
-    const media = matchMedia("(max-width: 850px)");
-    const updateNavigationMode = (): void => {
-      mobileNavigation = media.matches;
-      if (!mobileNavigation) navOpen = false;
-    };
     updateNavigationMode();
-    media.addEventListener("change", updateNavigationMode);
+    window.addEventListener("resize", updateNavigationMode);
     void authenticate();
     return () => {
-      media.removeEventListener("change", updateNavigationMode);
+      window.removeEventListener("resize", updateNavigationMode);
       closeStream();
     };
   });
+
+  function updateNavigationMode(): void {
+    mobileNavigation = menuButton !== null && getComputedStyle(menuButton).display !== "none";
+    if (!mobileNavigation) navOpen = false;
+  }
 
   async function authenticate(): Promise<void> {
     phase = "loading";
@@ -56,6 +58,8 @@
     try {
       session = token === null ? await client.session() : await client.bootstrap(token);
       phase = "ready";
+      await tick();
+      updateNavigationMode();
       openStream();
     } catch (error: unknown) {
       phase = "signed-out";
@@ -81,7 +85,10 @@
     });
     stream.addEventListener("operational", (event) => {
       const value = JSON.parse((event as MessageEvent<string>).data) as { event: AdminOperationalEvent };
-      liveEvents = [...liveEvents, value.event].slice(-512);
+      liveEvents = [
+        ...liveEvents.filter((item) => item.eventId !== value.event.eventId),
+        value.event,
+      ].slice(-512);
     });
     stream.addEventListener("reset", () => {
       liveEvents = [];
@@ -147,10 +154,7 @@
 
 {#if phase === "loading"}
   <main class="auth-stage" aria-busy="true">
-    <svg class="auth-mark" viewBox="0 0 40 40" aria-hidden="true">
-      <rect x="2" y="2" width="36" height="36" rx="4" fill="currentColor" />
-      <path d="m11 13 7 7-7 7m12 0h6" fill="none" stroke="var(--canvas)" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter" />
-    </svg>
+    <TerminalMark class="auth-mark" />
     <p class="eyebrow">LOCAL ADMINISTRATION</p>
     <h1>Establishing a secure session</h1>
     <p class="muted">The one-time bootstrap is being exchanged in memory.</p>
@@ -175,12 +179,10 @@
       aria-label="Primary navigation"
       aria-hidden={mobileNavigation && !navOpen}
       inert={mobileNavigation && !navOpen ? true : undefined}
+      data-layout-region="navigation"
     >
       <div class="brand">
-        <svg class="brand-mark" viewBox="0 0 40 40" aria-hidden="true" focusable="false">
-          <rect x="2" y="2" width="36" height="36" rx="4" fill="currentColor" />
-          <path d="m11 13 7 7-7 7m12 0h6" fill="none" stroke="var(--canvas)" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter" />
-        </svg>
+        <TerminalMark class="brand-mark" />
         <strong>ghc-gateway</strong>
       </div>
       <p class="nav-caption">WORKSPACE</p>
@@ -216,8 +218,8 @@
     {#if navOpen}
       <button class="nav-backdrop" aria-label="Close navigation" onclick={() => closeNavigation()}></button>
     {/if}
-    <div class="main-column">
-      <div class="content-frame">
+    <div class="main-column" data-layout-region="main-column">
+      <div class="content-frame" data-layout-region="content-frame">
         <header class="utility-bar">
           <div class="utility-location">
             <button
@@ -240,17 +242,17 @@
         </header>
         <main id="admin-content" class="workspace" bind:this={workspace}>
           {#if view === "Overview"}
-            <Overview {client} {liveStatus} />
+            <Overview {client} {liveStatus} {pageNumber} />
           {:else if view === "Accounts"}
-            <Accounts {client} />
+            <Accounts {client} {pageNumber} />
           {:else if view === "Models"}
-            <Models {client} />
+            <Models {client} {pageNumber} />
           {:else if view === "Configuration"}
-            <Configuration {client} />
+            <Configuration {client} {pageNumber} />
           {:else if view === "Responses History"}
-            <ResponsesHistory {client} />
+            <ResponsesHistory {client} {pageNumber} />
           {:else}
-            <Events {client} {liveEvents} {resetVersion} {streamState} />
+            <Events {client} {liveEvents} {resetVersion} {streamState} {pageNumber} />
           {/if}
         </main>
         <footer class="footer-note">

--- a/web/src/TerminalMark.svelte
+++ b/web/src/TerminalMark.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  let { class: className = "" }: { class?: string } = $props();
+</script>
+
+<svg class={className} viewBox="0 0 40 40" aria-hidden="true" focusable="false">
+  <rect x="2" y="2" width="36" height="36" rx="4" fill="currentColor" />
+  <path
+    d="m11 13 7 7-7 7m12 0h6"
+    fill="none"
+    stroke="var(--canvas)"
+    stroke-width="2"
+    stroke-linecap="square"
+    stroke-linejoin="miter"
+  />
+</svg>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -397,6 +397,37 @@ tr.current-row > td:last-child { padding-right: 12px; }
   .main-column { padding-inline: 25px; }
   .fact-strip > div, .hero-metrics article, .stat-row > div { padding: 15px; }
   .capability-grid { grid-template-columns: 1fr; }
+  .account-table { min-width: 0; }
+  .account-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+  }
+  .account-table tbody, .account-table tr, .account-table td { display: block; width: 100%; }
+  .account-table tr { padding: 13px 0; border-bottom: 1px solid var(--line); }
+  .account-table td, .account-table td:first-child, .account-table td:last-child {
+    display: grid;
+    grid-template-columns: 110px minmax(0, 1fr);
+    align-items: center;
+    gap: 12px;
+    padding: 7px 0;
+    border: 0;
+  }
+  .account-table td::before {
+    content: attr(data-label);
+    color: var(--muted);
+    font-size: 10px;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+  }
+  .account-table tr.current-row > td:first-child {
+    padding-left: 10px;
+    border-left: 2px solid var(--ink);
+  }
+  .account-table tr.current-row > td:not(:first-child) { padding-left: 12px; }
+  .account-table .row-actions { justify-content: flex-start; }
 }
 
 @media (max-width: 850px) {
@@ -441,37 +472,6 @@ tr.current-row > td:last-child { padding-right: 12px; }
   .fact-strip > div:last-child, .stat-row > div:last-child { border-bottom: 0; }
   .fact-strip span { display: inline; margin-right: 10px; }
   .fact-strip strong { font-size: 13px; }
-  .account-table { min-width: 0; }
-  .account-table thead {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-  }
-  .account-table tbody, .account-table tr, .account-table td { display: block; width: 100%; }
-  .account-table tr { padding: 13px 0; border-bottom: 1px solid var(--line); }
-  .account-table td, .account-table td:first-child, .account-table td:last-child {
-    display: grid;
-    grid-template-columns: 110px minmax(0, 1fr);
-    align-items: center;
-    gap: 12px;
-    padding: 7px 0;
-    border: 0;
-  }
-  .account-table td::before {
-    content: attr(data-label);
-    color: var(--muted);
-    font-size: 10px;
-    letter-spacing: .5px;
-    text-transform: uppercase;
-  }
-  .account-table tr.current-row > td:first-child {
-    padding-left: 10px;
-    border-left: 2px solid var(--ink);
-  }
-  .account-table tr.current-row > td:not(:first-child) { padding-left: 12px; }
-  .account-table .row-actions { justify-content: flex-start; }
   .split-panels, .two-columns, .config-grid, .override-form { grid-template-columns: 1fr; }
   .metric-list li { grid-template-columns: minmax(0, 1fr) auto; }
   .metric-list small { grid-column: 1 / -1; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,3 +1,495 @@
-:root{font-family:Manrope,system-ui,sans-serif;color:#e9eee9;background:#0a0d0c;font-synthesis:none;--panel:#111614;--panel2:#151c19;--line:#27312d;--muted:#8f9c96;--green:#81f59c;--amber:#ffca72;--red:#ff8585;--mono:"DM Mono",monospace}*{box-sizing:border-box}body{margin:0;min-width:320px;min-height:100vh;background:radial-gradient(circle at 88% 3%,#153323 0,transparent 28rem),#0a0d0c}button,.button,input,select{font:inherit}button,.button{border:1px solid #35423d;border-radius:7px;background:#171e1b;color:#dce5e0;padding:.68rem 1rem;cursor:pointer;text-decoration:none;transition:.15s}button:hover,.button:hover{border-color:#718079;background:#202a26}button:focus-visible,.button:focus-visible,input:focus-visible,select:focus-visible,[tabindex]:focus-visible{outline:2px solid var(--green);outline-offset:3px}button:disabled{opacity:.45;cursor:not-allowed}.primary{background:var(--green);border-color:var(--green);color:#071009;font-weight:700}.primary:hover{background:#a0ffb5;border-color:#a0ffb5}.quiet{background:transparent}.danger{border-color:#6a3434;color:#ffb0b0;background:#291616}.danger-text{border-color:transparent;background:transparent;color:#ff9c9c}.eyebrow{font:500 .69rem var(--mono);letter-spacing:.15em;color:#75d98c;margin:0 0 .6rem}.muted,.subtle{color:var(--muted)}h1{font-size:clamp(2rem,4vw,3.5rem);line-height:1;letter-spacing:-.055em;margin:.1rem 0 .8rem}h2{letter-spacing:-.025em}.shell{display:grid;grid-template:64px 1fr/225px 1fr;min-height:100vh}.topbar{grid-column:1/-1;border-bottom:1px solid var(--line);background:#0c100fdd;backdrop-filter:blur(12px);display:flex;align-items:center;justify-content:space-between;padding:0 1.2rem;position:sticky;top:0;z-index:5}.brand{display:flex;align-items:center;gap:.8rem}.brand-glyph{display:grid;place-items:center;width:32px;height:32px;border:1px solid var(--green);color:var(--green);font:500 1rem var(--mono);transform:rotate(45deg)}.brand-glyph::first-letter{transform:rotate(-45deg)}.brand div{display:flex;flex-direction:column}.brand small{font:500 .57rem var(--mono);letter-spacing:.17em;color:var(--muted)}.top-actions{display:flex;align-items:center;gap:1rem}.stream-state,.live-badge{font:500 .67rem var(--mono);letter-spacing:.1em;text-transform:uppercase;display:flex;align-items:center;gap:.5rem}.status-dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--green);box-shadow:0 0 14px var(--green)}.status-dot.reconnecting,.status-dot.stopped{background:var(--amber);box-shadow:0 0 14px var(--amber)}.rail{border-right:1px solid var(--line);padding:2rem .8rem 1rem;display:flex;flex-direction:column;justify-content:space-between;position:sticky;top:64px;height:calc(100vh - 64px)}.rail nav{display:grid;gap:.25rem}.rail nav button{border:0;background:transparent;display:grid;grid-template-columns:28px 1fr;text-align:left;color:#99a59f;padding:.75rem}.rail nav button.active{background:#17221c;color:#effff2;box-shadow:inset 2px 0 var(--green)}.nav-index{font:.63rem var(--mono);color:#58635e}.rail-foot{display:flex;flex-direction:column;border-top:1px solid var(--line);padding:1rem .7rem;color:var(--muted);font:.62rem var(--mono);gap:.4rem}.workspace{min-width:0;padding:clamp(1.5rem,4vw,4rem);max-width:1500px;width:100%}.page-head{display:flex;align-items:flex-end;justify-content:space-between;gap:2rem;margin-bottom:2.2rem}.page-head p:last-child{margin:0;color:var(--muted)}.section-block,.connect-panel,.toolbar,.notice,.signed-out{border:1px solid var(--line);background:linear-gradient(145deg,#141a17,#101412);border-radius:10px;padding:1.3rem}.section-title{display:flex;justify-content:space-between;align-items:center}.hero-metrics{display:grid;grid-template-columns:1.3fr 1fr 1fr;gap:1rem;margin-bottom:1rem}.hero-metrics article{min-height:180px;padding:1.4rem;background:var(--panel);border:1px solid var(--line);border-radius:10px;display:flex;flex-direction:column}.hero-metrics article>p{color:var(--muted)}.hero-metrics article>strong{font-size:2.5rem;margin:auto 0}.hero-metrics strong small{font-size:1rem;color:var(--muted)}.hero-metrics meter{width:100%;height:4px}.hero-metrics small{color:var(--muted)}.health-card{background:linear-gradient(135deg,#15251b,#111614)!important}.health-card .status-dot{align-self:flex-end}.stat-row{display:grid;grid-template-columns:repeat(4,1fr);margin-top:1rem;border-top:1px solid var(--line)}.stat-row div{padding:1rem;border-right:1px solid var(--line);display:grid;gap:.4rem}.stat-row div:last-child{border:0}.stat-row span,.storage-list span{color:var(--muted);font-size:.82rem}.stat-row strong{font:500 1.35rem var(--mono)}.split-panels{display:grid;grid-template-columns:1.4fr 1fr;gap:1rem;margin-top:1rem}.metric-list,.storage-list{list-style:none;padding:0;margin:1rem 0 0}.metric-list li{display:grid;grid-template-columns:1fr auto auto;gap:1rem;border-top:1px solid var(--line);padding:.8rem 0;font-size:.8rem}.metric-list span{text-transform:capitalize}.metric-list small{color:var(--muted)}.storage-list li{display:flex;justify-content:space-between;padding:.9rem 0;border-top:1px solid var(--line)}.chip,.revision{font:500 .63rem var(--mono);letter-spacing:.08em;padding:.28rem .5rem;background:#1e2b25;border:1px solid #34473d;border-radius:4px;text-transform:uppercase}.warning{color:var(--amber);border-color:#69512b!important}.degraded{display:flex;justify-content:space-between;gap:2rem;border:1px solid #72572b;background:#241d11;padding:1.2rem;margin-bottom:1rem}.degraded h2,.degraded p{margin:.2rem 0}.notice{margin:0 0 1rem}.notice p{margin:.4rem 0}.notice.error{border-color:#6d3434;background:#241414;color:#ffbaba}.notice.success{border-color:#2f6040;color:#aef3bd}.skeleton-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem}.skeleton-grid i{height:180px;border-radius:10px;background:linear-gradient(100deg,#111613,#1e2823,#111613);background-size:200%;animation:shimmer 1.2s infinite}@keyframes shimmer{to{background-position:-200%}}.connect-panel{display:grid;grid-template-columns:1fr 1.5fr;align-items:end;gap:2rem}.connect-panel h2{margin:0}.connect-panel label,.toolbar label{display:block;font-weight:600;font-size:.82rem;margin-bottom:.5rem}.inline-form{display:flex;gap:.5rem}.inline-form input{flex:1}.device-flow{border:1px solid #3a6645;background:#14251a;padding:1.5rem;margin:1rem 0;display:flex;justify-content:space-between;align-items:center;gap:1rem}.device-flow code{font:500 2rem var(--mono);letter-spacing:.18em}.device-flow>div:last-child{display:flex;gap:.5rem}.card-list{display:grid;gap:.75rem;margin-top:1rem}.card-list article{display:flex;align-items:center;gap:1rem;padding:1.1rem;border:1px solid var(--line);background:var(--panel);border-radius:8px}.avatar{width:44px;height:44px;display:grid;place-items:center;background:#203529;color:var(--green);font:500 .8rem var(--mono);border-radius:50%}.grow{flex:1}.account-title{display:flex;align-items:center;gap:.5rem}.account-title h2{margin:0;font-size:1.05rem}.grow p,.grow small{color:var(--muted);margin:.25rem 0}.card-actions{display:flex;gap:.4rem}.muted-card{opacity:.6}.state-removing{color:var(--amber)}.state-removed{color:#aaa}.toolbar{display:flex;align-items:end;gap:1rem;margin-bottom:1rem}.toolbar label{margin:0}.toolbar .subtle{margin-left:auto;font:.7rem var(--mono)}input,select{background:#0d1210;color:#e8efeb;border:1px solid #34403a;border-radius:6px;padding:.72rem}.model-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:1rem}.model-grid article{border:1px solid var(--line);background:var(--panel);padding:1.3rem;border-radius:9px;position:relative;overflow:hidden}.model-grid article.preferred{border-color:#4f8a60;box-shadow:inset 0 3px var(--green)}.model-vendor{font:.65rem var(--mono);color:var(--green);text-transform:uppercase}.model-grid h2{margin:.7rem 0 .2rem}.model-grid code{font:400 .7rem var(--mono);color:var(--muted)}.model-grid dl div{display:flex;justify-content:space-between;border-top:1px solid var(--line);padding:.65rem 0;font-size:.78rem}.model-grid dt{color:var(--muted)}.model-grid button{width:100%}.config-form{display:grid;gap:1rem}.config-form fieldset{border:1px solid var(--line);background:var(--panel);border-radius:8px;padding:1.2rem}.config-form legend{font:500 .69rem var(--mono);letter-spacing:.12em;color:var(--green);text-transform:uppercase;padding:0 .5rem}.config-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:.7rem 1.5rem}.config-grid label{display:grid;grid-template-columns:1fr 145px;gap:.2rem 1rem;align-items:center;padding:.6rem}.config-grid label span{display:grid}.config-grid small{color:var(--muted)}.config-grid .range{grid-column:2;font:400 .6rem var(--mono)}.sticky-save{position:sticky;bottom:1rem;z-index:2;background:#19211eeb;backdrop-filter:blur(10px);border:1px solid #3a4842;border-radius:8px;padding:.8rem 1rem;display:flex;justify-content:space-between;align-items:center}.sticky-save p{color:var(--muted);font-size:.75rem}.history-orbit{display:grid;grid-template-columns:220px 1fr;gap:3rem;align-items:center;padding:3rem;background:radial-gradient(circle at 110px,#1d4b2b,transparent 12rem),var(--panel);border:1px solid var(--line)}.orb{width:180px;height:180px;border:1px solid #4e8e5e;border-radius:50%;display:grid;place-content:center;text-align:center;box-shadow:0 0 50px #2c7b4133}.orb strong{font:500 3.2rem var(--mono)}.orb span{color:var(--muted)}.history-orbit h2{font-size:2rem;margin:.3rem 0}.timeline{list-style:none;padding:0;margin:0;max-width:950px}.timeline li{display:grid;grid-template-columns:25px 1fr;gap:1rem;position:relative}.timeline li::before{content:"";position:absolute;left:5px;top:14px;bottom:-14px;border-left:1px solid var(--line)}.timeline li:last-child::before{display:none}.timeline-mark{width:11px;height:11px;border:2px solid var(--green);background:#0a0d0c;border-radius:50%;margin-top:14px;z-index:1}.severity-warning .timeline-mark{border-color:var(--amber)}.severity-error .timeline-mark{border-color:var(--red)}.timeline article{border-bottom:1px solid var(--line);padding:.7rem 0 1.5rem}.timeline header{display:flex;gap:.6rem;align-items:center}.timeline time,.timeline small{font:.65rem var(--mono);color:var(--muted)}.timeline h2{font-size:1rem;text-transform:capitalize;margin:.7rem 0 .3rem}.timeline p{color:#b5c0ba;font-size:.8rem}.load-more{margin:1rem 0 0 40px}.empty{text-align:center;border:1px dashed #34413b;padding:4rem;color:var(--muted)}.empty span{font:500 2.2rem var(--mono);color:#425049}.empty h2{color:#dae3de}.loading-line{color:var(--muted);font-family:var(--mono)}.auth-stage{min-height:100vh;display:grid;place-content:center;text-align:center;padding:2rem}.boot-mark{width:50px;height:50px;border:1px solid var(--green);margin:0 auto 2rem;animation:spin 2s linear infinite}@keyframes spin{to{transform:rotate(180deg)}}.signed-out{max-width:540px;padding:3rem}.signed-out .status-dot{margin-bottom:1.5rem}
-@media(max-width:850px){.shell{grid-template:64px 1fr 68px/1fr}.rail{grid-row:3;position:fixed;bottom:0;top:auto;left:0;right:0;height:68px;z-index:6;border:1px solid var(--line);background:#0d1210;padding:.3rem;overflow-x:auto}.rail nav{display:flex;min-width:650px}.rail nav button{display:flex;gap:.35rem;white-space:nowrap}.rail-foot{display:none}.workspace{grid-row:2;padding:1.4rem 1rem 6rem}.hero-metrics,.split-panels{grid-template-columns:1fr}.connect-panel{grid-template-columns:1fr}.config-grid{grid-template-columns:1fr}.page-head{align-items:flex-start}.top-actions .stream-state{display:none}.stat-row{grid-template-columns:repeat(2,1fr)}.history-orbit{grid-template-columns:1fr;padding:2rem}.device-flow{align-items:flex-start;flex-direction:column}}
-@media(max-width:520px){.topbar{padding:0 .7rem}.brand strong{font-size:.86rem}.top-actions button{padding:.5rem}.page-head{display:grid;gap:1rem}.page-head h1{font-size:2.5rem}.hero-metrics article{min-height:150px}.inline-form,.device-flow>div:last-child,.card-list article{align-items:stretch;flex-direction:column}.card-actions{margin-top:.5rem}.toolbar{display:grid}.toolbar .subtle{margin:0}.config-grid label{grid-template-columns:1fr}.config-grid .range{grid-column:1}.sticky-save{position:static;display:grid}.stat-row{grid-template-columns:1fr}.stat-row div{border-right:0;border-bottom:1px solid var(--line)}}
+:root {
+  font-family: "Berkeley Mono", "IBM Plex Mono", ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  color: #201d1d;
+  background: #fdfcfc;
+  font-synthesis: none;
+  --canvas: #fdfcfc;
+  --soft: #f8f7f7;
+  --panel: #f1eeee;
+  --ink: #201d1d;
+  --muted: #646262;
+  --line: rgba(15, 0, 0, .15);
+  --green: #267748;
+  --amber: #92630a;
+  --red: #b42920;
+  --focus: #006bd6;
+  --sidebar-width: 248px;
+}
+
+* { box-sizing: border-box; }
+html, body, #app { min-width: 320px; min-height: 100%; max-width: 100%; overflow-x: clip; }
+body { margin: 0; background: var(--canvas); font-size: 14px; line-height: 1.65; }
+button, input, select, textarea { font: inherit; }
+button, .button {
+  min-height: 36px;
+  padding: 6px 13px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: var(--ink);
+  background: var(--canvas);
+  cursor: pointer;
+  text-decoration: none;
+}
+button:hover, .button:hover { background: var(--panel); border-color: #8d8585; }
+button:disabled { color: #8d8585; background: var(--soft); cursor: default; }
+button.primary, .button.primary { background: var(--ink); border-color: var(--ink); color: var(--canvas); }
+button.primary:hover, .button.primary:hover { background: #0f0000; }
+button.primary:disabled { background: var(--panel); border-color: var(--line); color: var(--muted); }
+button.text-button { min-height: 28px; padding: 2px 5px; border-color: transparent; background: transparent; }
+button.danger, button.danger-text { color: var(--red); }
+button.danger-text { border-color: transparent; background: transparent; }
+button:focus-visible, .button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible,
+textarea:focus-visible, summary:focus-visible, [tabindex]:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 3px;
+}
+button:focus:not(:focus-visible), h1:focus { outline: none; }
+input, select, textarea {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 9px 11px;
+  color: var(--ink);
+  background: var(--soft);
+}
+input:focus, select:focus, textarea:focus { background: var(--canvas); }
+input[type="checkbox"] { accent-color: var(--ink); }
+a { color: inherit; text-underline-offset: 4px; }
+h1, h2, h3, p { margin-top: 0; }
+h1 { margin-bottom: 9px; font-size: clamp(26px, 2.4vw, 36px); line-height: 1.3; letter-spacing: -1px; }
+h2 { margin-bottom: 9px; font-size: 16px; line-height: 1.5; }
+h3 { margin-bottom: 7px; font-size: 14px; }
+code, pre { font: inherit; }
+code { overflow-wrap: anywhere; }
+pre { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+small, .small { font-size: 12px; }
+[hidden] { display: none !important; }
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.muted, .subtle { color: var(--muted); }
+.eyebrow { margin: 0 0 12px; color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 1px; }
+.skip-link { position: fixed; top: -70px; left: 16px; z-index: 100; padding: 10px; background: var(--canvas); }
+.skip-link:focus { top: 12px; }
+
+.shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  width: 100%;
+  max-width: 100%;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+.sidebar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  height: 100dvh;
+  min-width: 0;
+  flex-direction: column;
+  padding: 30px 16px 22px;
+  border-right: 1px solid var(--line);
+  background: var(--canvas);
+}
+.brand { display: flex; align-items: center; gap: 10px; padding: 0 10px 34px; }
+.brand-mark { width: 36px; height: 36px; flex: 0 0 36px; color: var(--ink); }
+.brand strong { font-size: 16px; letter-spacing: -.5px; }
+.nav-caption { margin: 0; padding: 0 10px 10px; color: var(--muted); font-size: 11px; letter-spacing: 1px; }
+.sidebar nav { display: grid; gap: 4px; }
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 11px 10px;
+  border-color: transparent;
+  font-size: 14px;
+  text-align: left;
+  white-space: nowrap;
+}
+.nav-item .nav-index { flex-shrink: 0; color: #8b8585; font-size: 11px; }
+.nav-item.active { background: var(--panel); color: var(--ink); }
+.nav-item.active .nav-index { color: var(--ink); }
+.sidebar-foot {
+  display: grid;
+  gap: 4px;
+  margin-top: auto;
+  padding: 18px 10px 0;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 11px;
+}
+.stream-state { display: flex; align-items: center; gap: 7px; text-transform: uppercase; }
+.status-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--green); }
+.status-dot.reconnecting, .status-dot.stopped { background: var(--amber); }
+.main-column { min-width: 0; padding: 30px clamp(24px, 3vw, 56px) 48px; }
+.content-frame { width: 100%; max-width: 1100px; min-width: 0; margin-inline: auto; }
+.utility-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 37px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 11px;
+}
+.utility-location, .utility-actions { display: flex; align-items: center; gap: 14px; }
+.mobile-menu { display: none; min-height: 30px; padding: 1px 9px; }
+.workspace { min-width: 0; }
+.footer-note {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  margin-top: 40px;
+  padding-top: 15px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.page-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 28px; }
+.page-head > div:first-child { min-width: 0; }
+.page-head p:last-child { max-width: 680px; margin: 0; color: var(--muted); font-size: 13px; }
+.page-head > button, .page-head > .revision, .page-head > .live-badge { flex-shrink: 0; }
+.section { min-width: 0; max-width: 100%; margin-top: 30px; padding-top: 23px; border-top: 1px solid var(--line); }
+.section-heading, .section-title { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin-bottom: 14px; }
+.section-heading h2, .section-title h2 { margin: 0; }
+.section-number { margin-right: 11px; color: var(--muted); font-size: 11px; }
+.section-block { min-width: 0; }
+.chip, .revision, .badge {
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  max-width: 100%;
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.7;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.chip.strong, .badge.strong { border-color: var(--ink); background: var(--ink); color: var(--canvas); }
+.good { color: var(--green); }
+.warning { color: var(--amber); }
+.error-text { color: var(--red); }
+.notice, .degraded {
+  margin: 0 0 18px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  background: var(--soft);
+}
+.notice p, .degraded p { margin: 4px 0 0; }
+.notice.error { border-color: rgba(180, 41, 32, .45); color: #711c16; }
+.notice.success { border-color: rgba(38, 119, 72, .4); color: #185d35; }
+.notice.warning, .degraded { border-color: rgba(146, 99, 10, .45); color: #6b4806; }
+.degraded { display: flex; align-items: center; justify-content: space-between; gap: 24px; }
+.degraded h2 { margin: 0; color: var(--ink); }
+.loading-line { color: var(--muted); }
+.skeleton-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border: 1px solid var(--line); }
+.skeleton-grid i { height: 150px; border-right: 1px solid var(--line); background: var(--soft); }
+.skeleton-grid i:last-child { border: 0; }
+.empty { padding: 40px 24px; border: 1px dashed #c8c0c0; color: var(--muted); text-align: center; }
+.empty span { display: block; margin-bottom: 4px; color: var(--ink); font-size: 20px; }
+.empty h2 { color: var(--ink); }
+
+.fact-strip, .hero-metrics, .stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--line);
+}
+.fact-strip { margin: 26px 0; }
+.fact-strip > div, .hero-metrics article, .stat-row > div {
+  min-width: 0;
+  padding: 17px 20px;
+  border-right: 1px solid var(--line);
+}
+.fact-strip > div:last-child, .hero-metrics article:last-child, .stat-row > div:last-child { border-right: 0; }
+.fact-strip span, .hero-metrics p, .stat-row span {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: .6px;
+  text-transform: uppercase;
+}
+.fact-strip strong { font-size: 15px; overflow-wrap: anywhere; }
+.hero-metrics { margin-bottom: 30px; }
+.hero-metrics article { display: flex; min-height: 145px; flex-direction: column; }
+.hero-metrics article > strong { margin: auto 0 5px; font-size: 28px; line-height: 1.2; overflow-wrap: anywhere; }
+.hero-metrics article > small { color: var(--muted); }
+.hero-metrics meter { width: 100%; height: 6px; margin-top: 10px; accent-color: var(--ink); }
+.stat-row { grid-template-columns: repeat(4, minmax(0, 1fr)); margin-top: 14px; }
+.stat-row strong { display: block; font-size: 17px; overflow-wrap: anywhere; }
+.split-panels, .two-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 28px; }
+.plain-list, .metric-list, .storage-list { margin: 0; padding: 0; list-style: none; }
+.plain-list li, .metric-list li, .storage-list li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 12px;
+}
+.metric-list li { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; }
+.plain-list li span:first-child, .metric-list small, .storage-list span { color: var(--muted); }
+
+.table-scroll { display: block; width: 100%; max-width: 100%; min-width: 0; overflow-x: auto; contain: inline-size; }
+table { width: 100%; border-collapse: collapse; text-align: left; }
+th {
+  padding: 11px 13px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 400;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+}
+td { padding: 16px 13px; border-bottom: 1px solid var(--line); font-size: 12px; vertical-align: middle; }
+th:first-child, td:first-child { padding-left: 0; }
+th:last-child, td:last-child { padding-right: 0; }
+.account-table { min-width: 780px; }
+.model-table { min-width: 980px; }
+tr.current-row { background: var(--soft); }
+tr.current-row > td:first-child { padding-left: 12px; border-left: 2px solid var(--ink); }
+tr.current-row > td:last-child { padding-right: 12px; }
+.identity { display: flex; align-items: center; gap: 12px; min-width: 0; }
+.avatar {
+  display: grid;
+  width: 35px;
+  height: 35px;
+  flex: 0 0 35px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--soft);
+  color: var(--muted);
+  font-size: 11px;
+}
+.identity strong, .identity small { display: block; overflow-wrap: anywhere; }
+.identity small { color: var(--muted); font-size: 11px; }
+.row-actions { display: flex; align-items: center; justify-content: flex-end; gap: 7px; }
+.state-removing { color: var(--amber); }
+.state-removed { color: var(--muted); }
+.muted-row { color: var(--muted); }
+.hint-line { display: flex; align-items: flex-start; gap: 11px; margin: 17px 0; color: var(--muted); font-size: 11px; }
+.hint-line > span { color: var(--ink); font-weight: 700; }
+.hint-line p { margin: 0; }
+.command-block {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 17px 20px;
+  border-radius: 4px;
+  background: var(--panel);
+}
+.command-lines { display: grid; gap: 5px; font-size: 12px; }
+.connect-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(340px, 1.4fr);
+  align-items: end;
+  gap: 28px;
+  padding: 20px;
+  border: 1px solid var(--line);
+}
+.connect-panel h2 { margin: 0; }
+.connect-panel label, .toolbar label { display: block; margin-bottom: 6px; font-size: 12px; font-weight: 700; }
+.inline-form { display: flex; gap: 7px; }
+.inline-form input { flex: 1; }
+.device-flow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 22px;
+  margin: 18px 0;
+  padding: 20px;
+  border: 1px solid rgba(38, 119, 72, .4);
+  background: var(--soft);
+}
+.device-flow code { display: block; margin: 9px 0; font-size: 25px; letter-spacing: .14em; }
+.device-actions { display: flex; flex-wrap: wrap; gap: 7px; }
+
+.toolbar { display: flex; align-items: flex-end; flex-wrap: wrap; gap: 13px; margin: 20px 0; }
+.toolbar .grow { flex: 1; }
+.toolbar .subtle { font-size: 11px; }
+.model-summary { max-width: 240px; }
+.model-summary strong, .model-summary code { display: block; }
+.model-summary code { color: var(--muted); font-size: 11px; }
+.tag-group { display: flex; flex-wrap: wrap; gap: 5px; }
+.model-source { display: grid; gap: 4px; }
+.model-editor-row td { padding: 0 0 18px; }
+.model-editor { padding: 18px 20px; border: 1px solid var(--line); border-top: 0; background: var(--soft); }
+.model-editor summary { width: max-content; cursor: pointer; font-weight: 700; }
+.capability-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 28px; margin-top: 16px; }
+.capability-grid dl { margin: 0; }
+.capability-grid dl div { display: grid; grid-template-columns: minmax(130px, .8fr) minmax(0, 1.2fr); gap: 12px; padding: 9px 0; border-bottom: 1px solid var(--line); }
+.capability-grid dt { color: var(--muted); }
+.capability-grid dd { margin: 0; overflow-wrap: anywhere; }
+.override-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 18px;
+  align-content: start;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.override-form > label { display: grid; gap: 5px; }
+.override-form > label.check { display: flex; align-items: center; gap: 8px; }
+.protocol-fieldset { grid-column: 1 / -1; margin: 0; padding: 12px; border: 1px solid var(--line); }
+.protocol-fieldset label { margin-right: 16px; }
+.model-actions { display: flex; flex-wrap: wrap; gap: 7px; grid-column: 1 / -1; }
+
+.config-form { display: grid; gap: 24px; }
+.config-form fieldset { margin: 0; padding: 18px 20px; border: 1px solid var(--line); }
+.config-form legend { padding: 0 8px; font-size: 12px; font-weight: 700; text-transform: uppercase; }
+.config-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 34px; }
+.config-grid label { display: grid; grid-template-columns: minmax(0, 1fr) 145px; gap: 4px 14px; align-items: center; padding: 15px 0; border-bottom: 1px solid var(--line); }
+.config-grid label span { display: grid; }
+.config-grid small { color: var(--muted); }
+.config-grid .range { grid-column: 2; font-size: 10px; }
+.sticky-save { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding-top: 18px; border-top: 1px solid var(--line); }
+.sticky-save p { margin: 0; color: var(--muted); font-size: 11px; }
+.history-summary { margin-bottom: 26px; }
+.history-summary .fact-strip { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.history-copy { padding: 22px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.history-copy p:last-child { margin-bottom: 0; color: var(--muted); }
+
+.live-badge { display: flex; align-items: center; gap: 7px; color: var(--muted); font-size: 11px; text-transform: uppercase; }
+.event-list { margin: 0; padding: 0; list-style: none; }
+.event-row {
+  display: grid;
+  grid-template-columns: 160px 90px minmax(0, 1fr) 90px;
+  gap: 18px;
+  align-items: start;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 12px;
+}
+.event-row time, .event-id { color: var(--muted); font-size: 11px; }
+.event-row details { min-width: 0; }
+.event-row summary { cursor: pointer; font-weight: 700; text-transform: capitalize; }
+.event-row pre { margin-top: 10px; padding: 12px; background: var(--soft); color: var(--muted); font-size: 11px; }
+.load-more { margin-top: 18px; }
+
+.auth-stage { display: grid; min-height: 100vh; place-content: center; padding: 32px; text-align: center; }
+.auth-mark { width: 46px; height: 46px; margin: 0 auto 22px; color: var(--ink); }
+.signed-out { max-width: 540px; padding: 30px; border: 1px solid var(--line); background: var(--soft); }
+.signed-out .status-dot { margin-bottom: 15px; }
+
+@media (max-width: 1100px) {
+  :root { --sidebar-width: 232px; }
+  .main-column { padding-inline: 25px; }
+  .fact-strip > div, .hero-metrics article, .stat-row > div { padding: 15px; }
+  .capability-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 850px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .sidebar {
+    position: fixed;
+    left: 0;
+    width: var(--sidebar-width);
+    transform: translateX(-101%);
+    transition: transform .15s;
+  }
+  .sidebar.open { transform: translateX(0); }
+  .nav-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 20;
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: rgb(32 29 29 / 32%);
+  }
+  .nav-backdrop:hover { background: rgb(32 29 29 / 32%); }
+  .main-column { padding: 19px 22px 42px; }
+  .mobile-menu { display: inline-block; }
+  .desktop-stream { display: none; }
+  .utility-bar { margin-bottom: 29px; }
+  .hero-metrics, .skeleton-grid { grid-template-columns: 1fr; }
+  .hero-metrics article, .skeleton-grid i { min-height: 110px; border-right: 0; border-bottom: 1px solid var(--line); }
+  .hero-metrics article:last-child, .skeleton-grid i:last-child { border-bottom: 0; }
+  .connect-panel { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 600px) {
+  body { font-size: 13px; }
+  .main-column { padding-inline: 18px; }
+  .page-head { display: block; }
+  .page-head > button, .page-head > .revision, .page-head > .live-badge { margin-top: 18px; }
+  .page-head p:last-child { font-size: 12px; }
+  .fact-strip, .stat-row, .history-summary .fact-strip { grid-template-columns: 1fr; }
+  .fact-strip > div, .stat-row > div { border-right: 0; border-bottom: 1px solid var(--line); padding: 12px 16px; }
+  .fact-strip > div:last-child, .stat-row > div:last-child { border-bottom: 0; }
+  .fact-strip span { display: inline; margin-right: 10px; }
+  .fact-strip strong { font-size: 13px; }
+  .account-table { min-width: 0; }
+  .account-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+  }
+  .account-table tbody, .account-table tr, .account-table td { display: block; width: 100%; }
+  .account-table tr { padding: 13px 0; border-bottom: 1px solid var(--line); }
+  .account-table td, .account-table td:first-child, .account-table td:last-child {
+    display: grid;
+    grid-template-columns: 110px minmax(0, 1fr);
+    align-items: center;
+    gap: 12px;
+    padding: 7px 0;
+    border: 0;
+  }
+  .account-table td::before {
+    content: attr(data-label);
+    color: var(--muted);
+    font-size: 10px;
+    letter-spacing: .5px;
+    text-transform: uppercase;
+  }
+  .account-table tr.current-row > td:first-child {
+    padding-left: 10px;
+    border-left: 2px solid var(--ink);
+  }
+  .account-table tr.current-row > td:not(:first-child) { padding-left: 12px; }
+  .account-table .row-actions { justify-content: flex-start; }
+  .split-panels, .two-columns, .config-grid, .override-form { grid-template-columns: 1fr; }
+  .metric-list li { grid-template-columns: minmax(0, 1fr) auto; }
+  .metric-list small { grid-column: 1 / -1; }
+  .inline-form, .device-flow { align-items: stretch; flex-direction: column; }
+  .command-block, .sticky-save { align-items: flex-start; flex-direction: column; }
+  .toolbar .grow { flex-basis: 100%; }
+  .toolbar input { width: 100%; }
+  .config-grid label { grid-template-columns: 1fr; }
+  .config-grid .range { grid-column: 1; }
+  .capability-grid dl div { grid-template-columns: 1fr; gap: 2px; }
+  .protocol-fieldset, .model-actions { grid-column: 1; }
+  .event-row { grid-template-columns: 80px minmax(0, 1fr); gap: 8px 12px; }
+  .event-row details { grid-column: 1 / -1; }
+  .event-id { text-align: right; }
+  .footer-note { display: block; }
+  .footer-note span { display: block; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { scroll-behavior: auto !important; transition: none !important; }
+}

--- a/web/src/views/Accounts.svelte
+++ b/web/src/views/Accounts.svelte
@@ -263,16 +263,16 @@
   ): string {
     const identity = account.login === null ? account.numericUserId : `@${account.login}`;
     if (refreshed === null) {
-      return `Connected ${identity}. Refresh accounts to confirm the current default.`;
+      return `Connected ${identity}. Refresh accounts to confirm which account is in use.`;
     }
     if (refreshed.defaultAccountId === account.accountId) {
-      return `Connected ${identity}; it is the default account.`;
+      return `Connected ${identity}; it is in use for new requests.`;
     }
     const currentDefault = refreshed.items.find((item) => item.accountId === refreshed.defaultAccountId);
     const defaultIdentity = currentDefault?.login ?? currentDefault?.numericUserId;
     return defaultIdentity === undefined
-      ? `Connected ${identity}. No default account is currently selected.`
-      : `Connected ${identity}. Current default is ${currentDefault?.login === null ? defaultIdentity : `@${defaultIdentity}`}.`;
+      ? `Connected ${identity}. No account is currently selected.`
+      : `Connected ${identity}. Current account in use is ${currentDefault?.login === null ? defaultIdentity : `@${defaultIdentity}`}.`;
   }
 
   function isAbort(error: unknown): boolean {
@@ -285,7 +285,7 @@
     failure = "";
     try {
       await client.useAccount(id, data.defaultRevision);
-      message = "Default account updated.";
+      message = "Account is now in use for new requests.";
       await load();
     } catch (error: unknown) {
       failure = errorMessage(error);
@@ -314,11 +314,11 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">IDENTITY ROSTER</p>
+    <p class="eyebrow">[02] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Accounts</h1>
-    <p>Connect GitHub.com or GHES and choose the request identity.</p>
+    <p>Connect GitHub.com or GHES and choose the identity used by new gateway requests.</p>
   </div>
-  <button class="quiet" onclick={() => void load()}>Refresh</button>
+  <button onclick={() => void load()}>Refresh</button>
 </header>
 
 {#if message}
@@ -328,8 +328,8 @@
   <p class="notice error" role="alert">{failure}</p>
 {/if}
 
-<section class="section-block connect-panel">
-  <div>
+<section class="connect-panel">
+  <div class="device-actions">
     <p class="eyebrow">DEVICE AUTHORIZATION</p>
     <h2>Connect an account</h2>
   </div>
@@ -386,40 +386,113 @@
     <p>Start a device authorization above. Credentials never enter browser storage.</p>
   </section>
 {:else if data}
-  <section class="card-list" aria-label="Connected accounts">
-    {#each data.items as account (account.accountId)}
-      <article class:muted-card={account.state !== "active"}>
-        <div class="avatar" aria-hidden="true">
-          {(account.login ?? account.host).slice(0, 2).toUpperCase()}
-        </div>
-        <div class="grow">
-          <div class="account-title">
-            <h2>{account.displayName ?? account.login ?? account.numericUserId}</h2>
-            {#if data.defaultAccountId === account.accountId}<span class="chip">DEFAULT</span>{/if}
-            <span class="chip state-{account.state}">{account.state}</span>
-          </div>
-          <p>{account.login ? `@${account.login} · ` : ""}{account.host}</p>
-          <small>
-            Authenticated {account.authenticatedAt
-              ? new Date(account.authenticatedAt).toLocaleString()
-              : "not active"}
-          </small>
-        </div>
-        <div class="card-actions">
-          {#if account.state === "active" && data.defaultAccountId !== account.accountId}
-            <button onclick={() => useAccount(account.accountId)} disabled={busy === account.accountId}>
-              Make default
-            </button>
-          {/if}
-          {#if account.state !== "removed"}
-            <button
-              class="danger-text"
-              onclick={() => remove(account.accountId, account.revision)}
-              disabled={busy === account.accountId}
-            >Remove</button>
-          {/if}
-        </div>
-      </article>
-    {/each}
+  {@const defaultAccountId = data.defaultAccountId}
+  {@const selected = data.items.find((account) => account.accountId === defaultAccountId)}
+  <div class="fact-strip" aria-label="Account selection summary">
+    <div>
+      <span>Current identity</span>
+      <strong>{selected ? (selected.login === null ? selected.numericUserId : `@${selected.login}`) : "No account selected"}</strong>
+    </div>
+    <div>
+      <span>Connected accounts</span>
+      <strong>{data.items.filter((account) => account.state === "active").length}</strong>
+    </div>
+    <div>
+      <span>Request selection</span>
+      <strong>{selected ? "Explicit account" : "Fallback applies"}</strong>
+    </div>
+  </div>
+  <section class="section" aria-labelledby="connected-identities">
+    <div class="section-heading">
+      <h2 id="connected-identities"><span class="section-number">[01]</span>Connected identities</h2>
+    </div>
+    <div class="table-scroll">
+      <table class="account-table">
+        <thead>
+          <tr>
+            <th>Account</th>
+            <th>Authorization</th>
+            <th>Authenticated</th>
+            <th>Request identity</th>
+            <th><span class="visually-hidden">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each data.items as account (account.accountId)}
+            <tr
+              class:current-row={defaultAccountId === account.accountId}
+              class:muted-row={account.state !== "active"}
+            >
+              <td data-label="Account">
+                <div class="identity">
+                  <span class="avatar" aria-hidden="true">
+                    {(account.login ?? account.host).slice(0, 2).toUpperCase()}
+                  </span>
+                  <span>
+                    <strong>{account.displayName ?? account.login ?? account.numericUserId}</strong>
+                    <small>{account.login ? `@${account.login} · ` : ""}{account.host}</small>
+                  </span>
+                </div>
+              </td>
+              <td data-label="Authorization">
+                <span class:good={account.state === "active"} class="badge state-{account.state}">
+                  {account.state === "active" ? "Connected" : account.state}
+                </span>
+              </td>
+              <td data-label="Authenticated">{account.authenticatedAt ? new Date(account.authenticatedAt).toLocaleString() : "Not active"}</td>
+              <td data-label="Request identity">
+                {#if defaultAccountId === account.accountId}
+                  <span class="badge strong">In use</span>
+                {:else if account.state === "active"}
+                  <button
+                    class="primary"
+                    onclick={() => useAccount(account.accountId)}
+                    disabled={busy !== ""}
+                  >{busy === account.accountId ? "Switching..." : "Use this account"}</button>
+                {:else}
+                  <span class="muted">Unavailable</span>
+                {/if}
+              </td>
+              <td data-label="Actions">
+                <div class="row-actions">
+                  {#if account.state !== "removed"}
+                    <button
+                      class="danger-text"
+                      onclick={() => remove(account.accountId, account.revision)}
+                      disabled={busy !== ""}
+                    >{busy === account.accountId ? "Working..." : "Remove"}</button>
+                  {/if}
+                </div>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+    <div class="hint-line">
+      <span aria-hidden="true">[i]</span>
+      <p>
+        Use this account changes the identity for new requests. Requests already running keep their
+        bound account. Connected accounts are not rotated automatically after errors or rate limits.
+      </p>
+    </div>
+    {#if data.defaultAccountId === null}
+      <p class="notice warning" role="status">
+        No account is explicitly selected. New requests use the gateway's existing fallback rule;
+        this page does not choose one automatically.
+      </p>
+    {/if}
+  </section>
+  <section class="section">
+    <div class="section-heading">
+      <h2><span class="section-number">[02]</span>From your terminal</h2>
+    </div>
+    <div class="command-block">
+      <div class="command-lines">
+        <span class="muted">The same selection is available in the CLI. Account IDs come from the list command.</span>
+        <code>$ ghcg accounts list</code>
+        <code>$ ghcg accounts use &lt;account-id&gt;</code>
+      </div>
+    </div>
   </section>
 {/if}

--- a/web/src/views/Accounts.svelte
+++ b/web/src/views/Accounts.svelte
@@ -3,7 +3,7 @@
   import { ApiError, errorMessage, type AdminClient } from "../api.js";
   import type { AdminAccounts, DeviceFlow } from "../types.js";
 
-  let { client }: { client: AdminClient } = $props();
+  let { client, pageNumber }: { client: AdminClient; pageNumber: string } = $props();
   let data: AdminAccounts | null = $state(null);
   let host = $state("github.com");
   let flow: DeviceFlow | null = $state(null);
@@ -71,7 +71,7 @@
         if (canceled.state === "complete") {
           const refreshed = await load();
           if (generation !== pollGeneration) return;
-          message = connectedMessage(canceled.account, refreshed);
+          reportConnected(canceled.account, refreshed);
           return;
         }
       }
@@ -126,7 +126,7 @@
         const completionGeneration = pollGeneration;
         const refreshed = await load(false, completionGeneration);
         if (completionGeneration !== pollGeneration) return;
-        message = connectedMessage(result.account, refreshed);
+        reportConnected(result.account, refreshed);
         return;
       }
       finishFlow(generation, "Authorization expired. Start a new login.");
@@ -161,7 +161,7 @@
         const completionGeneration = pollGeneration;
         const refreshed = await load(false, completionGeneration);
         if (completionGeneration !== pollGeneration) return;
-        message = connectedMessage(result.account, refreshed);
+        reportConnected(result.account, refreshed);
       } else if (result.state === "pending") {
         pollIntervalSeconds = result.pollIntervalSeconds;
         nextPollAtMs = Date.parse(result.nextPollAt);
@@ -216,7 +216,7 @@
       if (canceled.state === "complete") {
         const refreshed = await load();
         if (cancellationGeneration !== pollGeneration) return;
-        message = connectedMessage(canceled.account, refreshed);
+        reportConnected(canceled.account, refreshed);
       }
     } catch (error: unknown) {
       if (cancellationGeneration !== pollGeneration) return;
@@ -272,7 +272,15 @@
     const defaultIdentity = currentDefault?.login ?? currentDefault?.numericUserId;
     return defaultIdentity === undefined
       ? `Connected ${identity}. No account is currently selected.`
-      : `Connected ${identity}. Current account in use is ${currentDefault?.login === null ? defaultIdentity : `@${defaultIdentity}`}.`;
+      : `Connected ${identity}. Account in use is ${currentDefault?.login === null ? defaultIdentity : `@${defaultIdentity}`}.`;
+  }
+
+  function reportConnected(
+    account: NonNullable<AdminAccounts["items"][number]>,
+    refreshed: AdminAccounts | null,
+  ): void {
+    failure = "";
+    message = connectedMessage(account, refreshed);
   }
 
   function isAbort(error: unknown): boolean {
@@ -314,7 +322,7 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">[02] LOCAL ADMINISTRATION</p>
+    <p class="eyebrow">[{pageNumber}] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Accounts</h1>
     <p>Connect GitHub.com or GHES and choose the identity used by new gateway requests.</p>
   </div>
@@ -390,7 +398,7 @@
   {@const selected = data.items.find((account) => account.accountId === defaultAccountId)}
   <div class="fact-strip" aria-label="Account selection summary">
     <div>
-      <span>Current identity</span>
+      <span>Selected identity</span>
       <strong>{selected ? (selected.login === null ? selected.numericUserId : `@${selected.login}`) : "No account selected"}</strong>
     </div>
     <div>

--- a/web/src/views/Configuration.svelte
+++ b/web/src/views/Configuration.svelte
@@ -94,7 +94,7 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">RUNTIME ENVELOPE</p>
+    <p class="eyebrow">[04] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Configuration</h1>
     <p>Revision-safe limits, admission and retention controls.</p>
   </div>
@@ -114,7 +114,7 @@
   <form class="config-form" onsubmit={(event) => { event.preventDefault(); void save(); }}>
     {#each groups as group (group)}
       <fieldset>
-        <legend>{group}</legend>
+        <legend>{group} settings</legend>
         <div class="config-grid">
           {#each fields.filter((configField) => configField.key.startsWith(`${group}.`)) as configField (configField.key)}
             <label>

--- a/web/src/views/Configuration.svelte
+++ b/web/src/views/Configuration.svelte
@@ -13,7 +13,7 @@
     readonly write: (config: RuntimeConfig, value: number) => void;
   }
 
-  let { client }: { client: AdminClient } = $props();
+  let { client, pageNumber }: { client: AdminClient; pageNumber: string } = $props();
   let data: AdminRuntimeConfig | null = $state(null);
   let loading = $state(true);
   let saving = $state(false);
@@ -94,7 +94,7 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">[04] LOCAL ADMINISTRATION</p>
+    <p class="eyebrow">[{pageNumber}] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Configuration</h1>
     <p>Revision-safe limits, admission and retention controls.</p>
   </div>

--- a/web/src/views/Events.svelte
+++ b/web/src/views/Events.svelte
@@ -59,9 +59,7 @@
   }
 
   function metadata(event: AdminOperationalEvent): string {
-    return Object.entries(event.metadata)
-      .map(([key, value]) => `${key}: ${String(value)}`)
-      .join(" · ") || "No additional metadata";
+    return JSON.stringify(event.metadata, null, 2);
   }
 
   function newestFirst(a: AdminOperationalEvent, b: AdminOperationalEvent): number {
@@ -73,7 +71,7 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">SANITIZED OPERATIONS</p>
+    <p class="eyebrow">[06] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Events</h1>
     <p>Persisted diagnostics joined with the bounded live SSE feed.</p>
   </div>
@@ -107,19 +105,16 @@
     <p>Operational events contain sanitized metadata only.</p>
   </section>
 {:else}
-  <ol class="timeline" aria-label="Operational events">
+  <ol class="event-list" aria-label="Operational events">
     {#each all as event (event.eventId)}
-      <li class="severity-{event.severity}">
-        <div class="timeline-mark"></div>
-        <article>
-          <header>
-            <time datetime={event.occurredAt}>{new Date(event.occurredAt).toLocaleString()}</time>
-            <span class="chip">{event.severity}</span>
-          </header>
-          <h2>{event.kind.replaceAll("_", " ")}</h2>
-          <p>{metadata(event)}</p>
-          <small>EVENT {event.eventId}</small>
-        </article>
+      <li class="event-row severity-{event.severity}">
+        <time datetime={event.occurredAt}>{new Date(event.occurredAt).toLocaleString()}</time>
+        <span class="chip">{event.severity}</span>
+        <details>
+          <summary>{event.kind.replaceAll("_", " ")}</summary>
+          <pre>{metadata(event)}</pre>
+        </details>
+        <span class="event-id">EVENT {event.eventId}</span>
       </li>
     {/each}
   </ol>

--- a/web/src/views/Events.svelte
+++ b/web/src/views/Events.svelte
@@ -8,11 +8,13 @@
     liveEvents,
     resetVersion,
     streamState,
+    pageNumber,
   }: {
     client: AdminClient;
     liveEvents: AdminOperationalEvent[];
     resetVersion: number;
     streamState: StreamState;
+    pageNumber: string;
   } = $props();
   let persisted: AdminOperationalEvent[] = $state([]);
   let cursor: string | null = $state(null);
@@ -71,7 +73,7 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">[06] LOCAL ADMINISTRATION</p>
+    <p class="eyebrow">[{pageNumber}] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Events</h1>
     <p>Persisted diagnostics joined with the bounded live SSE feed.</p>
   </div>

--- a/web/src/views/Models.svelte
+++ b/web/src/views/Models.svelte
@@ -15,7 +15,7 @@
     chatOutputTokenField: "" | "max_tokens" | "max_completion_tokens";
   };
 
-  let { client }: { client: AdminClient } = $props();
+  let { client, pageNumber }: { client: AdminClient; pageNumber: string } = $props();
   let accounts: AdminAccounts | null = $state(null);
   let data: AdminModels | null = $state(null);
   let accountId = $state("");
@@ -243,7 +243,7 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">[03] LOCAL ADMINISTRATION</p>
+    <p class="eyebrow">[{pageNumber}] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Models</h1>
     <p>Inspect real capability provenance and explicitly configure each account's catalog.</p>
   </div>
@@ -344,7 +344,14 @@
               </td>
               <td>
                 <div class="model-source">
-                  <span>{model.discovered ? "Discovered" : "Configured / unverified"}</span>
+                  <div class="tag-group">
+                    {#if model.discovered}<span class="badge">Discovered</span>{/if}
+                    {#if model.configured}
+                      <span class="badge" class:warning={!model.verified}>
+                        {model.verified ? "Configured override" : "Configured / unverified"}
+                      </span>
+                    {/if}
+                  </div>
                   <small class="muted">{model.protocolsSource}{model.protocolsConflict ? " · conflict" : ""}</small>
                 </div>
               </td>
@@ -372,7 +379,16 @@
                   <summary>Capability details and override</summary>
                   <div class="capability-grid">
                     <dl>
-                      <div><dt>Catalog state</dt><dd>{model.discovered ? "Discovered" : "Configured / unverified"} · {model.enabled ? "enabled" : "disabled"} · override revision {model.overrideRevision}</dd></div>
+                      <div>
+                        <dt>Catalog state</dt>
+                        <dd>
+                          {model.discovered ? "Discovered" : "Not discovered"} ·
+                          {model.configured
+                            ? (model.verified ? "Configured override" : "Configured / unverified")
+                            : "No Admin override"} ·
+                          {model.enabled ? "enabled" : "disabled"} · override revision {model.overrideRevision}
+                        </dd>
+                      </div>
                       <div><dt>Native HTTP protocols</dt><dd>{model.protocols?.join(", ") || (model.protocols === null ? "Unknown" : "None")}</dd></div>
                       <div><dt>Protocol provenance</dt><dd>{model.protocolsSource}{model.protocolsConflict ? " · conflict" : ""} · live {model.protocolsLiveState}</dd></div>
                       <div><dt>Input window</dt><dd>{model.maxInputTokens?.toLocaleString() ?? "Unknown"} · {model.maxInputTokensSource}{model.maxInputTokensConflict ? " · conflict" : ""} · live {model.maxInputTokensLiveState}</dd></div>

--- a/web/src/views/Models.svelte
+++ b/web/src/views/Models.svelte
@@ -243,9 +243,9 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">CATALOG CONTROL</p>
+    <p class="eyebrow">[03] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Models</h1>
-    <p>Inspect native capabilities and explicitly configure each account's models.</p>
+    <p>Inspect real capability provenance and explicitly configure each account's catalog.</p>
   </div>
   <button class="primary" onclick={refresh} disabled={!accountId || busy === "refresh"}>
     {busy === "refresh" ? "Refreshing..." : "Refresh catalog"}
@@ -301,102 +301,174 @@
     <p>The account returned no visible models. Add an exact model ID or refresh discovery.</p>
   </section>
 {:else if data}
-  <section class="model-grid" aria-label="Account models">
-    {#each data.items as model, index (`${model.id}:${index}`)}
-      {@const editor = editors[model.id]}
-      <article class:preferred={data.preferredModel?.modelId === model.id && data.preferredModel.validity === "valid"}>
-        <div class="model-vendor">{model.vendor}</div>
-        <h2>{model.name}</h2>
-        <code>{model.id}</code>
-        <p class="subtle">
-          {model.discovered ? "Discovered" : "Configured / unverified"} ·
-          {model.enabled ? "enabled" : "disabled"} · revision {model.overrideRevision}
-        </p>
-        <dl>
-          <div><dt>Native HTTP protocols</dt><dd>{model.protocols?.join(", ") || (model.protocols === null ? "Unknown" : "None")}</dd></div>
-          <div><dt>Protocol source</dt><dd>{model.protocolsSource}{model.protocolsConflict ? " · conflict" : ""}</dd></div>
-          <div><dt>Live declaration</dt><dd>{model.protocolsLiveState}</dd></div>
-          <div><dt>Input window</dt><dd>{model.maxInputTokens?.toLocaleString() ?? "Unknown"} · {model.maxInputTokensSource}{model.maxInputTokensConflict ? " · conflict" : ""} · live {model.maxInputTokensLiveState}</dd></div>
-          <div><dt>Output window</dt><dd>{model.maxOutputTokens?.toLocaleString() ?? "Unknown"} · {model.maxOutputTokensSource}{model.maxOutputTokensConflict ? " · conflict" : ""} · live {model.maxOutputTokensLiveState}</dd></div>
-          <div><dt>Default output</dt><dd>{model.defaultOutputTokens.effective.toLocaleString()} · {model.defaultOutputTokens.source}{model.defaultOutputTokens.conflict ? " · conflict" : ""}{model.defaultOutputTokens.valid ? "" : " · invalid for current ceiling"} · live {model.defaultOutputTokens.liveState}</dd></div>
-          <div><dt>Chat budget field</dt><dd>{model.chatOutputTokenField ?? "Unknown"} · {model.chatOutputTokenFieldSource}{model.chatOutputTokenFieldConflict ? " · conflict" : ""} · live {model.chatOutputTokenFieldLiveState}</dd></div>
-          <div><dt>Built-in revision</dt><dd>{model.builtinRevision ?? "None"}</dd></div>
-        </dl>
+  <section class="section" aria-labelledby="model-directory-title">
+    <div class="section-heading">
+      <h2 id="model-directory-title"><span class="section-number">[01]</span>Model directory</h2>
+      <span class="badge">{data.items.length} models</span>
+    </div>
+    <div class="table-scroll">
+      <table class="model-table">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Native interfaces</th>
+            <th>Source</th>
+            <th>Limits</th>
+            <th>Preference</th>
+          </tr>
+        </thead>
+        {#each data.items as model, index (`${model.id}:${index}`)}
+          {@const editor = editors[model.id]}
+          {@const preferred = data.preferredModel?.modelId === model.id && data.preferredModel.validity === "valid"}
+          <tbody data-model-id={model.id}>
+            <tr class:current-row={preferred}>
+              <td>
+                <div class="model-summary">
+                  <strong>{model.name}</strong>
+                  <code>{model.id}</code>
+                  <small>{model.vendor}</small>
+                </div>
+              </td>
+              <td>
+                <div class="tag-group">
+                  {#if model.protocols === null}
+                    <span class="badge warning">Unknown</span>
+                  {:else if model.protocols.length === 0}
+                    <span class="badge">None</span>
+                  {:else}
+                    {#each model.protocols as protocol (protocol)}
+                      <span class="badge">{protocol}</span>
+                    {/each}
+                  {/if}
+                </div>
+              </td>
+              <td>
+                <div class="model-source">
+                  <span>{model.discovered ? "Discovered" : "Configured / unverified"}</span>
+                  <small class="muted">{model.protocolsSource}{model.protocolsConflict ? " · conflict" : ""}</small>
+                </div>
+              </td>
+              <td>
+                <span>{model.maxInputTokens?.toLocaleString() ?? "Unknown"} in</span><br />
+                <span>{model.maxOutputTokens?.toLocaleString() ?? "Unknown"} out</span>
+              </td>
+              <td>
+                <div class="row-actions">
+                  {#if model.visible}
+                    <button
+                      class:primary={!preferred}
+                      onclick={() => prefer(model.id)}
+                      disabled={busy === `prefer:${model.id}` || preferred}
+                    >{preferred ? "Preferred" : "Set preferred"}</button>
+                  {:else}
+                    <span class="badge">Hidden</span>
+                  {/if}
+                </div>
+              </td>
+            </tr>
+            <tr class="model-editor-row">
+              <td colspan="5">
+                <details class="model-editor">
+                  <summary>Capability details and override</summary>
+                  <div class="capability-grid">
+                    <dl>
+                      <div><dt>Catalog state</dt><dd>{model.discovered ? "Discovered" : "Configured / unverified"} · {model.enabled ? "enabled" : "disabled"} · override revision {model.overrideRevision}</dd></div>
+                      <div><dt>Native HTTP protocols</dt><dd>{model.protocols?.join(", ") || (model.protocols === null ? "Unknown" : "None")}</dd></div>
+                      <div><dt>Protocol provenance</dt><dd>{model.protocolsSource}{model.protocolsConflict ? " · conflict" : ""} · live {model.protocolsLiveState}</dd></div>
+                      <div><dt>Input window</dt><dd>{model.maxInputTokens?.toLocaleString() ?? "Unknown"} · {model.maxInputTokensSource}{model.maxInputTokensConflict ? " · conflict" : ""} · live {model.maxInputTokensLiveState}</dd></div>
+                      <div><dt>Output window</dt><dd>{model.maxOutputTokens?.toLocaleString() ?? "Unknown"} · {model.maxOutputTokensSource}{model.maxOutputTokensConflict ? " · conflict" : ""} · live {model.maxOutputTokensLiveState}</dd></div>
+                      <div><dt>Default output</dt><dd>{model.defaultOutputTokens.effective.toLocaleString()} · {model.defaultOutputTokens.source}{model.defaultOutputTokens.conflict ? " · conflict" : ""}{model.defaultOutputTokens.valid ? "" : " · invalid for current ceiling"} · live {model.defaultOutputTokens.liveState}</dd></div>
+                      <div><dt>Chat budget field</dt><dd>{model.chatOutputTokenField ?? "Unknown"} · {model.chatOutputTokenFieldSource}{model.chatOutputTokenFieldConflict ? " · conflict" : ""} · live {model.chatOutputTokenFieldLiveState}</dd></div>
+                      <div><dt>Built-in revision</dt><dd>{model.builtinRevision ?? "None"}</dd></div>
+                    </dl>
 
-        {#if editor}
-          <label>
-            <input type="checkbox" bind:checked={editor.enabled} />
-            Enabled and visible
-          </label>
-          <label>
-            <input type="checkbox" bind:checked={editor.overrideProtocols} />
-            Override native protocols
-          </label>
-          <fieldset disabled={!editor.overrideProtocols}>
-            <legend>Native HTTP protocols</legend>
-            {#each ["chat", "messages", "responses"] as protocol (protocol)}
-              <label>
-                <input
-                  type="checkbox"
-                  checked={editor.protocols.includes(protocol as Protocol)}
-                  onchange={(event) => toggleProtocol(model.id, protocol as Protocol, event.currentTarget.checked)}
-                />
-                {protocol}
-              </label>
-            {/each}
-          </fieldset>
-          <label for={`input-limit-${model.id}`}>Override input ceiling</label>
-          <input
-            id={`input-limit-${model.id}`}
-            type="number"
-            min="1"
-            value={editor.maxInputTokens ?? ""}
-            oninput={(event) => { editor.maxInputTokens = event.currentTarget.value === "" ? null : event.currentTarget.valueAsNumber; }}
-            placeholder="use live/builtin"
-          />
-          <label for={`output-limit-${model.id}`}>Override output ceiling</label>
-          <input
-            id={`output-limit-${model.id}`}
-            type="number"
-            min="1"
-            value={editor.maxOutputTokens ?? ""}
-            oninput={(event) => { editor.maxOutputTokens = event.currentTarget.value === "" ? null : event.currentTarget.valueAsNumber; }}
-            placeholder="use live/builtin"
-          />
-          <label for={`default-output-${model.id}`}>Default output tokens</label>
-          <input
-            id={`default-output-${model.id}`}
-            type="number"
-            min="1"
-            value={editor.defaultOutputTokens ?? ""}
-            oninput={(event) => { editor.defaultOutputTokens = event.currentTarget.value === "" ? null : event.currentTarget.valueAsNumber; }}
-            placeholder="automatic policy"
-          />
-          <label for={`chat-field-${model.id}`}>Chat output token field</label>
-          <select id={`chat-field-${model.id}`} bind:value={editor.chatOutputTokenField}>
-            <option value="">Use live/builtin/unknown</option>
-            <option value="max_tokens">max_tokens</option>
-            <option value="max_completion_tokens">max_completion_tokens</option>
-          </select>
-          <button onclick={() => save(model)} disabled={busy === `save:${model.id}`}>
-            {busy === `save:${model.id}` ? "Saving..." : "Save capability override"}
-          </button>
-          {#if model.configured}
-            <button onclick={() => reset(model)} disabled={busy === `reset:${model.id}`}>
-              {busy === `reset:${model.id}` ? "Resetting..." : "Reset override"}
-            </button>
-          {/if}
-        {/if}
-
-        {#if model.visible}
-          <button
-            onclick={() => prefer(model.id)}
-            disabled={busy === `prefer:${model.id}` || (data.preferredModel?.modelId === model.id && data.preferredModel.validity === "valid")}
-          >
-            {data.preferredModel?.modelId === model.id && data.preferredModel.validity === "valid" ? "Preferred" : "Set preferred"}
-          </button>
-        {/if}
-      </article>
-    {/each}
+                    {#if editor}
+                      <fieldset
+                        class="override-form"
+                        aria-label={`${model.id} capability override`}
+                        disabled={busy === `save:${model.id}` || busy === `reset:${model.id}`}
+                      >
+                        <label class="check">
+                          <input type="checkbox" bind:checked={editor.enabled} />
+                          Enabled and visible
+                        </label>
+                        <label class="check">
+                          <input type="checkbox" bind:checked={editor.overrideProtocols} />
+                          Override native protocols
+                        </label>
+                        <fieldset class="protocol-fieldset" disabled={!editor.overrideProtocols}>
+                          <legend>Native HTTP protocols</legend>
+                          {#each ["chat", "messages", "responses"] as protocol (protocol)}
+                            <label>
+                              <input
+                                type="checkbox"
+                                checked={editor.protocols.includes(protocol as Protocol)}
+                                onchange={(event) => toggleProtocol(model.id, protocol as Protocol, event.currentTarget.checked)}
+                              />
+                              {protocol}
+                            </label>
+                          {/each}
+                        </fieldset>
+                        <label for={`input-limit-${index}`}>
+                          Override input ceiling
+                          <input
+                            id={`input-limit-${index}`}
+                            type="number"
+                            min="1"
+                            value={editor.maxInputTokens ?? ""}
+                            oninput={(event) => { editor.maxInputTokens = event.currentTarget.value === "" ? null : event.currentTarget.valueAsNumber; }}
+                            placeholder="use live/builtin"
+                          />
+                        </label>
+                        <label for={`output-limit-${index}`}>
+                          Override output ceiling
+                          <input
+                            id={`output-limit-${index}`}
+                            type="number"
+                            min="1"
+                            value={editor.maxOutputTokens ?? ""}
+                            oninput={(event) => { editor.maxOutputTokens = event.currentTarget.value === "" ? null : event.currentTarget.valueAsNumber; }}
+                            placeholder="use live/builtin"
+                          />
+                        </label>
+                        <label for={`default-output-${index}`}>
+                          Default output tokens
+                          <input
+                            id={`default-output-${index}`}
+                            type="number"
+                            min="1"
+                            value={editor.defaultOutputTokens ?? ""}
+                            oninput={(event) => { editor.defaultOutputTokens = event.currentTarget.value === "" ? null : event.currentTarget.valueAsNumber; }}
+                            placeholder="automatic policy"
+                          />
+                        </label>
+                        <label for={`chat-field-${index}`}>
+                          Chat output token field
+                          <select id={`chat-field-${index}`} bind:value={editor.chatOutputTokenField}>
+                            <option value="">Use live/builtin/unknown</option>
+                            <option value="max_tokens">max_tokens</option>
+                            <option value="max_completion_tokens">max_completion_tokens</option>
+                          </select>
+                        </label>
+                        <div class="model-actions">
+                          <button class="primary" onclick={() => save(model)} disabled={busy === `save:${model.id}`}>
+                            {busy === `save:${model.id}` ? "Saving..." : "Save capability override"}
+                          </button>
+                          {#if model.configured}
+                            <button onclick={() => reset(model)} disabled={busy === `reset:${model.id}`}>
+                              {busy === `reset:${model.id}` ? "Resetting..." : "Reset override"}
+                            </button>
+                          {/if}
+                        </div>
+                      </fieldset>
+                    {/if}
+                  </div>
+                </details>
+              </td>
+            </tr>
+          </tbody>
+        {/each}
+      </table>
+    </div>
   </section>
 {/if}

--- a/web/src/views/Overview.svelte
+++ b/web/src/views/Overview.svelte
@@ -29,11 +29,11 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">SYSTEM PULSE</p>
+    <p class="eyebrow">[01] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Overview</h1>
-    <p>Health, throughput and pressure at a glance.</p>
+    <p>Health, usage, performance and bounded storage from the running gateway.</p>
   </div>
-  <button class="quiet" onclick={load}>Refresh</button>
+  <button onclick={load}>Refresh</button>
 </header>
 
 {#if loading}
@@ -52,11 +52,10 @@
     </section>
   {/if}
   <section class="hero-metrics" aria-label="Gateway status">
-    <article class="health-card">
-      <span class="status-dot"></span>
-      <p>Gateway health</p>
-      <strong>{current.health === "ok" ? "Nominal" : current.health}</strong>
-      <small>v{current.version} · up {Math.floor(current.uptimeMs / 60000)} min</small>
+    <article>
+      <p>Gateway</p>
+      <strong>{current.health === "ok" ? "Running" : current.health}</strong>
+      <small><span class="status-dot"></span> v{current.version} · up {Math.floor(current.uptimeMs / 60000)} min</small>
     </article>
     <article>
       <p>Active requests</p>
@@ -71,11 +70,12 @@
       <small>{current.admission.queuedRequests} queued</small>
     </article>
   </section>
-  <section class="section-block">
-    <div class="section-title">
-      <div><p class="eyebrow">LAST 24 HOURS</p><h2>Usage ledger</h2></div>
+  <section class="section">
+    <div class="section-heading">
+      <h2><span class="section-number">[01]</span>Usage ledger</h2>
       <span class="chip">{usage.items.length} buckets</span>
     </div>
+    <p class="muted small">Content-free totals for the last 24 hours.</p>
     <div class="stat-row">
       <div><span>Requests</span><strong>{number(usage.totals.requestCount)}</strong></div>
       <div><span>Errors</span><strong>{number(usage.totals.errorCount)}</strong></div>
@@ -83,10 +83,10 @@
       <div><span>Output tokens</span><strong>{number(usage.totals.outputTokens)}</strong></div>
     </div>
   </section>
-  <section class="split-panels">
-    <article class="section-block">
-      <div class="section-title">
-        <h2>Performance windows</h2>
+  <section class="split-panels section">
+    <article>
+      <div class="section-heading">
+        <h2><span class="section-number">[02]</span>Performance windows</h2>
         <span class:warning={current.performance === "degraded"} class="chip">{current.performance}</span>
       </div>
       <ul class="metric-list">
@@ -99,8 +99,8 @@
         {/each}
       </ul>
     </article>
-    <article class="section-block">
-      <div class="section-title"><h2>Bounded storage</h2></div>
+    <article>
+      <div class="section-heading"><h2><span class="section-number">[03]</span>Bounded storage</h2></div>
       <ul class="storage-list">
         <li><span>Responses history</span><strong>{current.storage.historyCount}</strong></li>
         <li><span>Usage buckets</span><strong>{current.storage.usageBucketCount}</strong></li>

--- a/web/src/views/Overview.svelte
+++ b/web/src/views/Overview.svelte
@@ -3,7 +3,11 @@
   import { errorMessage, type AdminClient } from "../api.js";
   import type { AdminStatus, AdminUsagePage } from "../types.js";
 
-  let { client, liveStatus }: { client: AdminClient; liveStatus: AdminStatus | null } = $props();
+  let {
+    client,
+    liveStatus,
+    pageNumber,
+  }: { client: AdminClient; liveStatus: AdminStatus | null; pageNumber: string } = $props();
   let status: AdminStatus | null = $state(null);
   let usage: AdminUsagePage | null = $state(null);
   let loading = $state(true);
@@ -29,7 +33,7 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">[01] LOCAL ADMINISTRATION</p>
+    <p class="eyebrow">[{pageNumber}] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Overview</h1>
     <p>Health, usage, performance and bounded storage from the running gateway.</p>
   </div>

--- a/web/src/views/ResponsesHistory.svelte
+++ b/web/src/views/ResponsesHistory.svelte
@@ -42,7 +42,7 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">CONVERSATION CONTINUITY</p>
+    <p class="eyebrow">[05] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Responses History</h1>
     <p>Inspect bounded bridge checkpoints without exposing response content.</p>
   </div>
@@ -61,27 +61,20 @@
 {#if loading}
   <p class="loading-line" aria-busy="true">Inspecting history...</p>
 {:else if data}
-  <section class="history-orbit">
-    <div class="orb"><strong>{data.count}</strong><span>of {data.maxResponses}</span></div>
-    <div>
+  <section class="history-summary">
+    <div class="fact-strip">
+      <div><span>Checkpoints</span><strong>{data.count} / {data.maxResponses}</strong></div>
+      <div><span>Oldest</span><strong>{data.oldestAt ? new Date(data.oldestAt).toLocaleString() : "None"}</strong></div>
+      <div><span>Newest</span><strong>{data.newestAt ? new Date(data.newestAt).toLocaleString() : "None"}</strong></div>
+      <div><span>TTL / revision</span><strong>{data.ttlDays} days · {data.revision}</strong></div>
+    </div>
+    <div class="history-copy">
       <p class="eyebrow">RETAINED CHECKPOINTS</p>
       <h2>{data.count === 0 ? "History is empty" : "History is within bounds"}</h2>
       <p>
-        Only completed semantic checkpoints from bridged Responses are retained. Native Responses
-        never enter this store.
+        Only completed Semantic Checkpoints from bridged Responses are retained. Native Responses
+        never enter this store, and response content is not shown here.
       </p>
     </div>
-  </section>
-  <section class="stat-row history-stats">
-    <div>
-      <span>Oldest checkpoint</span>
-      <strong>{data.oldestAt ? new Date(data.oldestAt).toLocaleString() : "None"}</strong>
-    </div>
-    <div>
-      <span>Newest checkpoint</span>
-      <strong>{data.newestAt ? new Date(data.newestAt).toLocaleString() : "None"}</strong>
-    </div>
-    <div><span>Time to live</span><strong>{data.ttlDays} days</strong></div>
-    <div><span>Revision</span><strong>{data.revision}</strong></div>
   </section>
 {/if}

--- a/web/src/views/ResponsesHistory.svelte
+++ b/web/src/views/ResponsesHistory.svelte
@@ -3,7 +3,7 @@
   import { ApiError, errorMessage, type AdminClient } from "../api.js";
   import type { AdminHistorySummary } from "../types.js";
 
-  let { client }: { client: AdminClient } = $props();
+  let { client, pageNumber }: { client: AdminClient; pageNumber: string } = $props();
   let data: AdminHistorySummary | null = $state(null);
   let loading = $state(true);
   let clearing = $state(false);
@@ -42,7 +42,7 @@
 
 <header class="page-head">
   <div>
-    <p class="eyebrow">[05] LOCAL ADMINISTRATION</p>
+    <p class="eyebrow">[{pageNumber}] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Responses History</h1>
     <p>Inspect bounded bridge checkpoints without exposing response content.</p>
   </div>


### PR DESCRIPTION
## Summary
- replace the Admin shell and six real views with the approved OpenCode A/Directory visual system
- preserve automatic OAuth, account ownership/cancel/retry, Models capability provenance/overrides/CAS, configuration, history, and SSE behavior
- add responsive, semantic, overflow, long-content, prototype-exclusion, OAuth recovery, and SSE dedupe coverage

## Validation
- `npm run web:typecheck`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run e2e -- tests/e2e/admin.spec.ts` (19 passed)
- `npx vitest run --config vitest.config.ts tests/integration/admin_mount.test.ts tests/integration/admin_static.test.ts tests/integration/pack.test.ts tests/unit/toolchain.test.ts` (38 passed)

## Review
- Standards: no findings
- Spec: no findings

No SDK or live inference suites were run. Automated evidence covers 390/900/1600/2560/3440 layout, all six views, mobile focus/Escape/inert behavior, one main/h1, root overflow prevention, and semantic control names. No pixel-diff or assistive-technology manual pass was performed.

Closes #111