### PR TITLE
feat(replay): verify HTTP faults, early disconnects, and stream cancellations via replay

### DIFF
--- a/src/replay/server.ts
+++ b/src/replay/server.ts
@@ -7,6 +7,7 @@ export interface ReplayServerOptions {
   readonly port?: number; // default 31488
   readonly corpusDir: string;
   readonly exchanges: readonly ReplayExchangeRecord[];
+  readonly faultMode?: "disconnect_early" | "stall_first_byte" | undefined;
 }
 
 export interface ReplayReceipt {
@@ -23,11 +24,13 @@ export class MockCopilotReplayServer {
   private readonly exchanges: readonly ReplayExchangeRecord[];
   private server: Server | undefined;
   private readonly receipts: ReplayReceipt[] = [];
+  public faultMode: "disconnect_early" | "stall_first_byte" | undefined;
 
   constructor(options: ReplayServerOptions) {
     this.port = options.port ?? 31488;
     this.corpusDir = options.corpusDir;
     this.exchanges = options.exchanges;
+    this.faultMode = options.faultMode;
   }
 
   get recordedReceipts(): readonly ReplayReceipt[] {
@@ -215,6 +218,21 @@ export class MockCopilotReplayServer {
     } else {
       headers["content-type"] = headers["content-type"] ?? "application/json; charset=utf-8";
       headers["content-length"] = String(bodyBytes.byteLength);
+    }
+
+    // Handle fault injection
+    if (this.faultMode === "stall_first_byte") {
+      // Don't send headers or body, let client/gateway time out
+      return;
+    }
+
+    if (this.faultMode === "disconnect_early") {
+      res.writeHead(match.response.status, headers);
+      if (match.response.stream) {
+        res.write(bodyBytes.subarray(0, Math.min(20, bodyBytes.byteLength)));
+      }
+      res.destroy();
+      return;
     }
 
     res.writeHead(match.response.status, headers);

--- a/tests/sdk/matrix_faults_cancellation_replay.sdk.test.ts
+++ b/tests/sdk/matrix_faults_cancellation_replay.sdk.test.ts
@@ -1,0 +1,99 @@
+import OpenAI from "openai";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  CHAT_MODEL,
+  NATIVE_RESPONSES_MODEL,
+  type ReplaySdkHarness,
+  startReplaySdkHarness,
+} from "./replay_harness.js";
+
+describe("replay HTTP fault injection & stream cancellation acceptance", () => {
+  let harness: ReplaySdkHarness;
+  let client: OpenAI;
+
+  beforeAll(async () => {
+    harness = await startReplaySdkHarness();
+    client = new OpenAI({
+      apiKey: "local-gateway",
+      baseURL: harness.openAiBaseUrl,
+      fetch: harness.fetch,
+      maxRetries: 0,
+    });
+  });
+
+  afterAll(async () => {
+    await harness.close();
+  });
+
+  describe("Stream Abort & Cancellation", () => {
+    it("cancels Chat streaming and tears down cleanly without emitting completed event", async () => {
+      const stream = await client.chat.completions.create({
+        model: CHAT_MODEL,
+        messages: [{ role: "user", content: "sdk-chat-stream" }],
+        stream: true,
+      });
+
+      // Trigger abort immediately
+      stream.controller.abort();
+
+      const items = [];
+      const iterator = stream[Symbol.asyncIterator]();
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) break;
+        items.push(next.value);
+      }
+      expect(items.length).toBe(0);
+      expect(stream.controller.signal.aborted).toBe(true);
+    });
+
+    it("cancels Responses streaming and tears down cleanly", async () => {
+      const stream = await client.responses.create({
+        model: NATIVE_RESPONSES_MODEL,
+        input: "sdk-responses-stream",
+        stream: true,
+      });
+
+      stream.controller.abort();
+
+      const items = [];
+      const iterator = stream[Symbol.asyncIterator]();
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) break;
+        items.push(next.value);
+      }
+      expect(items.length).toBe(0);
+      expect(stream.controller.signal.aborted).toBe(true);
+    });
+  });
+
+  describe("HTTP Upstream Fault Injection", () => {
+    it("handles early upstream socket disconnect and returns 502 upstream error", async () => {
+      harness.replayServer.faultMode = "disconnect_early";
+      try {
+        await client.chat.completions.create({
+          model: CHAT_MODEL,
+          messages: [{ role: "user", content: "sdk-chat-nonstream" }],
+        });
+        expect.unreachable("should have thrown 502");
+      } catch (err: unknown) {
+        expect((err as { status: number }).status).toBe(502);
+      } finally {
+        harness.replayServer.faultMode = undefined;
+      }
+    });
+
+    it("handles unmapped upstream routes with fail-closed 404 response", async () => {
+      try {
+        await client.chat.completions.create({
+          model: "unmapped-model",
+          messages: [{ role: "user", content: "sdk-chat-nonstream" }],
+        });
+        expect.unreachable("should have thrown error");
+      } catch (err: unknown) {
+        expect((err as { status: number }).status).toBeGreaterThanOrEqual(400);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `faultMode` support to `MockCopilotReplayServer` (`disconnect_early`, `stall_first_byte`)
- add `tests/sdk/matrix_faults_cancellation_replay.sdk.test.ts` verifying Chat and Responses stream cancellations (clean exit without completed events), early socket disconnect handling (HTTP 502), and fail-closed unmapped route rejections (HTTP >= 400)

Closes #133

## Review
- Standards & Spec dual-axis review completed with no must-fix blockers.
