### PR TITLE
Pin icacls invocation to System32 in credential store and logger

### DIFF
--- a/src/accounts/credential_store.ts
+++ b/src/accounts/credential_store.ts
@@ -203,10 +203,11 @@ function protectFile(filePath: string): void {
 function restrictWindowsAcl(target: string): void {
   const current = currentWindowsIdentity();
   const grant = isDirectory(target) ? `*${current.sid}:(OI)(CI)(F)` : `*${current.sid}:(F)`;
-  execFileSync("icacls", [target, "/inheritance:r", "/grant:r", grant], { stdio: "ignore", windowsHide: true });
+  const icacls = windowsCommandPath("icacls");
+  execFileSync(icacls, [target, "/inheritance:r", "/grant:r", grant], { stdio: "ignore", windowsHide: true });
   for (const identity of windowsAclIdentities(target)) {
     if (!isCurrentWindowsIdentity(identity, current)) {
-      execFileSync("icacls", [target, "/remove:g", identity], { stdio: "ignore", windowsHide: true });
+      execFileSync(icacls, [target, "/remove:g", identity], { stdio: "ignore", windowsHide: true });
     }
   }
 }
@@ -238,7 +239,8 @@ function currentWindowsIdentity(): { readonly name: string; readonly sid: string
 }
 
 function windowsAclIdentities(target: string): readonly string[] {
-  const output = execFileSync("icacls", [target], { encoding: "utf8", windowsHide: true });
+  const icacls = windowsCommandPath("icacls");
+  const output = execFileSync(icacls, [target], { encoding: "utf8", windowsHide: true });
   const identities: string[] = [];
   for (const rawLine of output.split(/\r?\n/u)) {
     const line = rawLine.trim();

--- a/src/daemon/logger.ts
+++ b/src/daemon/logger.ts
@@ -206,7 +206,8 @@ function appendProtected(filePath: string, value: string, windowsSecurity: Windo
 function restrictWindowsAcl(target: string, directory: boolean): void {
   const identity = currentWindowsIdentity();
   const grant = directory ? `*${identity.sid}:(OI)(CI)(F)` : `*${identity.sid}:(F)`;
-  execFileSync("icacls", [target, "/inheritance:r", "/grant:r", grant], {
+  const icacls = windowsCommandPath("icacls");
+  execFileSync(icacls, [target, "/inheritance:r", "/grant:r", grant], {
     encoding: "utf8",
     windowsHide: true,
   });
@@ -259,7 +260,8 @@ function isWindowsReparsePoint(target: string): boolean {
 
 function assertWindowsAcl(target: string): void {
   const current = currentWindowsIdentity();
-  const output = execFileSync("icacls", [target], { encoding: "utf8", windowsHide: true });
+  const icacls = windowsCommandPath("icacls");
+  const output = execFileSync(icacls, [target], { encoding: "utf8", windowsHide: true });
   const identities: string[] = [];
   for (const rawLine of output.split(/\r?\n/u)) {
     const line = rawLine.trim();


### PR DESCRIPTION
## Summary
- resolve `icacls` via `windowsCommandPath("icacls")` across `credential_store.ts` and `logger.ts`
- pins all `icacls` invocations to `%SystemRoot%\System32\icacls.exe`, matching `identity_file.ts`
- addresses review finding from PR #122

## Review
- Standards & Spec dual-axis review passed with no must-fix findings.
