### PR TITLE
Replay cleanup batch 2: coherent sessions, reasoning and source cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,13 +307,13 @@ npm run bench -- full --repeat 3
 npm run pack
 ```
 
-Automated tests are offline and use scripted GitHub/Copilot remotes or recorded loopback HTTP replay. Official-client suites are manual release evidence and require explicit opt-in:
+Automated tests are offline and use scripted GitHub/Copilot remotes or fixed-response loopback HTTP replay. Official-client suites are manual release evidence and require explicit opt-in:
 
 ```bash
 GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk
 ```
 
-The replay suite exercises the production gateway against a local mock Copilot HTTP server on `127.0.0.1:31488` using real recorded and verified upstream exchanges. Official client SDK tests run strictly offline without outbound network access.
+The replay suite exercises the production gateway against a local mock Copilot HTTP server on `127.0.0.1:31488` using fixed response fixtures with byte-integrity checks. Official client SDK tests run strictly offline without outbound network access.
 
 ### Explicit Upstream Capture
 

--- a/src/protocols/responses/bridge_request.ts
+++ b/src/protocols/responses/bridge_request.ts
@@ -32,7 +32,6 @@ export interface ResponsesBridgeRequestContext {
   readonly toolContext: RequestToolContext;
   readonly reasoningConfig: ReasoningConfig | null;
   readonly upstreamHost?: string;
-  readonly upstreamPath?: string;
   readonly promptCacheRouting?: "enabled" | "disabled" | "auto";
   readonly clientSessionId?: string;
   readonly chatOutputTokenField?: ChatOutputTokenField | null;
@@ -708,10 +707,7 @@ function defaultPromptCacheAllowed(context: Readonly<ResponsesBridgeRequestConte
   if (context.promptCacheRouting !== undefined && context.promptCacheRouting !== "auto") {
     return false;
   }
-  if (context.upstreamHost === "api.openai.com") {
-    return true;
-  }
-  return context.upstreamHost === "api.kimi.com" && (context.upstreamPath === "/coding" || context.upstreamPath?.startsWith("/coding/") === true);
+  return context.upstreamHost === "api.openai.com";
 }
 
 function chatRole(item: WireJsonObject): string {

--- a/tests/contract/responses_bridge_request.test.ts
+++ b/tests/contract/responses_bridge_request.test.ts
@@ -279,6 +279,67 @@ describe("Responses bridge request conversion", () => {
     expect(json(converted)).not.toHaveProperty("prompt_cache_key");
   });
 
+  describe("prompt cache routing", () => {
+    it.each([
+      { host: "api.openai.com", automatic: true },
+      { host: "api.githubcopilot.com", automatic: false },
+      { host: "upstream.example.test", automatic: false },
+      { host: "api.openai.com.example.test", automatic: false },
+      { host: undefined, automatic: false },
+    ])("preserves automatic and configured routing for $host", ({ host, automatic }) => {
+      const request = requestFromJson(JSON.stringify({
+        model: "gpt",
+        input: "hi",
+        prompt_cache_key: "  cache-key  ",
+      }));
+      for (const routing of [undefined, "auto", "enabled", "disabled"] as const) {
+        const converted = convertResponsesRequest(request, {
+          resolvedModel: "gpt",
+          toolContext: buildRequestToolContext(request),
+          reasoningConfig: null,
+          ...(host === undefined ? {} : { upstreamHost: host }),
+          ...(routing === undefined ? {} : { promptCacheRouting: routing }),
+          clientSessionId: "session-key",
+        });
+        const expectedKey = routing === "enabled" || (routing !== "disabled" && automatic)
+          ? ",\"prompt_cache_key\":\"cache-key\""
+          : "";
+        expect(new TextDecoder().decode(serializeWireJson(converted))).toBe(
+          `{"model":"gpt","messages":[{"role":"user","content":"hi"}]${expectedKey}}`,
+        );
+      }
+    });
+
+    it.each([
+      { explicit: "  request-key  ", session: "  session-key  ", expected: "request-key" },
+      { explicit: "request-key", session: undefined, expected: "request-key" },
+      { explicit: undefined, session: "  session-key  ", expected: "session-key" },
+      { explicit: "", session: "  session-key  ", expected: "session-key" },
+      { explicit: " \t ", session: "  session-key  ", expected: "session-key" },
+      { explicit: " \t ", session: " \t ", expected: undefined },
+      { explicit: undefined, session: undefined, expected: undefined },
+    ])("selects a nonempty key from $explicit and $session", ({ explicit, session, expected }) => {
+      const request = requestFromJson(JSON.stringify({
+        model: "gpt",
+        input: "hi",
+        ...(explicit === undefined ? {} : { prompt_cache_key: explicit }),
+      }));
+      const converted = convertResponsesRequest(request, {
+        resolvedModel: "gpt",
+        toolContext: buildRequestToolContext(request),
+        reasoningConfig: null,
+        upstreamHost: "upstream.example.test",
+        promptCacheRouting: "enabled",
+        ...(session === undefined ? {} : { clientSessionId: session }),
+      });
+      expect(json(converted)).toEqual({
+        model: "gpt",
+        messages: [{ role: "user", content: "hi" }],
+        ...(expected === undefined ? {} : { prompt_cache_key: expected }),
+      });
+    });
+  });
+
   it("classifies a missing Chat token dialect as unavailable capability", () => {
     const request = requestFromJson("{\"model\":\"chat\",\"input\":\"hi\",\"max_output_tokens\":9}");
     expect(() => convertResponsesRequest(request, {

--- a/tests/sdk/client.ts
+++ b/tests/sdk/client.ts
@@ -37,7 +37,13 @@ export interface SdkResult<Response> {
   readonly text: string;
   readonly terminal: string | null | undefined;
   /** Observations only: official SDKs own stream accumulation and lifecycle validation. */
-  readonly stream?: { readonly text: string; readonly terminalCount: number };
+  readonly stream?: {
+    readonly text: string;
+    readonly terminalCount: number;
+    /** Provider extension observed on SDK-parsed chunks; the SDK does not accumulate it. */
+    readonly reasoningText?: string | undefined;
+    readonly reasoningDeltaCount?: number;
+  };
 }
 
 export async function executeChat(
@@ -51,6 +57,8 @@ export async function executeChat(
   }
   let text = "";
   let terminalCount = 0;
+  let reasoningText: string | undefined;
+  let reasoningDeltaCount = 0;
   const stream = client.chat.completions.stream({
     ...request,
     stream_options: { include_usage: true, ...request.stream_options },
@@ -58,13 +66,18 @@ export async function executeChat(
   stream.on("content", (delta) => { text += delta; });
   stream.on("chunk", (chunk) => {
     if (chunk.choices[0]?.finish_reason != null) terminalCount += 1;
+    const delta = chunk.choices[0]?.delta as { reasoning_text?: unknown } | undefined;
+    if (typeof delta?.reasoning_text === "string") {
+      reasoningText = (reasoningText ?? "") + delta.reasoning_text;
+      reasoningDeltaCount += 1;
+    }
   });
   const response = await stream.finalChatCompletion();
   return {
     response,
     text: response.choices[0]?.message.content ?? "",
     terminal: response.choices[0]?.finish_reason,
-    stream: { text, terminalCount },
+    stream: { text, terminalCount, reasoningText, reasoningDeltaCount },
   };
 }
 
@@ -108,6 +121,45 @@ export async function executeResponses(
   });
   const response = await stream.finalResponse();
   return { response, text: response.output_text, terminal: response.status, stream: { text, terminalCount } };
+}
+
+export interface SdkToolCall {
+  readonly id: string;
+  readonly name: string;
+  readonly arguments: unknown;
+}
+
+export type SdkProtocolResult =
+  | { readonly protocol: "chat"; readonly result: SdkResult<OpenAI.ChatCompletion> }
+  | { readonly protocol: "messages"; readonly result: SdkResult<Anthropic.Message> }
+  | { readonly protocol: "responses"; readonly result: SdkResult<OpenAI.Responses.Response> };
+
+/** Read actual SDK calls, including on turns expected to contain text only. */
+export function sdkToolCalls(value: SdkProtocolResult): SdkToolCall[] {
+  switch (value.protocol) {
+  case "chat":
+    return (value.result.response.choices[0]?.message.tool_calls ?? []).map((call) => {
+      if (call.type !== "function") throw new Error("Unexpected SDK tool type");
+      return { id: call.id, name: call.function.name, arguments: toolArguments(call.function.arguments) };
+    });
+  case "messages":
+    if (value.result.response.content.some((block) => !["text", "thinking", "redacted_thinking", "tool_use"].includes(block.type))) {
+      throw new Error("Unexpected SDK output block");
+    }
+    return value.result.response.content.filter((block) => block.type === "tool_use")
+      .map((block) => ({ id: block.id, name: block.name, arguments: block.input }));
+  case "responses":
+    if (value.result.response.output.some((item) => !["message", "reasoning", "function_call"].includes(item.type))) {
+      throw new Error("Unexpected SDK output item");
+    }
+    return value.result.response.output.filter((item) => item.type === "function_call")
+      .map((item) => ({ id: item.call_id, name: item.name, arguments: toolArguments(item.arguments) }));
+  }
+}
+
+function toolArguments(value: string): unknown {
+  try { return JSON.parse(value) as unknown; }
+  catch { throw new Error("Invalid SDK tool arguments"); }
 }
 
 function messageText(response: Anthropic.Message): string {

--- a/tests/sdk/matrix_coherent_sessions_replay.sdk.test.ts
+++ b/tests/sdk/matrix_coherent_sessions_replay.sdk.test.ts
@@ -1,0 +1,166 @@
+import { readFile } from "node:fs/promises";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSdkClients, REPLAY_TARGETS, SDK_PROTOCOLS, type SdkProtocol, type SdkToolCall as ForecastCall } from "./client.js";
+import { readExpectedExchangeResult, type ExpectedResult } from "./replay_expectations.js";
+import { startReplaySdkHarness, type ReplaySdkHarness } from "./replay_harness.js";
+import { expectSessionTurn, matchesSessionRequest } from "./session_expectations.js";
+import { createSessionDriver, SESSION_TURNS, type SessionTurn } from "./session_inputs.js";
+import { TOKYO_RESULT } from "./scenarios.js";
+
+const MUTATIONS = ["image", "history", "history-order", "result-value", "result-binding", "result-format", "call-arguments", "tool-schema"] as const;
+type Mutation = typeof MUTATIONS[number];
+
+describe("coherent five-turn image/tool continuity through official SDKs and production HTTP replay", () => {
+  let harness: ReplaySdkHarness;
+  let imageBase64: string;
+  const expected = new Map<SdkProtocol, ExpectedResult[]>();
+
+  beforeAll(async () => {
+    harness = await startReplaySdkHarness();
+    imageBase64 = (await readFile(new URL("./images/vergil.jpg", import.meta.url))).toString("base64");
+    for (const target of REPLAY_TARGETS) {
+      expected.set(target.protocol, await Promise.all(responseSet(target.protocol).exchangeIds.map((id) => {
+        const exchange = harness.corpus.exchanges.find((entry) => entry.caseId === id);
+        if (exchange === undefined) throw new Error("Missing session exchange");
+        return readExpectedExchangeResult(exchange);
+      })));
+    }
+  });
+
+  afterAll(async () => { await harness.close(); });
+
+  describe.each(SDK_PROTOCOLS)("%s downstream", (downstream) => {
+    it.each(REPLAY_TARGETS)("five ordered turns against $protocol upstream", async (target) => {
+      let calls: readonly ForecastCall[] = [];
+      const scenarioId = `session.${downstream}.${target.protocol}`;
+      select(scenarioId, target.protocol, () => calls);
+      const execute = createSessionDriver(createSdkClients(harness), downstream, target.model, imageBase64);
+      try {
+        for (const turn of SESSION_TURNS) {
+          const result = await execute(turn, calls);
+          const actual = expectSessionTurn(result, expected.get(target.protocol)![turn - 1]!, turn);
+          if (turn === 2) calls = actual;
+        }
+        harness.replayServer.finishScenario();
+        const receipts = harness.receipts.filter((receipt) => receipt.scenarioId === scenarioId);
+        expect(receipts.map((receipt) => receipt.scenarioStep)).toEqual(SESSION_TURNS);
+        expect(receipts.map((receipt) => receipt.matchedCaseId)).toEqual(responseSet(target.protocol).exchangeIds);
+      } finally {
+        harness.replayServer.abortScenario();
+      }
+    });
+  });
+
+  // Mutate requests before gateway ingress, not expectations or frozen responses. Each native
+  // route must reach the real replay predicate and fail without consuming its selected step.
+  describe.each(REPLAY_TARGETS)("$protocol request semantics fail closed", (target) => {
+    it.each(MUTATIONS)("rejects changed %s", async (mutation) => {
+      let calls: readonly ForecastCall[] = [];
+      let changed = false;
+      const failTurn: SessionTurn = mutation === "tool-schema" ? 2 : 3;
+      const scenarioId = `session.reject.${target.protocol}.${mutation}`;
+      select(scenarioId, target.protocol, () => calls);
+      let requests = 0;
+      const clients = createSdkClients({ ...harness, fetch: async (url, init) => {
+        requests += 1;
+        if (requests === failTurn) {
+          if (typeof init?.body !== "string") throw new Error("Expected SDK JSON body");
+          const body = JSON.parse(init.body) as Record<string, unknown>;
+          changed = mutateRequest(body, target.protocol, mutation, expected.get(target.protocol)![0]!.text);
+          return harness.fetch(url, { ...init, body: JSON.stringify(body) });
+        }
+        return harness.fetch(url, init);
+      } });
+      const execute = createSessionDriver(clients, target.protocol, target.model, imageBase64);
+      try {
+        for (const turn of SESSION_TURNS.filter((turn) => turn < failTurn)) {
+          const actual = expectSessionTurn(await execute(turn, calls), expected.get(target.protocol)![turn - 1]!, turn);
+          if (turn === 2) calls = actual;
+        }
+        const status = await execute(failTurn, calls).then(() => 200, (error: unknown) =>
+          (error as { status?: number }).status);
+        expect(changed, "the significant request field was actually mutated").toBe(true);
+        expect(status, "gateway propagates replay rejection").toBe(409);
+        const receipts = harness.receipts.filter((receipt) => receipt.scenarioId === scenarioId);
+        expect(receipts.map((receipt) => receipt.scenarioStep)).toEqual(SESSION_TURNS.slice(0, failTurn));
+        expect(receipts.at(-1)?.matchedCaseId, "mutant reached replay but did not match").toBeUndefined();
+        expect(() => harness.replayServer.finishScenario()).toThrow("replay scenario incomplete");
+      } finally {
+        harness.replayServer.abortScenario();
+      }
+    });
+  });
+
+  function responseSet(protocol: SdkProtocol) {
+    const set = harness.corpus.responseSets.find((candidate) => candidate.id === `cosplay-shoot-planning.${protocol}`);
+    if (set === undefined || set.exchangeIds.length !== 5) throw new Error("Missing five-turn response set");
+    return set;
+  }
+
+  function select(id: string, protocol: SdkProtocol, calls: () => readonly ForecastCall[]) {
+    harness.replayServer.selectScenario({ id, steps: responseSet(protocol).exchangeIds.map((exchangeId, index) => ({
+      exchangeId,
+      matchesRequest: (body) => matchesSessionRequest(body, {
+        protocol, turn: SESSION_TURNS[index]!, imageBase64, turns: expected.get(protocol)!, calls: calls(),
+      }),
+    })) });
+  }
+});
+
+/** Only downstream native JSON is changed; no production codec or observed upstream body is reused. */
+function mutateRequest(body: Record<string, unknown>, protocol: SdkProtocol, mutation: Mutation, firstText: string): boolean {
+  if (mutation === "history-order") {
+    const items = (protocol === "responses" ? body.input : body.messages) as unknown[];
+    const index = protocol === "chat" ? 1 : 0;
+    [items[index], items[index + 1]] = [items[index + 1], items[index]];
+    return true;
+  }
+  const results: Record<string, unknown>[] = [];
+  let changed = false;
+  function visit(value: unknown): void {
+    if (Array.isArray(value)) { value.forEach(visit); return; }
+    if (value === null || typeof value !== "object") return;
+    const item = value as Record<string, unknown>;
+    if (item.role === "tool" || item.type === "tool_result" || item.type === "function_call_output") results.push(item);
+    if (mutation === "image") {
+      if (item.type === "image") { (item.source as Record<string, unknown>).data = "d3Jvbmc="; changed = true; }
+      if (item.type === "image_url") { (item.image_url as Record<string, unknown>).url = "data:image/jpeg;base64,d3Jvbmc="; changed = true; }
+      if (item.type === "input_image") { item.image_url = "data:image/jpeg;base64,d3Jvbmc="; changed = true; }
+    }
+    if (mutation === "history") {
+      for (const key of ["text", "content"]) if (item[key] === firstText) { item[key] = "Unrelated assistant history"; changed = true; }
+    }
+    if (mutation === "tool-schema" && item.country_code !== undefined) {
+      (item.country_code as Record<string, unknown>).type = "integer";
+      changed = true;
+    }
+    if (mutation === "call-arguments") {
+      const key = item.name === "get_hourly_forecast" ? (item.type === "tool_use" ? "input" : "arguments") : undefined;
+      if (key !== undefined && item[key] !== undefined) {
+        const args = (typeof item[key] === "string" ? JSON.parse(item[key]) : item[key]) as { start_hour: number | string };
+        args.start_hour = "15";
+        item[key] = key === "input" ? args : JSON.stringify(args);
+        changed = true;
+      }
+    }
+    Object.values(item).forEach(visit);
+  }
+  visit(body);
+  if (mutation === "result-binding" && results.length === 2) {
+    const key = protocol === "chat" ? "tool_call_id" : protocol === "messages" ? "tool_use_id" : "call_id";
+    [results[0]![key], results[1]![key]] = [results[1]![key], results[0]![key]];
+    changed = true;
+  }
+  if (mutation === "result-value" || mutation === "result-format") {
+    for (const result of results) {
+      const key = protocol === "responses" ? "output" : "content";
+      if (result[key] === TOKYO_RESULT) {
+        const payload = JSON.parse(TOKYO_RESULT) as { hours: { temperature_c: number }[] };
+        if (mutation === "result-value") payload.hours[0]!.temperature_c = 99;
+        result[key] = mutation === "result-format" ? payload : JSON.stringify(payload);
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}

--- a/tests/sdk/matrix_constraints_replay.sdk.test.ts
+++ b/tests/sdk/matrix_constraints_replay.sdk.test.ts
@@ -1,166 +1,84 @@
-import Anthropic from "@anthropic-ai/sdk";
-import OpenAI from "openai";
+import type Anthropic from "@anthropic-ai/sdk";
+import type OpenAI from "openai";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
-  CHAT_MODEL,
-  MESSAGES_MODEL,
-  NATIVE_RESPONSES_MODEL,
-  type ReplaySdkHarness,
-  startReplaySdkHarness,
-} from "./replay_harness.js";
+  createSdkClients, executeChat, executeMessages, executeResponses, REPLAY_TARGETS, SDK_PROTOCOLS,
+  type SdkClients, type SdkProtocol,
+} from "./client.js";
+import { expectReasoningResult, expectUsage, matchesTextRequest, readExpectedExchangeResult } from "./replay_expectations.js";
+import { type ReplaySdkHarness, startReplaySdkHarness } from "./replay_harness.js";
 
-describe("nine-cell matrix constraints, reasoning & usage execution via Mock Copilot Replay", () => {
+const prompt = "Explain quantum entanglement in 20 words.";
+
+describe("nine-cell SDK-parsed reasoning and usage via production HTTP replay", () => {
   let harness: ReplaySdkHarness;
-  let openai: OpenAI;
-  let anthropic: Anthropic;
+  let clients: SdkClients;
 
   beforeAll(async () => {
     harness = await startReplaySdkHarness();
-    openai = new OpenAI({
-      apiKey: "local-gateway",
-      baseURL: harness.openAiBaseUrl,
-      fetch: harness.fetch,
-      maxRetries: 0,
-    });
-    anthropic = new Anthropic({
-      apiKey: "local-gateway",
-      baseURL: harness.baseUrl,
-      fetch: harness.fetch,
-      maxRetries: 0,
+    clients = createSdkClients(harness);
+  });
+  afterAll(async () => { await harness.close(); });
+
+  describe.each(SDK_PROTOCOLS)("%s downstream", (downstream) => {
+    it.each(REPLAY_TARGETS)("$protocol upstream preserves native reasoning or approved converted omission", async (target) => {
+      const exchangeId = `replay.${target.protocol}.reasoning-effort.nonstream`;
+      const exchange = harness.corpus.exchanges.find((candidate) => candidate.caseId === exchangeId)!;
+      const expected = await readExpectedExchangeResult(exchange);
+      harness.replayServer.selectScenario({
+        id: `${downstream}.${target.protocol}.reasoning`,
+        steps: [{ exchangeId, matchesRequest: (body) => matchesTextRequest(body, target.protocol, { prompt }, undefined) }],
+      });
+      try {
+        const result = await executeReasoning(downstream, target.model);
+        expect(expected.text.length).toBeGreaterThan(0);
+        expect(result.text === expected.text, "all captured answer text remains separate from reasoning").toBe(true);
+        // The immutable legacy Chat fixture is truncated. Preserve that fact, never call it completed.
+        const terminal = (target.protocol === "chat"
+          ? { chat: "length", messages: "max_tokens", responses: "incomplete" }
+          : { chat: "stop", messages: "end_turn", responses: "completed" })[downstream];
+        expect(result.terminal === terminal, "native or converted fixture terminal outcome").toBe(true);
+        if (target.protocol === "chat" && downstream === "responses") {
+          expect((result.response as OpenAI.Responses.Response).incomplete_details?.reason === "max_output_tokens", "truncation reason is preserved").toBe(true);
+        }
+        expectUsage(result.response.usage, downstream, expected);
+        expectReasoningResult(result, expected, downstream);
+
+        // Inspect official parsed objects, not just request options or reasoning-token counters.
+        if (downstream === target.protocol) {
+          if (downstream === "messages") {
+            const thinking = (result.response as Anthropic.Message).content.find((block) => block.type === "thinking");
+            expect(thinking?.thinking.length, "fixture supplies actual public thinking").toBeGreaterThan(0);
+          } else if (downstream === "responses") {
+            // This fixture supplies opaque state, not a portable public summary. Do not fabricate one.
+            const reasoning = (result.response as OpenAI.Responses.Response).output.filter((item) => item.type === "reasoning");
+            expect(reasoning.length).toBe(1);
+            expect(reasoning[0]?.summary.length).toBe(0);
+            expect(reasoning[0]?.content?.length).toBe(0);
+            expect(typeof reasoning[0]?.encrypted_content).toBe("string");
+            expect(reasoning[0]?.encrypted_content?.length).toBeGreaterThan(0);
+          } else {
+            const message = (result.response as OpenAI.ChatCompletion).choices[0]!.message as unknown as { reasoning_text?: string; reasoning_opaque?: string };
+            expect(message.reasoning_text?.length, "Chat fixture supplies public reasoning").toBeGreaterThan(0);
+            expect(message.reasoning_opaque?.length, "Chat fixture also supplies native opaque state").toBeGreaterThan(0);
+          }
+        }
+        harness.replayServer.finishScenario();
+      } finally { harness.replayServer.abortScenario(); }
     });
   });
 
-  afterAll(async () => {
-    await harness.close();
-  });
-
-  describe("Chat Downstream Constraints & Usage", () => {
-    it("C -> C with reasoning_effort and usage observation", async () => {
-      const resp = await openai.chat.completions.create({
-        model: CHAT_MODEL,
-        messages: [{ role: "user", content: "Explain quantum entanglement in 20 words." }],
-        reasoning_effort: "low",
-      });
-      expect(resp.choices[0]?.message.content?.length).toBeGreaterThan(0);
-      expect(resp.usage).toBeDefined();
-      expect(resp.usage?.prompt_tokens).toBeGreaterThan(0);
-      const r = harness.receipts.find((rec) => rec.matchedCaseId === "replay.chat.reasoning-effort.nonstream");
-      expect(r?.path).toBe("/chat/completions");
-      expect(r?.model).toBe(CHAT_MODEL);
-    });
-
-    it("C -> R with reasoning_effort and usage observation", async () => {
-      const resp = await openai.chat.completions.create({
-        model: NATIVE_RESPONSES_MODEL,
-        messages: [{ role: "user", content: "Explain quantum entanglement in 20 words." }],
-        reasoning_effort: "low",
-      });
-      expect(resp.choices[0]?.message.content?.length).toBeGreaterThan(0);
-      expect(resp.usage).toBeDefined();
-      const r = harness.receipts.find((rec) => rec.matchedCaseId === "replay.responses.reasoning-effort.nonstream");
-      expect(r?.path).toBe("/responses");
-      expect(r?.model).toBe(NATIVE_RESPONSES_MODEL);
-    });
-
-    it("C -> M with reasoning_effort and usage observation", async () => {
-      const resp = await openai.chat.completions.create({
-        model: MESSAGES_MODEL,
-        messages: [{ role: "user", content: "Explain quantum entanglement in 20 words." }],
-        reasoning_effort: "low",
-      });
-      expect(resp.choices[0]?.message.content?.length).toBeGreaterThan(0);
-      expect(resp.usage).toBeDefined();
-      const r = harness.receipts.find((rec) => rec.matchedCaseId === "replay.messages.reasoning-effort.nonstream");
-      expect(r?.path).toBe("/v1/messages");
-      expect(r?.model).toBe(MESSAGES_MODEL);
-    });
-  });
-
-  describe("Messages Downstream Constraints & Usage", () => {
-    it("M -> C with output_config effort and usage observation", async () => {
-      const resp = await anthropic.messages.create({
-        model: CHAT_MODEL,
-        max_tokens: 64,
-        messages: [{ role: "user", content: "Explain quantum entanglement in 20 words." }],
-        output_config: { effort: "low" },
-      });
-      expect(resp.content[0]?.type).toBe("text");
-      expect(resp.usage.input_tokens).toBeGreaterThan(0);
-      const r = harness.receipts.find((rec) => rec.matchedCaseId === "replay.chat.reasoning-effort.nonstream");
-      expect(r?.path).toBe("/chat/completions");
-      expect(r?.model).toBe(CHAT_MODEL);
-    });
-
-    it("M -> R with output_config effort and usage observation", async () => {
-      const resp = await anthropic.messages.create({
-        model: NATIVE_RESPONSES_MODEL,
-        max_tokens: 64,
-        messages: [{ role: "user", content: "Explain quantum entanglement in 20 words." }],
-        output_config: { effort: "low" },
-      });
-      expect(resp.content[0]?.type).toBe("text");
-      expect(resp.usage.input_tokens).toBeGreaterThan(0);
-      const r = harness.receipts.find((rec) => rec.matchedCaseId === "replay.responses.reasoning-effort.nonstream");
-      expect(r?.path).toBe("/responses");
-      expect(r?.model).toBe(NATIVE_RESPONSES_MODEL);
-    });
-
-    it("M -> M with output_config effort and usage observation", async () => {
-      const resp = await anthropic.messages.create({
-        model: MESSAGES_MODEL,
-        max_tokens: 64,
-        messages: [{ role: "user", content: "Explain quantum entanglement in 20 words." }],
-        output_config: { effort: "low" },
-      });
-      expect(resp.content.length).toBeGreaterThan(0);
-      expect(resp.usage.input_tokens).toBeGreaterThan(0);
-      const r = harness.receipts.find((rec) => rec.matchedCaseId === "replay.messages.reasoning-effort.nonstream");
-      expect(r?.path).toBe("/v1/messages");
-      expect(r?.model).toBe(MESSAGES_MODEL);
-    });
-  });
-
-  describe("Responses Downstream Constraints & Usage", () => {
-    it("R -> C with reasoning.effort and usage observation", async () => {
-      const resp = await openai.responses.create({
-        model: CHAT_MODEL,
-        input: "Explain quantum entanglement in 20 words.",
-        reasoning: { effort: "low" },
-        max_output_tokens: 64,
-      });
-      expect(resp.output_text?.length).toBeGreaterThan(0);
-      expect(resp.usage?.input_tokens).toBeGreaterThan(0);
-      const r = harness.receipts.find((rec) => rec.matchedCaseId === "replay.chat.reasoning-effort.nonstream");
-      expect(r?.path).toBe("/chat/completions");
-      expect(r?.model).toBe(CHAT_MODEL);
-    });
-
-    it("R -> R with reasoning.effort and usage observation", async () => {
-      const resp = await openai.responses.create({
-        model: NATIVE_RESPONSES_MODEL,
-        input: "Explain quantum entanglement in 20 words.",
-        reasoning: { effort: "low" },
-        max_output_tokens: 64,
-      });
-      expect(resp.output_text?.length).toBeGreaterThan(0);
-      expect(resp.usage?.input_tokens).toBeGreaterThan(0);
-      const r = harness.receipts.find((rec) => rec.matchedCaseId === "replay.responses.reasoning-effort.nonstream");
-      expect(r?.path).toBe("/responses");
-      expect(r?.model).toBe(NATIVE_RESPONSES_MODEL);
-    });
-
-    it("R -> M with reasoning.effort and usage observation", async () => {
-      const resp = await openai.responses.create({
-        model: MESSAGES_MODEL,
-        input: "Explain quantum entanglement in 20 words.",
-        reasoning: { effort: "low" },
-        max_output_tokens: 64,
-      });
-      expect(resp.output_text?.length).toBeGreaterThan(0);
-      expect(resp.usage?.input_tokens).toBeGreaterThan(0);
-      const r = harness.receipts.find((rec) => rec.matchedCaseId === "replay.messages.reasoning-effort.nonstream");
-      expect(r?.path).toBe("/v1/messages");
-      expect(r?.model).toBe(MESSAGES_MODEL);
-    });
-  });
+  function executeReasoning(downstream: SdkProtocol, model: string) {
+    switch (downstream) {
+    case "chat": return executeChat(clients.openai, {
+      model, messages: [{ role: "user", content: prompt }], reasoning_effort: "low",
+    }, "nonstream");
+    case "messages": return executeMessages(clients.anthropic, {
+      model, max_tokens: 64, messages: [{ role: "user", content: prompt }], output_config: { effort: "low" },
+    }, "nonstream");
+    case "responses": return executeResponses(clients.openai, {
+      model, input: prompt, reasoning: { effort: "low" }, max_output_tokens: 64,
+    }, "nonstream");
+    }
+  }
 });

--- a/tests/sdk/matrix_streaming_tools_replay.sdk.test.ts
+++ b/tests/sdk/matrix_streaming_tools_replay.sdk.test.ts
@@ -1,0 +1,80 @@
+import { isDeepStrictEqual } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  createSdkClients, executeChat, executeMessages, executeResponses, REPLAY_TARGETS, SDK_PROTOCOLS, sdkToolCalls,
+  type SdkClients, type SdkProtocol, type SdkProtocolResult,
+} from "./client.js";
+import { expectUsage, readExpectedExchangeResult } from "./replay_expectations.js";
+import { type ReplaySdkHarness, startReplaySdkHarness } from "./replay_harness.js";
+import {
+  FORECAST_COMPARE_PROMPT, FORECAST_TOOL_ANTHROPIC, FORECAST_TOOL_OPENAI, FORECAST_TOOL_RESPONSES,
+  expectedForecastArguments,
+} from "./scenarios.js";
+
+describe("nine-cell parallel streaming tools with official SDK accumulation", () => {
+  let harness: ReplaySdkHarness;
+  let clients: SdkClients;
+  beforeAll(async () => {
+    harness = await startReplaySdkHarness();
+    clients = createSdkClients(harness);
+  });
+  afterAll(async () => { await harness.close(); });
+
+  describe.each(SDK_PROTOCOLS)("%s downstream", (downstream) => {
+    it.each(REPLAY_TARGETS)("$protocol upstream preserves complete arguments, call binding and terminal usage", async (target) => {
+      const exchangeId = `replay.${target.protocol}.parallel-tools.stream`;
+      const exchange = harness.corpus.exchanges.find((candidate) => candidate.caseId === exchangeId)!;
+      const expected = await readExpectedExchangeResult(exchange);
+      const receiptStart = harness.receipts.length;
+      const value = await executeTools(downstream, target.model);
+      const { result } = value;
+      const calls = sdkToolCalls(value);
+      expect(calls.length).toBe(2);
+      expect(expected.toolCallIds.length).toBe(2);
+      expect(new Set(calls.map((call) => call.id)).size).toBe(2);
+      // Fixed native IDs bind the ordered complete arguments, not merely two plausible cities.
+      for (const [index, city] of (["Tokyo", "Paris"] as const).entries()) {
+        const call = calls[index]!;
+        expect(call.id.length).toBeGreaterThan(0);
+        expect(call.id === expected.toolCallIds[index], "SDK call ID retains its upstream argument binding").toBe(true);
+        expect(call.name === "get_hourly_forecast", "forecast tool name is preserved").toBe(true);
+        expect(isDeepStrictEqual(call.arguments, expectedForecastArguments(city)), "complete nested forecast arguments are preserved").toBe(true);
+      }
+      expectUsage(result.response.usage, downstream, expected);
+      expect(result.text === expected.text, "complete ancillary tool text").toBe(true);
+      expect(result.stream?.text === expected.text, "no duplicated or truncated streamed text").toBe(true);
+      expect(result.stream?.terminalCount).toBe(1);
+      expect(result.terminal === { chat: "tool_calls", messages: "tool_use", responses: "completed" }[downstream], "normal tool terminal outcome").toBe(true);
+      expect(harness.receipts.slice(receiptStart).filter((receipt) => receipt.matchedCaseId !== undefined))
+        .toMatchObject([{ matchedCaseId: exchangeId, model: target.model, stream: true }]);
+      // Chat/Responses raw argument frames are coarse. Interleaving and byte fragmentation remain
+      // independently covered by protocol_conversion_response.test.ts, not fabricated capture frames.
+    });
+  });
+
+  async function executeTools(downstream: SdkProtocol, model: string): Promise<SdkProtocolResult> {
+    switch (downstream) {
+    case "chat": {
+      const result = await executeChat(clients.openai, {
+        model, messages: [{ role: "user", content: FORECAST_COMPARE_PROMPT }],
+        tools: [FORECAST_TOOL_OPENAI], tool_choice: "auto", parallel_tool_calls: true, max_tokens: 700,
+      }, "stream");
+      return { protocol: downstream, result };
+    }
+    case "messages": {
+      const result = await executeMessages(clients.anthropic, {
+        model, max_tokens: 700, messages: [{ role: "user", content: FORECAST_COMPARE_PROMPT }],
+        tools: [FORECAST_TOOL_ANTHROPIC], tool_choice: { type: "auto", disable_parallel_tool_use: false },
+      }, "stream");
+      return { protocol: downstream, result };
+    }
+    case "responses": {
+      const result = await executeResponses(clients.openai, {
+        model, input: FORECAST_COMPARE_PROMPT, tools: [FORECAST_TOOL_RESPONSES],
+        tool_choice: "auto", parallel_tool_calls: true, max_output_tokens: 700,
+      }, "stream");
+      return { protocol: downstream, result };
+    }
+    }
+  }
+});

--- a/tests/sdk/replay_expectations.ts
+++ b/tests/sdk/replay_expectations.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
 import type Anthropic from "@anthropic-ai/sdk";
 import type OpenAI from "openai";
 import { expect } from "vitest";
@@ -12,15 +13,60 @@ export interface ExpectedResult {
   readonly text: string;
   readonly upstream: SdkProtocol;
   readonly usage: CapturedUsage;
+  /** Fixed native fields retain the difference between an explicit zero and no report. */
+  readonly nativeUsage: Readonly<Record<string, unknown>>;
+  readonly mode: SdkMode;
+  readonly reasoning: readonly unknown[];
+  readonly toolCallIds: readonly string[];
 }
 
 export async function readExpectedResult(manifest: readonly ReplayExchangeRecord[], protocol: SdkProtocol, scenario: TextScenario["id"], mode: SdkMode): Promise<ExpectedResult> {
-  const usage = manifest.find((record) => record.caseId === `replay.${protocol}.${scenario}.${mode}`)?.downstreamExpectation?.usage;
-  if (usage === undefined) throw new Error("Missing captured usage expectation");
-  return { text: await readExpectedText(protocol, scenario, mode), upstream: protocol, usage };
+  const exchange = manifest.find((record) => record.caseId === `replay.${protocol}.${scenario}.${mode}`);
+  if (exchange === undefined) throw new Error("Missing captured exchange expectation");
+  return readExpectedExchangeResult(exchange);
 }
 
-export function matchesTextRequest(body: unknown, protocol: SdkProtocol, scenario: TextScenario, imageBase64: string | undefined): boolean {
+/** Read immutable fixture fields, never a production converter or the downstream SDK result. */
+export async function readExpectedExchangeResult(exchange: ReplayExchangeRecord): Promise<ExpectedResult> {
+  const raw = await readFile(new URL(`./corpus/${exchange.response.bodyFile}`, import.meta.url), "utf8");
+  const upstream = exchange.targetProtocol;
+  const mode = exchange.response.stream ? "stream" : "nonstream";
+  // These fixed SSE fixtures have one JSON data line per event; this is not a wire decoder.
+  const fixtures: Record<string, unknown>[] = mode === "nonstream" ? [JSON.parse(raw)]
+    : raw.split(/\r?\n/u).filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim()).filter((data) => data !== "[DONE]").map((data) => JSON.parse(data));
+  const last = fixtures.at(-1)!;
+  const completed = mode === "nonstream" ? last : upstream === "responses" ? record(last.response) : undefined;
+  // Current captures have complete final Chat/Responses usage; Messages has start + final delta usage.
+  const nativeUsage = mode === "nonstream" ? record(last.usage)!
+    : upstream === "chat" ? record(fixtures.findLast((event) => record(event.usage) !== undefined)?.usage)!
+      : upstream === "responses" ? record(completed?.usage)!
+        : { ...record(record(fixtures[0]?.message)?.usage), ...record(fixtures.findLast((event) => event.type === "message_delta")?.usage) };
+  if (nativeUsage === undefined) throw new Error("Missing fixed fixture usage");
+  const fields = usageFields(nativeUsage, upstream);
+  const usage = exchange.downstreamExpectation?.usage ?? {
+    inputTokens: fields.input, outputTokens: fields.output,
+    cacheReadTokens: fields.cacheRead ?? 0, cacheWriteTokens: fields.cacheWrite ?? 0,
+    reasoningTokens: fields.reasoning ?? 0, visualTokens: "not_reported",
+  };
+  expect({ inputTokens: fields.input, outputTokens: fields.output, cacheReadTokens: fields.cacheRead ?? 0,
+    cacheWriteTokens: fields.cacheWrite ?? 0, reasoningTokens: fields.reasoning ?? 0 }).toEqual({
+    inputTokens: usage.inputTokens, outputTokens: usage.outputTokens, cacheReadTokens: usage.cacheReadTokens,
+    cacheWriteTokens: usage.cacheWriteTokens, reasoningTokens: usage.reasoningTokens,
+  });
+  const reasoning = upstream === "messages"
+    ? (completed?.content as Anthropic.ContentBlock[] | undefined)?.filter((block) => block.type === "thinking" || block.type === "redacted_thinking") ?? []
+    : upstream === "responses"
+      ? (completed?.output as OpenAI.Responses.ResponseOutputItem[] | undefined)?.filter((item) => item.type === "reasoning") ?? []
+      : fixtures.flatMap((fixture) => {
+        const choice = record((fixture.choices as unknown[] | undefined)?.[0]);
+        return chatReasoning(mode === "stream" ? choice?.delta : choice?.message);
+      });
+  return { text: fixedText(fixtures, upstream, mode), upstream, usage, nativeUsage, mode, reasoning,
+    toolCallIds: fixedToolIds(fixtures, upstream, mode) };
+}
+
+export function matchesTextRequest(body: unknown, protocol: SdkProtocol, scenario: Pick<TextScenario, "prompt" | "system">, imageBase64: string | undefined): boolean {
   const request = record(body);
   if (request === undefined || request.tools !== undefined) return false;
   let content: unknown;
@@ -82,22 +128,38 @@ function record(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
 }
 
-/** Read only fixed upstream fixture fields, independently of SDK result extraction and production converters. */
-async function readExpectedText(protocol: SdkProtocol, scenario: TextScenario["id"], mode: SdkMode): Promise<string> {
-  const extension = mode === "stream" ? "txt" : "json";
-  const raw = await readFile(new URL(`./corpus/${protocol}/${scenario}.${mode}.${extension}`, import.meta.url), "utf8");
+function fixedToolIds(fixtures: readonly Record<string, unknown>[], protocol: SdkProtocol, mode: SdkMode): string[] {
+  // Read identity-bearing fixture entries only; SDKs, not this helper, assemble arguments.
+  return fixtures.flatMap((fixture) => {
+    if (protocol === "chat") {
+      const calls = mode === "stream" ? (fixture as unknown as OpenAI.ChatCompletionChunk).choices[0]?.delta.tool_calls
+        : (fixture as unknown as OpenAI.ChatCompletion).choices[0]?.message.tool_calls;
+      return calls?.flatMap((call) => call.id === undefined ? [] : [call.id]) ?? [];
+    }
+    if (protocol === "messages") {
+      const blocks = mode === "nonstream" ? (fixture as unknown as Anthropic.Message).content
+        : fixture.type === "content_block_start" ? [(fixture as unknown as Anthropic.ContentBlockStartEvent).content_block] : [];
+      return blocks.flatMap((block) => block.type === "tool_use" ? [block.id] : []);
+    }
+    const items = mode === "nonstream" ? (fixture as unknown as OpenAI.Responses.Response).output
+      : fixture.type === "response.output_item.added" ? [(fixture as unknown as OpenAI.Responses.ResponseOutputItemAddedEvent).item] : [];
+    return items.flatMap((item) => item.type === "function_call" ? [item.call_id] : []);
+  });
+}
+
+function fixedText(fixtures: readonly Record<string, unknown>[], protocol: SdkProtocol, mode: SdkMode): string {
   if (mode === "nonstream") {
     switch (protocol) {
     case "chat": {
-      const fixture = JSON.parse(raw) as OpenAI.ChatCompletion;
+      const fixture = fixtures[0] as unknown as OpenAI.ChatCompletion;
       return fixture.choices[0]?.message.content ?? "";
     }
     case "messages": {
-      const fixture = JSON.parse(raw) as Anthropic.Message;
+      const fixture = fixtures[0] as unknown as Anthropic.Message;
       return fixture.content.filter((block) => block.type === "text").map((block) => block.text).join("");
     }
     case "responses": {
-      const fixture = JSON.parse(raw) as OpenAI.Responses.Response;
+      const fixture = fixtures[0] as unknown as OpenAI.Responses.Response;
       return fixture.output.flatMap((item) => item.type === "message"
         ? item.content.flatMap((part) => part.type === "output_text" ? [part.text] : [])
         : []).join("");
@@ -105,21 +167,18 @@ async function readExpectedText(protocol: SdkProtocol, scenario: TextScenario["i
     }
   }
 
-  // These immutable SSE fixtures have one JSON data line per event; this is not a wire decoder.
-  const events = raw.split(/\r?\n/u).filter((line) => line.startsWith("data:"))
-    .map((line) => line.slice(5).trim()).filter((data) => data !== "[DONE]");
-  return events.map((data) => {
+  return fixtures.map((data) => {
     switch (protocol) {
     case "chat": {
-      const event = JSON.parse(data) as OpenAI.ChatCompletionChunk;
+      const event = data as unknown as OpenAI.ChatCompletionChunk;
       return event.choices[0]?.delta.content ?? "";
     }
     case "messages": {
-      const event = JSON.parse(data) as Anthropic.MessageStreamEvent;
+      const event = data as unknown as Anthropic.MessageStreamEvent;
       return event.type === "content_block_delta" && event.delta.type === "text_delta" ? event.delta.text : "";
     }
     case "responses": {
-      const event = JSON.parse(data) as OpenAI.Responses.ResponseStreamEvent;
+      const event = data as unknown as OpenAI.Responses.ResponseStreamEvent;
       return event.type === "response.output_text.delta" ? event.delta : "";
     }
     }
@@ -141,54 +200,108 @@ export function expectScenarioResult(
     expect(fact.pattern.test(result.text), fact.name).toBe(true);
   }
   expectUsage(result.response.usage, downstream, expected);
-  expect(result.response.usage).not.toHaveProperty("visual_tokens");
-  if (scenario.id === "image") {
-    // These captures aggregate vision cost in input totals, without a separate visual-token breakdown.
-    for (const field of ["image_tokens", "prompt_tokens_details.image_tokens", "input_tokens_details.image_tokens"]) {
-      expect(result.response.usage).not.toHaveProperty(field);
-    }
-  }
-  expect(result.terminal).toBe({ chat: "stop", messages: "end_turn", responses: "completed" }[downstream]);
+  expectReasoningResult(result, expected, downstream);
+  expect(result.terminal === { chat: "stop", messages: "end_turn", responses: "completed" }[downstream], "normal terminal outcome").toBe(true);
   if (mode === "stream") {
     expect(result.stream?.terminalCount, "exactly one normal terminal outcome").toBe(1);
     expect(result.stream?.text === expectedText, "streamed text is neither truncated nor duplicated").toBe(true);
   } else {
-    expect(result.stream).toBeUndefined();
+    expect(result.stream === undefined, "buffered results contain no stream observations").toBe(true);
   }
 }
 
-function expectUsage(usage: unknown, downstream: SdkProtocol, expected: ExpectedResult): void {
+export function expectReasoningResult(
+  result: SdkResult<OpenAI.ChatCompletion | Anthropic.Message | OpenAI.Responses.Response>,
+  expected: ExpectedResult,
+  downstream: SdkProtocol,
+): void {
+  const native = downstream === expected.upstream;
+  if (downstream === "chat" && expected.mode === "stream") {
+    const fragments = native ? expected.reasoning.flatMap((value) => {
+      const text = record(value)?.reasoning_text;
+      return typeof text === "string" ? [text] : [];
+    }) : [];
+    expect(result.stream?.reasoningText === (fragments.length === 0 ? undefined : fragments.join("")), "complete SDK-parsed reasoning deltas, or approved converted absence").toBe(true);
+    expect(result.stream?.reasoningDeltaCount).toBe(fragments.length);
+    if (!native) expect(chatReasoning((result.response as OpenAI.ChatCompletion).choices[0]?.message).length).toBe(0);
+    return;
+  }
+  const actual = downstream === "chat" ? chatReasoning((result.response as OpenAI.ChatCompletion).choices[0]?.message)
+    : downstream === "messages" ? (result.response as Anthropic.Message).content.filter((block) => block.type === "thinking" || block.type === "redacted_thinking")
+      : (result.response as OpenAI.Responses.Response).output.filter((item) => item.type === "reasoning");
+  expect(JSON.stringify(actual) === JSON.stringify(native ? expected.reasoning : []), "SDK-parsed native reasoning/opaque state is preserved; converted nonportable content is omitted").toBe(true);
+}
+
+function chatReasoning(value: unknown): Record<string, unknown>[] {
+  const message = record(value);
+  const fields = Object.fromEntries(["reasoning_text", "reasoning_opaque", "reasoning_content", "thinking_blocks", "reasoning_items"]
+    .flatMap((key) => message?.[key] === undefined ? [] : [[key, message[key]]]));
+  return Object.keys(fields).length === 0 ? [] : [fields];
+}
+
+export function expectUsage(usage: unknown, downstream: SdkProtocol, expected: ExpectedResult): void {
   const captured = expected.usage;
-  // Capture metadata records native counters. Messages cache inputs and this Chat provider's
-  // top-level reasoning output are separate; Responses counters already include them.
+  const source = usageFields(expected.nativeUsage, expected.upstream);
+  const actual = usageFields(usage, downstream);
+  // Messages input excludes both cache categories. Only top-level Chat reasoning is additional output.
   const input = captured.inputTokens + (expected.upstream === "messages" ? captured.cacheReadTokens + captured.cacheWriteTokens : 0);
-  const output = captured.outputTokens + (expected.upstream === "chat" ? captured.reasoningTokens : 0);
-  switch (downstream) {
-  case "chat": {
-    const actual = usage as OpenAI.CompletionUsage & { reasoning_tokens?: number };
-    expect(actual).toMatchObject({
-      prompt_tokens: input,
-      completion_tokens: expected.upstream === "chat" ? captured.outputTokens : output,
-      total_tokens: input + output,
-    });
-    expect(actual.prompt_tokens_details?.cached_tokens ?? 0).toBe(captured.cacheReadTokens);
-    const reasoning = expected.upstream === "chat" ? actual.reasoning_tokens : actual.completion_tokens_details?.reasoning_tokens;
-    expect(reasoning ?? 0).toBe(captured.reasoningTokens);
-    break;
+  const separateReasoning = expected.upstream === "chat" && record(expected.nativeUsage.completion_tokens_details)?.reasoning_tokens === undefined;
+  const output = captured.outputTokens + (separateReasoning ? captured.reasoningTokens : 0);
+  const native = downstream === expected.upstream;
+  if (native) expect(isDeepStrictEqual(usage, expected.nativeUsage), "native usage preserves reported fields, including explicit zero").toBe(true);
+  else expect(Object.hasOwn(record(usage)!, "reasoning_tokens"), "converted usage does not expose a separate reasoning counter").toBe(false);
+  expect(actual.input).toBe(downstream === "messages" ? input - captured.cacheReadTokens - captured.cacheWriteTokens : input);
+  expect(actual.output).toBe(native ? captured.outputTokens : output);
+  if (downstream !== "messages") expect(record(usage)?.total_tokens === input + output, "inclusive total tokens match").toBe(true);
+
+  // Native absence stays absent. Converted envelopes deliberately materialize only portable details.
+  const messagesStream = downstream === "messages" && expected.mode === "stream";
+  // The converted Messages message_start reports zero cache counters. SDK finalMessage retains
+  // those zeros when message_delta omits them; buffered Messages has no such initial snapshot.
+  expect(actual.cacheRead).toBe(native ? source.cacheRead : downstream === "messages" && !messagesStream ? nonzero(captured.cacheReadTokens) : captured.cacheReadTokens);
+  expect(actual.cacheWrite).toBe(native ? source.cacheWrite : messagesStream ? captured.cacheWriteTokens : nonzero(captured.cacheWriteTokens));
+  expect(actual.reasoning).toBe(native ? source.reasoning : downstream === "messages" ? undefined
+    : downstream === "chat" && expected.mode === "nonstream" ? nonzero(captured.reasoningTokens) : captured.reasoningTokens);
+
+  if (source.cacheRead !== undefined) {
+    const actualInput = actual.input + (downstream === "messages" ? (actual.cacheRead ?? 0) + (actual.cacheWrite ?? 0) : 0);
+    // No hit-rate thresholds: preserve the fixed source ratio, including fully cached Messages input.
+    expect(cacheFraction(actual.cacheRead ?? 0, actualInput)).toBe(cacheFraction(source.cacheRead, input));
   }
-  case "messages": {
-    const actual = usage as Anthropic.Usage;
-    expect(actual).toMatchObject({ input_tokens: input - captured.cacheReadTokens - captured.cacheWriteTokens, output_tokens: output });
-    expect(actual.cache_read_input_tokens ?? 0).toBe(captured.cacheReadTokens);
-    expect(actual.cache_creation_input_tokens ?? 0).toBe(captured.cacheWriteTokens);
-    break;
+  expectNoVisualUsage(usage);
+}
+
+function nonzero(value: number): number | undefined { return value === 0 ? undefined : value; }
+function cacheFraction(cached: number, inclusiveInput: number): number | undefined {
+  return inclusiveInput === 0 ? undefined : cached / inclusiveInput;
+}
+
+/** These are documented source counters, not a production conversion oracle. */
+function usageFields(value: unknown, protocol: SdkProtocol) {
+  const usage = record(value);
+  if (usage === undefined) throw new Error("Missing SDK-visible usage");
+  const inputDetails = record(usage[protocol === "chat" ? "prompt_tokens_details" : "input_tokens_details"]);
+  const outputDetails = record(usage[protocol === "chat" ? "completion_tokens_details" : "output_tokens_details"]);
+  const fields = {
+    input: usage[protocol === "chat" ? "prompt_tokens" : "input_tokens"] as number,
+    output: usage[protocol === "chat" ? "completion_tokens" : "output_tokens"] as number,
+    cacheRead: (protocol === "messages" ? usage.cache_read_input_tokens : inputDetails?.cached_tokens) as number | undefined,
+    cacheWrite: (protocol === "messages" ? usage.cache_creation_input_tokens : inputDetails?.cache_write_tokens) as number | undefined,
+    reasoning: (protocol === "messages" ? undefined : outputDetails?.reasoning_tokens ?? (protocol === "chat" ? usage.reasoning_tokens : undefined)) as number | undefined,
+  };
+  if (fields.input === undefined || fields.output === undefined
+    || Object.values(fields).some((value) => value !== undefined && (!Number.isSafeInteger(value) || value < 0))) {
+    throw new Error("Invalid SDK usage counter");
   }
-  case "responses": {
-    const actual = usage as OpenAI.Responses.ResponseUsage;
-    expect(actual).toMatchObject({ input_tokens: input, output_tokens: output, total_tokens: input + output });
-    expect(actual.input_tokens_details?.cached_tokens ?? 0).toBe(captured.cacheReadTokens);
-    expect(actual.output_tokens_details?.reasoning_tokens ?? 0).toBe(captured.reasoningTokens);
-    break;
-  }
+  return fields;
+}
+
+export function expectNoVisualUsage(usage: unknown): void {
+  // Image understanding is included in input totals; these providers report no separate image tokens.
+  for (const field of ["visual_tokens", "image_tokens", "prompt_tokens_details.image_tokens", "input_tokens_details.image_tokens"]) {
+    const keys = field.split(".");
+    const key = keys.pop()!;
+    const parent = record(keys.reduce<unknown>((value, member) => record(value)?.[member], usage));
+    expect(parent !== undefined && Object.hasOwn(parent, key), `no inferred ${field} breakdown`).toBe(false);
   }
 }

--- a/tests/sdk/session_expectations.ts
+++ b/tests/sdk/session_expectations.ts
@@ -1,0 +1,181 @@
+import { isDeepStrictEqual } from "node:util";
+import { expect } from "vitest";
+import { sdkToolCalls as sessionCalls, type SdkProtocol, type SdkProtocolResult as SessionResult, type SdkToolCall as ForecastCall } from "./client.js";
+import { expectUsage, type ExpectedResult } from "./replay_expectations.js";
+import {
+  expectedForecastArguments, FORECAST_PARAMETERS, PARIS_RESULT, SESSION_SYSTEM, TEXT_SCENARIOS, TOKYO_RESULT,
+} from "./scenarios.js";
+import { SESSION_PROMPTS, type SessionTurn } from "./session_inputs.js";
+
+export function expectSessionTurn(value: SessionResult, expected: ExpectedResult, turn: SessionTurn): ForecastCall[] {
+  const { result, protocol } = value;
+  const calls = sessionCalls(value);
+  expect(calls.length, "actual parsed call count on every turn").toBe(turn === 2 ? 2 : 0);
+  expect(isDeepStrictEqual(calls.map((call) => call.id), expected.toolCallIds), "fixture call identities and order are preserved").toBe(true);
+  if (turn === 2) {
+    expect(calls.every((call) => call.id.length > 0), "nonempty returned call identities").toBe(true);
+    expect(new Set(calls.map((call) => call.id)).size, "unique returned call identities").toBe(2);
+    for (const [index, city] of (["Tokyo", "Paris"] as const).entries()) {
+      expect(calls[index]?.name === "get_hourly_forecast", "forecast tool name").toBe(true);
+      expect(isDeepStrictEqual(calls[index]?.arguments, expectedForecastArguments(city)), "nested multi-parameter forecast arguments").toBe(true);
+    }
+  } else {
+    expect(result.text.length, "substantive textual response").toBeGreaterThan(600);
+    const patterns = turn === 1 ? TEXT_SCENARIOS.find((scenario) => scenario.id === "image")!.facts.map((fact) => fact.pattern)
+      : [ /Tokyo/iu, /silver|white/iu, /coat/iu, /sword|katana/iu, /30%/u, /13\s*(?:kph|km\/h)/iu,
+        ...(turn === 4 ? [/15:00/u, /18:00/u, /contingency|rain|shelter|covered/iu] : [
+          /Paris/iu, /blue/iu, /20\s*°?\s*C/u, /14\s*°?\s*C/u, /70%/u, /21\s*(?:kph|km\/h)/iu,
+        ]),
+        ...(turn === 5 ? [/Image-derived claims/iu, /Tool-derived claims/iu, /Unsupported claims/iu, /handoff/iu] : []),
+      ];
+    for (const pattern of patterns) expect(pattern.test(result.text), `session fact ${pattern.source}`).toBe(true);
+    if (turn === 4) expect([...result.text.matchAll(/^[* \t]*(?:15|16|17|18):[0-5]\d/gmu)].length, "six scheduled shots").toBe(6);
+  }
+  expect(result.text === expected.text, "complete parsed text matches independent fixture text").toBe(true);
+  const terminal = protocol === "responses" ? "completed"
+    : protocol === "messages" ? (turn === 2 ? "tool_use" : "end_turn") : (turn === 2 ? "tool_calls" : "stop");
+  expect(result.terminal === terminal, "expected session terminal outcome").toBe(true);
+  if (turn === 1) expect(result.stream === undefined, "buffered turn contains no stream observations").toBe(true);
+  else {
+    expect(result.stream?.terminalCount, "exactly one normal stream terminal").toBe(1);
+    expect(result.stream?.text === expected.text, "streamed text has no loss or duplication").toBe(true);
+  }
+  expectUsage(result.response.usage, protocol, expected);
+  return calls;
+}
+
+export interface SessionRequestExpectation {
+  readonly protocol: SdkProtocol;
+  readonly turn: SessionTurn;
+  readonly imageBase64: string;
+  readonly turns: readonly ExpectedResult[];
+  readonly calls: readonly ForecastCall[];
+}
+
+export function matchesSessionRequest(body: unknown, expected: SessionRequestExpectation): boolean {
+  try {
+    return matchesSessionBody(body, expected);
+  } catch {
+    return false;
+  }
+}
+
+// A small, fixed-scenario projection of significant upstream fields, not a protocol codec.
+// Incidental envelopes and message grouping differ across native SDKs; ordered content must not.
+function matchesSessionBody(body: unknown, expected: SessionRequestExpectation): boolean {
+  const request = record(body);
+  if (request === undefined || request.previous_response_id !== undefined) return false;
+  const { protocol, turn } = expected;
+  const actual: unknown[][] = [];
+  let system = protocol === "messages" ? request.system : request.instructions;
+  const items = protocol === "responses" ? request.input : request.messages;
+  if (!Array.isArray(items)) return false;
+  for (const value of items) {
+    const item = record(value);
+    if (item === undefined) return false;
+    if (item.role === "system" || item.role === "developer") {
+      if (system !== undefined || actual.length !== 0) return false;
+      system = item.content;
+      continue;
+    }
+    if (protocol === "responses" && item.type === "function_call") {
+      actual.push(["call", item.call_id, item.name, parseArguments(item.arguments)]);
+    } else if (protocol === "responses" && item.type === "function_call_output") {
+      actual.push(["result", item.call_id, textContent(item.output, "input_text")]);
+    } else if (protocol === "chat" && item.role === "tool") {
+      actual.push(["result", item.tool_call_id, textContent(item.content, "text")]);
+    } else {
+      if (item.role !== "user" && item.role !== "assistant") return false;
+      if (!appendContent(actual, item.role, item.content, protocol, expected.imageBase64)) return false;
+      if (item.tool_calls !== undefined) {
+        if (protocol !== "chat" || item.role !== "assistant" || !Array.isArray(item.tool_calls)) return false;
+        for (const call of item.tool_calls) {
+          const tool = record(call);
+          const fn = record(tool?.function);
+          if (tool?.type !== "function" || fn === undefined) return false;
+          actual.push(["call", tool.id, fn.name, parseArguments(fn.arguments)]);
+        }
+      }
+    }
+  }
+  if (textContent(system, protocol === "responses" ? "input_text" : "text") !== SESSION_SYSTEM) return false;
+  if (turn === 1) {
+    if (request.tools !== undefined) return false;
+  } else {
+    if (!Array.isArray(request.tools) || request.tools.length !== 1) return false;
+    const tool = record(request.tools[0]);
+    const fn = protocol === "chat" ? record(tool?.function) : tool;
+    if (fn?.name !== "get_hourly_forecast" || (protocol !== "messages" && tool?.type !== "function")) return false;
+    if (!isDeepStrictEqual(protocol === "messages" ? fn.input_schema : fn.parameters, FORECAST_PARAMETERS)) return false;
+    if (turn === 2) {
+      if (protocol === "messages") {
+        const choice = record(request.tool_choice);
+        if (choice?.type !== "auto" || choice.disable_parallel_tool_use === true) return false;
+      } else if (request.tool_choice !== "auto" || request.parallel_tool_calls === false) return false;
+    }
+  }
+
+  const wanted: unknown[][] = [];
+  for (let index = 0; index < turn; index += 1) {
+    if (index === 2) {
+      if (expected.calls.length !== 2) return false;
+      wanted.push(["result", expected.calls[0]!.id, TOKYO_RESULT], ["result", expected.calls[1]!.id, PARIS_RESULT]);
+    }
+    wanted.push(["user", "text", SESSION_PROMPTS[index]]);
+    if (index === 0) wanted.push(["user", "image", expected.imageBase64]);
+    if (index < turn - 1) {
+      const text = expected.turns[index]!.text;
+      if (text !== "") wanted.push(["assistant", "text", text]);
+      if (index === 1) for (const call of expected.calls) wanted.push(["call", call.id, call.name, call.arguments]);
+    }
+  }
+  return isDeepStrictEqual(actual, wanted);
+}
+
+function appendContent(target: unknown[][], role: string, content: unknown, protocol: SdkProtocol, imageBase64: string): boolean {
+  if (content === null || content === undefined || content === "") return role === "assistant";
+  if (typeof content === "string") { target.push([role, "text", content]); return true; }
+  if (!Array.isArray(content)) return false;
+  for (const value of content) {
+    const part = record(value);
+    if (part === undefined) return false;
+    const textType = protocol === "responses" ? (role === "assistant" ? "output_text" : "input_text") : "text";
+    if (part.type === textType && typeof part.text === "string") {
+      if (part.text !== "") target.push([role, "text", part.text]);
+    } else if (protocol === "messages" && part.type === "tool_use" && role === "assistant") {
+      target.push(["call", part.id, part.name, part.input]);
+    } else if (protocol === "messages" && part.type === "tool_result" && role === "user") {
+      if (part.is_error !== undefined && part.is_error !== false) return false;
+      target.push(["result", part.tool_use_id, textContent(part.content, "text")]);
+    } else {
+      if (role !== "user") return false;
+      if (protocol === "messages") {
+        const source = record(part.source);
+        if (part.type !== "image" || source?.type !== "base64" || source.media_type !== "image/jpeg" || source.data !== imageBase64) return false;
+      } else {
+        const image = protocol === "chat" ? record(part.image_url)?.url : part.image_url;
+        const detail = protocol === "chat" ? record(part.image_url)?.detail : part.detail;
+        if (part.type !== (protocol === "chat" ? "image_url" : "input_image") || image !== `data:image/jpeg;base64,${imageBase64}`
+          || (detail !== undefined && detail !== "auto")) return false;
+      }
+      target.push([role, "image", imageBase64]);
+    }
+  }
+  return true;
+}
+
+function textContent(value: unknown, type: string): string | undefined {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value) || value.length !== 1) return undefined;
+  const part = record(value[0]);
+  return part?.type === type && typeof part.text === "string" ? part.text : undefined;
+}
+
+function parseArguments(value: unknown): unknown {
+  if (typeof value !== "string") throw new Error("Expected JSON tool arguments");
+  return JSON.parse(value) as unknown;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}

--- a/tests/sdk/session_inputs.ts
+++ b/tests/sdk/session_inputs.ts
@@ -1,0 +1,87 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import type OpenAI from "openai";
+import {
+  executeChat, executeMessages, executeResponses,
+  type SdkClients, type SdkProtocol, type SdkProtocolResult as SessionResult, type SdkToolCall as ForecastCall,
+} from "./client.js";
+import {
+  FORECAST_COMPARE_PROMPT, FORECAST_TOOL_ANTHROPIC, FORECAST_TOOL_OPENAI, FORECAST_TOOL_RESPONSES,
+  PARIS_RESULT, SESSION_AUDIT_PROMPT, SESSION_IMAGE_PROMPT, SESSION_SHOT_LIST_PROMPT,
+  SESSION_SYNTHESIS_PROMPT, SESSION_SYSTEM, TOKYO_RESULT,
+} from "./scenarios.js";
+
+export const SESSION_PROMPTS = [
+  SESSION_IMAGE_PROMPT, FORECAST_COMPARE_PROMPT, SESSION_SYNTHESIS_PROMPT,
+  SESSION_SHOT_LIST_PROMPT, SESSION_AUDIT_PROMPT,
+] as const;
+export type SessionTurn = 1 | 2 | 3 | 4 | 5;
+export const SESSION_TURNS: readonly SessionTurn[] = [1, 2, 3, 4, 5];
+export function forecastResults(calls: readonly ForecastCall[]): { id: string; content: string }[] {
+  return ["Tokyo", "Paris"].map((city) => {
+    const call = calls.find((candidate) => (candidate.arguments as { location: { city: string } }).location.city === city);
+    if (call === undefined) throw new Error("Missing forecast call binding");
+    return { id: call.id, content: city === "Tokyo" ? TOKYO_RESULT : PARIS_RESULT };
+  });
+}
+
+/** The test owns explicit native histories; the delivered client helper owns SDK execution. */
+export function createSessionDriver(clients: SdkClients, protocol: SdkProtocol, model: string, imageBase64: string) {
+  const dataUrl = `data:image/jpeg;base64,${imageBase64}`;
+  const chat: OpenAI.ChatCompletionMessageParam[] = [{ role: "system", content: SESSION_SYSTEM }];
+  const messages: Anthropic.MessageParam[] = [];
+  const input: OpenAI.Responses.ResponseInput = [];
+  return async (turn: SessionTurn, calls: readonly ForecastCall[]): Promise<SessionResult> => {
+    const prompt = SESSION_PROMPTS[turn - 1]!;
+    const results = turn === 3 ? forecastResults(calls) : [];
+    const mode = turn === 1 ? "nonstream" : "stream";
+    switch (protocol) {
+    case "chat": {
+      chat.push(...results.map(({ id, content }) => ({ role: "tool" as const, tool_call_id: id, content })));
+      chat.push({ role: "user", content: turn === 1
+        ? [{ type: "text", text: prompt }, { type: "image_url", image_url: { url: dataUrl, detail: "auto" } }]
+        : prompt });
+      const result = await executeChat(clients.openai, {
+        model, messages: chat, max_tokens: 3_000,
+        ...(turn >= 2 ? { tools: [FORECAST_TOOL_OPENAI] } : {}),
+        ...(turn === 2 ? { tool_choice: "auto", parallel_tool_calls: true } : {}),
+      }, mode);
+      const message = result.response.choices[0]!.message;
+      chat.push({ role: "assistant", content: message.content, ...(message.tool_calls ? { tool_calls: message.tool_calls } : {}) });
+      return { protocol, result };
+    }
+    case "messages": {
+      messages.push({ role: "user", content: [
+        ...results.map(({ id, content }) => ({ type: "tool_result" as const, tool_use_id: id, content })),
+        { type: "text", text: prompt },
+        ...(turn === 1 ? [{ type: "image" as const, source: { type: "base64" as const, media_type: "image/jpeg" as const, data: imageBase64 } }] : []),
+      ] });
+      const result = await executeMessages(clients.anthropic, {
+        model, system: SESSION_SYSTEM, messages, max_tokens: 3_000, thinking: { type: "disabled" },
+        ...(turn >= 2 ? { tools: [FORECAST_TOOL_ANTHROPIC] } : {}),
+        ...(turn === 2 ? { tool_choice: { type: "auto", disable_parallel_tool_use: false } } : {}),
+      }, mode);
+      messages.push({ role: "assistant", content: result.response.content });
+      return { protocol, result };
+    }
+    case "responses": {
+      input.push(...results.map(({ id, content }) => ({ type: "function_call_output" as const, call_id: id, output: content })));
+      input.push({ role: "user", content: [
+        { type: "input_text", text: prompt },
+        ...(turn === 1 ? [{ type: "input_image" as const, image_url: dataUrl, detail: "auto" as const }] : []),
+      ] });
+      const result = await executeResponses(clients.openai, {
+        model, instructions: SESSION_SYSTEM, input, max_output_tokens: 3_000,
+        ...(turn >= 2 ? { tools: [FORECAST_TOOL_RESPONSES] } : {}),
+        ...(turn === 2 ? { tool_choice: "auto", parallel_tool_calls: true } : {}),
+      }, mode);
+      // Explicit portable history, not previous_response_id, response-only logprobs, or opaque reasoning state.
+      for (const item of result.response.output) {
+        if (item.type === "message") input.push({ type: "message", id: item.id, status: item.status, role: "assistant", content: item.content.flatMap((part) =>
+          part.type === "output_text" ? [{ type: "output_text" as const, text: part.text, annotations: part.annotations }] : []) });
+        if (item.type === "function_call") input.push({ type: "function_call", call_id: item.call_id, name: item.name, arguments: item.arguments });
+      }
+      return { protocol, result };
+    }
+    }
+  };
+}

--- a/tests/unit/sdk_replay_expectations.test.ts
+++ b/tests/unit/sdk_replay_expectations.test.ts
@@ -1,0 +1,138 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import type { ReplayScenarioManifest } from "../../src/replay/types.js";
+import { expectReasoningResult, expectScenarioResult, expectUsage, readExpectedExchangeResult, type ExpectedResult } from "../sdk/replay_expectations.js";
+import { expectSessionTurn } from "../sdk/session_expectations.js";
+import type { SdkResult } from "../sdk/client.js";
+import type OpenAI from "openai";
+
+const messages: ExpectedResult = {
+  text: "", upstream: "messages", mode: "stream", reasoning: [], toolCallIds: [],
+  nativeUsage: { input_tokens: 23, output_tokens: 22, cache_read_input_tokens: 3, cache_creation_input_tokens: 5 },
+  usage: { inputTokens: 23, outputTokens: 22, cacheReadTokens: 3, cacheWriteTokens: 5, reasoningTokens: 0, visualTokens: "not_reported" },
+};
+const responses = {
+  input_tokens: 31, output_tokens: 22, total_tokens: 53,
+  input_tokens_details: { cached_tokens: 3, cache_write_tokens: 5 }, output_tokens_details: { reasoning_tokens: 0 },
+};
+
+describe("independent SDK replay expectations (no SDK execution)", () => {
+  it.each(["buffered-text", "first-session-turn", "native-usage", "invalid-counter"] as const)("keeps %s assertion diagnostics content-free", (kind) => {
+    const privateText = "synthetic-private-response-probe";
+    const text = "Vergil blue silver coat sword reserved. ".repeat(35);
+    const nativeUsage = { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 };
+    const expected: ExpectedResult = {
+      ...messages, upstream: "chat", mode: "nonstream", text, nativeUsage,
+      usage: { ...messages.usage, inputTokens: 3, outputTokens: 2, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    };
+    const result: SdkResult<OpenAI.ChatCompletion> = {
+      response: { choices: [{ message: { role: "assistant", content: text } }], usage: nativeUsage } as OpenAI.ChatCompletion,
+      text, terminal: "stop", stream: { text: privateText, reasoningText: privateText, terminalCount: 1 },
+    };
+    let error: unknown;
+    try {
+      if (kind === "buffered-text") expectScenarioResult(result, expected, { id: "plain-text", prompt: "synthetic", facts: [] }, "chat", "nonstream");
+      else if (kind === "first-session-turn") expectSessionTurn({ protocol: "chat", result }, expected, 1);
+      else expectUsage({ ...nativeUsage, ...(kind === "native-usage" ? { private: privateText } : { prompt_tokens: privateText }) }, "chat", expected);
+    } catch (caught) { error = caught; }
+    expect(error).toBeInstanceOf(Error);
+    expect(JSON.stringify(error).includes(privateText), "assertion metadata does not retain response content").toBe(false);
+  });
+
+  it("uses the Messages inclusive cache denominator and retains positive cache writes", () => {
+    expectUsage(messages.nativeUsage, "messages", messages);
+    expectUsage(responses, "responses", messages);
+    expectUsage({ prompt_tokens: 31, completion_tokens: 22, total_tokens: 53,
+      prompt_tokens_details: { cached_tokens: 3, cache_write_tokens: 5 }, completion_tokens_details: { reasoning_tokens: 0 } }, "chat", messages);
+  });
+
+  it.each([
+    { ...responses, input_tokens: 23, total_tokens: 45 },
+    { ...responses, output_tokens: 44, total_tokens: 75 },
+    { ...responses, input_tokens_details: { cached_tokens: 3 } },
+    { ...responses, input_tokens_details: { cached_tokens: 0, cache_write_tokens: 5 } },
+    { ...responses, output_tokens_details: {} },
+    { ...responses, output_tokens_details: { reasoning_tokens: 1 } },
+    { ...responses, visual_tokens: 1 },
+    { ...responses, input_tokens_details: { cached_tokens: 3, cache_write_tokens: 5, image_tokens: 7 } },
+  ])("rejects changed counters, lost fields or invented vision details %#", (usage) => {
+    expect(() => expectUsage(usage, "responses", messages)).toThrow();
+  });
+
+  it("distinguishes native missing cache fields from reported zero, and rejects both substitutions", () => {
+    const absent: ExpectedResult = { ...messages,
+      nativeUsage: { input_tokens: 23, output_tokens: 22 },
+      usage: { ...messages.usage, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    };
+    const zero: ExpectedResult = { ...absent,
+      nativeUsage: { ...absent.nativeUsage, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    };
+    expectUsage(absent.nativeUsage, "messages", absent);
+    expectUsage(zero.nativeUsage, "messages", zero);
+    expect(() => expectUsage(zero.nativeUsage, "messages", absent)).toThrow();
+    expect(() => expectUsage(absent.nativeUsage, "messages", zero)).toThrow();
+  });
+
+  it("retains initial converted Messages stream cache zeros rather than pretending the provider reported them", () => {
+    const chat: ExpectedResult = { ...messages, upstream: "chat",
+      nativeUsage: { prompt_tokens: 31, completion_tokens: 22, total_tokens: 53 },
+      usage: { ...messages.usage, inputTokens: 31, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    };
+    const buffered = { input_tokens: 31, output_tokens: 22 };
+    const streamed = { ...buffered, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 };
+    expectUsage(streamed, "messages", chat);
+    expectUsage(buffered, "messages", { ...chat, mode: "nonstream" });
+    expect(() => expectUsage(buffered, "messages", chat)).toThrow();
+    expect(() => expectUsage(streamed, "messages", { ...chat, mode: "nonstream" })).toThrow();
+  });
+
+  it("rejects lost or duplicated SDK-parsed reasoning fragments and converted reasoning leakage", () => {
+    const expected: ExpectedResult = { ...messages, upstream: "chat", reasoning: [{ reasoning_text: "first " }, { reasoning_text: "second" }] };
+    const result: SdkResult<OpenAI.ChatCompletion> = {
+      response: { choices: [{ message: { role: "assistant", content: "answer" } }] } as OpenAI.ChatCompletion,
+      text: "answer", terminal: "stop", stream: { text: "answer", terminalCount: 1, reasoningText: "first second", reasoningDeltaCount: 2 },
+    };
+    expectReasoningResult(result, expected, "chat");
+    for (const reasoningText of [undefined, "second", "first secondsecond"]) {
+      expect(() => expectReasoningResult({ ...result, stream: { ...result.stream!, reasoningText } }, expected, "chat")).toThrow();
+    }
+    expect(() => expectReasoningResult(result, { ...expected, upstream: "messages" }, "chat")).toThrow();
+  });
+
+  it("does not add nested Chat reasoning subsets, even when separate reasoning is also present", () => {
+    const expected: ExpectedResult = { ...messages, upstream: "chat",
+      nativeUsage: { prompt_tokens: 31, completion_tokens: 22, total_tokens: 53,
+        reasoning_tokens: 13, completion_tokens_details: { reasoning_tokens: 0 }, prompt_tokens_details: { cached_tokens: 3, cache_write_tokens: 5 } },
+      usage: { ...messages.usage, inputTokens: 31 },
+    };
+    expectUsage(expected.nativeUsage, "chat", expected);
+    expectUsage(responses, "responses", expected);
+    expect(() => expectUsage({ ...responses, output_tokens: 35, total_tokens: 66 }, "responses", expected)).toThrow();
+  });
+
+  it("reads every shared exchange using its own bodyFile and source metadata, including five-turn steps", async () => {
+    const manifest = JSON.parse(await readFile(new URL("../sdk/corpus/manifest.json", import.meta.url), "utf8")) as ReplayScenarioManifest;
+    const shared = new Set(manifest.responseSets.flatMap((set) => set.exchangeIds));
+    expect(shared.size).toBeGreaterThan(0);
+    for (const exchange of manifest.exchanges.filter((candidate) => shared.has(candidate.caseId))) {
+      const result = await readExpectedExchangeResult(exchange);
+      expect(result.upstream).toBe(exchange.targetProtocol);
+      expect(result.usage).toEqual(exchange.downstreamExpectation?.usage);
+      expectUsage(result.nativeUsage, result.upstream, result);
+    }
+  });
+
+  it.each([
+    { id: "replay.messages.plain-text.stream", uncached: 0, cached: 94, total: 94 },
+    { id: "replay.messages.image.stream", uncached: 82, cached: 629, total: 711 },
+  ])("keeps historical $id cache fraction without requiring fresh capture hit rates", async ({ id, uncached, cached, total }) => {
+    const manifest = JSON.parse(await readFile(new URL("../sdk/corpus/manifest.json", import.meta.url), "utf8")) as ReplayScenarioManifest;
+    const result = await readExpectedExchangeResult(manifest.exchanges.find((exchange) => exchange.caseId === id)!);
+    expect(result.nativeUsage.input_tokens).toBe(uncached);
+    expect(result.nativeUsage.cache_read_input_tokens).toBe(cached);
+    expect(result.usage.inputTokens + result.usage.cacheReadTokens + result.usage.cacheWriteTokens).toBe(total);
+    expect(cached / total).toBeLessThanOrEqual(1);
+    expectUsage({ input_tokens: total, output_tokens: result.usage.outputTokens, total_tokens: total + result.usage.outputTokens,
+      input_tokens_details: { cached_tokens: cached }, output_tokens_details: { reasoning_tokens: 0 } }, "responses", result);
+  });
+});

--- a/tests/unit/sdk_tool_calls.test.ts
+++ b/tests/unit/sdk_tool_calls.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { sdkToolCalls as sessionCalls, type SdkProtocolResult as SessionResult } from "../sdk/client.js";
+
+// Minimal SDK-parsed result shapes exercise extraction, not a second wire decoder.
+function result(protocol: "chat" | "responses", argumentsJson: string): SessionResult {
+  const response = protocol === "chat"
+    ? { choices: [{ message: { tool_calls: [{ type: "function", id: "call_test", function: { name: "lookup", arguments: argumentsJson } }] } }] }
+    : { output: [{ type: "function_call", call_id: "call_test", name: "lookup", arguments: argumentsJson }] };
+  return { protocol, result: { response, text: "", terminal: "completed" } } as SessionResult;
+}
+
+describe("SDK tool argument extraction privacy", () => {
+  it.each(["chat", "responses"] as const)("sanitizes malformed %s arguments without retaining a parser cause", (protocol) => {
+    let error: unknown;
+    try { sessionCalls(result(protocol, "synthetic-private-probe")); }
+    catch (caught) { error = caught; }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("Invalid SDK tool arguments");
+    expect(error).not.toHaveProperty("cause");
+  });
+
+  it.each(["chat", "responses"] as const)("preserves parsed %s call identity and arguments", (protocol) => {
+    expect(sessionCalls(result(protocol, "{\"q\":\"synthetic\"}"))).toEqual([
+      { id: "call_test", name: "lookup", arguments: { q: "synthetic" } },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #148
Closes #149
Closes #151

- Complete all nine five-turn official SDK flows using three shared upstream response sets: image understanding, two parallel nested-argument tools, correctly bound controlled results and synthesis, shot list, then a final textual audit/handoff.
- Independently validate significant upstream history, image content, tool schema/arguments and exact result content/format/binding. Add 24 real SDK/gateway/Replay HTTP mutation controls; an always-accept sensitivity probe correctly fails the binding controls.
- Check actual SDK-parsed thinking/reasoning and native opaque state, permitted converted omission, precise usage and zero-versus-absent/cache-denominator semantics. Add the nine-cell streaming tool matrix using official accumulators and shared safe call extraction.
- Remove the unused special-host/path automatic prompt-cache exception with public compatibility contracts. Correct README fixture wording without making authenticity claims for normalized legacy data.

No corpus, recorded response, image, existing capture artifact or repository ignore entry is changed. Four obsolete ignored local generation scripts were backed up outside the checkout and removed; all 90 existing capture files remain byte-identical. No live inference was run in batch 2.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run build`: passed.
- Final `npm test`: **1006 passed, 4 skipped**.
- Final `GHC_GATEWAY_SDK_TESTS=1 npm run test:sdk`: **156 passed**, strictly offline on the default replay port.
- `npm run fixtures:verify`: **53 entries verified**. SDK corpus/golden bytes and all 90 private capture digests are unchanged.
- Coherent matrix: **9 complete flows / 45 successful turns**, plus **24 rejecting HTTP mutation cases**. All three downstream SDKs and upstream protocols, including Messages, are exercised.
- Existing usage snapshot and fragmented/interleaved protocol contracts remain intact. New unit regressions validate meaningful expectations, safe malformed-argument errors and content-free assertion diagnostics.

The historical Chat reasoning fixture really terminates with `length`; its converted forms remain explicitly `max_tokens` / `incomplete`. It is not rewritten or represented as a completed response. Messages SDK retention of explicit initial zero cache counters is tested separately from genuinely absent fields. An opaque-only Responses fixture is not represented as public reasoning text.

## Independent review

Parallel Standards / Spec review-fix-review completed before commit. Standards rounds 1 and 2 identified payload-bearing tool/parser and unexpected-stream assertion diagnostics. Shared tool extraction now sanitizes parser errors; content-bearing comparisons are boolean, malformed usage counters are rejected safely, and four regression-first tests prove assertion metadata does not retain payloads. Required content, accounting, terminal and binding checks were not weakened.

**Round 3: no must-fix or safe-to-defer findings in either axis.**

## Deferred follow-ups

None from review. Final aggregate acceptance is tracked by #152 and starts after this PR merges and this batch's branches/worktrees are cleaned. The recorder-only two-model live evidence and intentionally unperformed live Claude verification remain recorded in #150 / PR #153; this does not restrict offline SDK coverage.
