### PR TITLE
Fix Admin refresh feedback, cache totals and model input limits

### DIFF
--- a/src/copilot/model_capabilities.ts
+++ b/src/copilot/model_capabilities.ts
@@ -87,19 +87,22 @@ export const UNKNOWN_DECLARATIONS: DeclaredModelCapabilities = Object.freeze({
 });
 
 export function parseLiveModelCapabilities(record: Readonly<Record<string, unknown>>): DeclaredModelCapabilities {
+  const explicitInputTokens = parseLocations(record, [
+    ["max_input_tokens"],
+    ["model_info", "max_input_tokens"],
+    ["capabilities", "max_input_tokens"],
+    ["capabilities", "limits", "max_prompt_tokens"],
+  ], parsePositiveInteger);
   return Object.freeze({
     protocols: parseLocations(record, [
       ["supported_endpoints"],
       ["model_info", "supported_endpoints"],
       ["capabilities", "supported_endpoints"],
     ], parseEndpointProtocols),
-    maxInputTokens: parseLocations(record, [
-      ["max_input_tokens"],
-      ["model_info", "max_input_tokens"],
-      ["capabilities", "max_input_tokens"],
-      ["capabilities", "limits", "max_prompt_tokens"],
-      ["capabilities", "limits", "max_context_window_tokens"],
-    ], parsePositiveInteger),
+    // Context windows are a fallback, not an alias of explicit input/prompt limits.
+    maxInputTokens: explicitInputTokens.state === "missing"
+      ? parseLocations(record, [["capabilities", "limits", "max_context_window_tokens"]], parsePositiveInteger)
+      : explicitInputTokens,
     maxOutputTokens: parseLocations(record, [
       ["max_output_tokens"],
       ["model_info", "max_output_tokens"],

--- a/tests/contract/admin_api.test.ts
+++ b/tests/contract/admin_api.test.ts
@@ -4,6 +4,8 @@ import type { AdminModule } from "../../src/gateway/create_gateway.js";
 import { createGateway, type Gateway } from "../../src/gateway/create_gateway.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
+import { capabilitySnapshotFromCatalog } from "../../src/copilot/capability_registry.js";
+import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
 import { adminDependencies } from "./admin_test_harness.js";
 import { login } from "./admin_test_harness.js";
 
@@ -65,6 +67,60 @@ describe("Admin API", () => {
       expect((await read(harness.gateway, "/admin/api/v1/events?severity=info", session.cookie)).data).toEqual({ items: [], nextCursor: null });
     } finally {
       await harness.close();
+    }
+  });
+
+  it("serializes discovered prompt limits without conflating context windows or changing output metadata", async () => {
+    const dependencies = adminDependencies();
+    const catalog = new CopilotModelCatalog({
+      async fetch() {
+        return { data: [
+          { id: "explicit", limits: { max_prompt_tokens: 128_000, max_context_window_tokens: 144_000 } },
+          { id: "context-only", limits: { max_context_window_tokens: 144_000 } },
+          { id: "malformed", limits: { max_prompt_tokens: null, max_context_window_tokens: 144_000 } },
+        ].map(({ id, limits }) => ({
+          id, name: id, vendor: "test", model_picker_enabled: true,
+          capabilities: {
+            supported_endpoints: ["/responses"],
+            limits: { ...limits, max_output_tokens: 16_000 },
+            default_output_tokens: 8000,
+            chat_output_token_field: "max_completion_tokens",
+          },
+        })) };
+      },
+    }, () => new Date("2027-01-15T08:00:00Z"));
+    dependencies.registry.get = async (account, signal) => capabilitySnapshotFromCatalog(
+      account, await catalog.get(account.accountId, signal, account.credentialGeneration),
+    );
+    const harness = await createHarness(dependencies);
+    try {
+      const session = await login(harness.gateway, harness.admin);
+      const response = (await read(harness.gateway, "/admin/api/v1/models", session.cookie)).data as {
+        items: Array<Record<string, unknown>>;
+      };
+      expect(response).toMatchObject({ accountId: "github.com/42", credentialGeneration: 4, catalogGeneration: 0 });
+      expect(response.items.map((item) => ({
+        id: item.id,
+        value: item.maxInputTokens,
+        source: item.maxInputTokensSource,
+        conflict: item.maxInputTokensConflict,
+        liveState: item.maxInputTokensLiveState,
+      }))).toEqual([
+        { id: "explicit", value: 128_000, source: "live", conflict: false, liveState: "value" },
+        { id: "context-only", value: 144_000, source: "live", conflict: false, liveState: "value" },
+        { id: "malformed", value: null, source: "unknown", conflict: false, liveState: "malformed" },
+      ]);
+      for (const item of response.items) {
+        expect(item).toMatchObject({
+          protocols: ["responses"], protocolsSource: "live", protocolsLiveState: "value",
+          maxOutputTokens: 16_000, maxOutputTokensSource: "live", maxOutputTokensConflict: false, maxOutputTokensLiveState: "value",
+          defaultOutputTokens: { configured: 8000, effective: 8000, source: "live", valid: true },
+          chatOutputTokenField: "max_completion_tokens", chatOutputTokenFieldSource: "live",
+        });
+      }
+    } finally {
+      await harness.close();
+      await catalog.close();
     }
   });
 

--- a/tests/contract/model_capability_registry.test.ts
+++ b/tests/contract/model_capability_registry.test.ts
@@ -145,6 +145,88 @@ describe("model capability registry", () => {
     expect(capability(snapshot, "empty").protocols).toMatchObject({ value: [], source: "live" });
   });
 
+  it("preserves input precedence, malformed declarations, and account-scoped overrides independently of output", async () => {
+    const builtins: BuiltinModelCapabilityLookup = {
+      get: () => ({
+        revision: "input-limits-test",
+        capabilities: parseLiveModelCapabilities({
+          max_input_tokens: 64_000,
+          max_output_tokens: 4096,
+          default_output_tokens: 2048,
+          supported_endpoints: ["/chat/completions"],
+        }),
+      }),
+    };
+    const inputModel = (id: string, limits: Readonly<Record<string, unknown>>) => ({
+      ...model(id, {
+        supported_endpoints: ["/responses"],
+        max_output_tokens: 16_000,
+        default_output_tokens: 8000,
+      }),
+      capabilities: { limits },
+    });
+    const harness = await createHarness({
+      "github.com/1": [
+        inputModel("explicit", { max_prompt_tokens: 128_000, max_context_window_tokens: 144_000 }),
+        inputModel("context-only", { max_context_window_tokens: 144_000 }),
+        inputModel("missing", {}),
+        inputModel("malformed", { max_prompt_tokens: null, max_context_window_tokens: 144_000 }),
+        inputModel("malformed-context", { max_context_window_tokens: null }),
+        { ...inputModel("conflicting", { max_prompt_tokens: 128_000, max_context_window_tokens: 144_000 }), max_input_tokens: 32_000 },
+      ],
+      "github.com/2": [inputModel("explicit", { max_prompt_tokens: 32_000, max_context_window_tokens: 144_000 })],
+    }, builtins);
+    try {
+      const initial = await harness.registry.get(harness.account1, signal);
+      expect(initial.models.map(({ modelId, maxInputTokens }) => ({ modelId, ...maxInputTokens }))).toEqual([
+        { modelId: "explicit", value: 128_000, source: "live", conflict: true, liveState: "value" },
+        { modelId: "context-only", value: 144_000, source: "live", conflict: true, liveState: "value" },
+        { modelId: "missing", value: 64_000, source: "builtin", conflict: false, liveState: "missing" },
+        { modelId: "malformed", value: null, source: "unknown", conflict: false, liveState: "malformed" },
+        { modelId: "malformed-context", value: null, source: "unknown", conflict: false, liveState: "malformed" },
+        { modelId: "conflicting", value: null, source: "unknown", conflict: false, liveState: "malformed" },
+      ]);
+      for (const item of initial.models) {
+        expect(item).toMatchObject({
+          protocols: { value: ["responses"], source: "live", conflict: true },
+          maxOutputTokens: { value: 16_000, source: "live", conflict: true },
+          defaultOutputTokens: { effective: 8000, source: "live", valid: true },
+        });
+      }
+      harness.overrides.set(harness.account1.accountId, "explicit", { enabled: true, maxInputTokens: 96_000 }, 0);
+      harness.overrides.set(harness.account1.accountId, "malformed", { enabled: true, maxInputTokens: 96_000 }, 1);
+      const overridden = await harness.registry.get(harness.account1, signal);
+      expect(capability(overridden, "explicit").maxInputTokens).toEqual({
+        value: 96_000, source: "admin_override", conflict: true, liveState: "value",
+      });
+      expect(capability(overridden, "malformed").maxInputTokens).toEqual({
+        value: 96_000, source: "admin_override", conflict: false, liveState: "malformed",
+      });
+      for (const item of overridden.models) {
+        const before = capability(initial, item.modelId);
+        expect(item.protocols).toEqual(before.protocols);
+        expect(item.maxOutputTokens).toEqual(before.maxOutputTokens);
+        expect(item.defaultOutputTokens).toEqual(before.defaultOutputTokens);
+        expect(item.profile).toEqual(before.profile);
+      }
+      expect(capability(initial, "explicit").maxInputTokens.value).toBe(128_000);
+      expect(Object.isFrozen(capability(initial, "explicit").maxInputTokens)).toBe(true);
+      const otherAccount = await harness.registry.get(harness.account2, signal);
+      expect(capability(otherAccount, "explicit").maxInputTokens).toEqual({
+        value: 32_000, source: "live", conflict: true, liveState: "value",
+      });
+      expect(otherAccount.capabilityRevision).toBe(0);
+
+      harness.overrides.reset(harness.account1.accountId, "explicit", 2);
+      harness.overrides.reset(harness.account1.accountId, "malformed", 3);
+      const reset = await harness.registry.get(harness.account1, signal);
+      expect(reset.models.map((item) => item.maxInputTokens)).toEqual(initial.models.map((item) => item.maxInputTokens));
+    } finally {
+      await harness.registry.close();
+      harness.database.close();
+    }
+  });
+
   it("isolates same model IDs by account and exposes configured-only models only when explicitly enabled", async () => {
     const harness = await createHarness({
       "github.com/1": [model("same", { supported_endpoints: ["/chat/completions"] })],

--- a/tests/contract/model_catalog.test.ts
+++ b/tests/contract/model_catalog.test.ts
@@ -92,6 +92,68 @@ describe("CAPI parse and cache", () => {
     expect(() => parseCapiModels({ data: [{ id: "x" }] })).toThrow(/invalid/u);
   });
 
+  it.each([
+    { name: "prompt and larger context window", fields: { capabilities: { limits: { max_prompt_tokens: 128_000, max_context_window_tokens: 144_000 } } }, expected: { state: "value", value: 128_000 } },
+    { name: "top-level input and context window", fields: { max_input_tokens: 128_000, capabilities: { limits: { max_context_window_tokens: 144_000 } } }, expected: { state: "value", value: 128_000 } },
+    { name: "model-info input and context window", fields: { model_info: { max_input_tokens: "128000" }, capabilities: { limits: { max_context_window_tokens: 144_000 } } }, expected: { state: "value", value: 128_000 } },
+    { name: "capabilities input and context window", fields: { capabilities: { max_input_tokens: 128_000, limits: { max_context_window_tokens: 144_000 } } }, expected: { state: "value", value: 128_000 } },
+    { name: "equal true aliases and different context window", fields: { max_input_tokens: 128_000, model_info: { max_input_tokens: "128000" }, capabilities: { max_input_tokens: 128_000, limits: { max_prompt_tokens: "128000", max_context_window_tokens: 144_000 } } }, expected: { state: "value", value: 128_000 } },
+    { name: "prompt only", fields: { capabilities: { limits: { max_prompt_tokens: 128_000 } } }, expected: { state: "value", value: 128_000 } },
+    { name: "context only", fields: { capabilities: { limits: { max_context_window_tokens: "144000" } } }, expected: { state: "value", value: 144_000 } },
+    { name: "malformed prompt and valid context", fields: { capabilities: { limits: { max_prompt_tokens: null, max_context_window_tokens: 144_000 } } }, expected: { state: "malformed" } },
+    { name: "no declarations", fields: {}, expected: { state: "missing" } },
+    { name: "empty containers", fields: { model_info: {}, capabilities: { limits: {} } }, expected: { state: "missing" } },
+  ])("parses input limits separately from context fallback: $name", ({ fields, expected }) => {
+    const [model] = parseCapiModels({ data: [{
+      id: "limits", name: "Limits", vendor: "test", model_picker_enabled: true, ...fields,
+    }] });
+    expect(model?.capabilities.maxInputTokens).toEqual(expected);
+  });
+
+  it.each([
+    { name: "top-level input", fields: (input: unknown) => ({ max_input_tokens: input, capabilities: { limits: { max_prompt_tokens: 128_000, max_context_window_tokens: 144_000 } } }) },
+    { name: "model-info input", fields: (input: unknown) => ({ model_info: { max_input_tokens: input }, capabilities: { limits: { max_prompt_tokens: 128_000, max_context_window_tokens: 144_000 } } }) },
+    { name: "capabilities input", fields: (input: unknown) => ({ capabilities: { max_input_tokens: input, limits: { max_prompt_tokens: 128_000, max_context_window_tokens: 144_000 } } }) },
+    { name: "prompt", fields: (input: unknown) => ({ max_input_tokens: 128_000, capabilities: { limits: { max_prompt_tokens: input, max_context_window_tokens: 144_000 } } }) },
+  ])("keeps conflicting or malformed true input aliases fail-closed: $name", ({ fields }) => {
+    for (const input of [64_000, undefined, null, false, 0, -1, 1.5, "", "0", "128000x", " 128000 ", Number.MAX_SAFE_INTEGER + 1, [], {}]) {
+      const [model] = parseCapiModels({ data: [{
+        id: "limits", name: "Limits", vendor: "test", model_picker_enabled: true, ...fields(input),
+      }] });
+      expect(model?.capabilities.maxInputTokens, `input: ${String(input)}`).toEqual({ state: "malformed" });
+    }
+  });
+
+  it("ignores malformed context values only when explicit input is valid", () => {
+    for (const context of [undefined, null, false, 0, -1, 1.5, "", "144000x", Number.MAX_SAFE_INTEGER + 1, [], {}]) {
+      for (const explicit of [{}, { max_prompt_tokens: 128_000 }, { max_prompt_tokens: null }]) {
+        const [model] = parseCapiModels({ data: [{
+          id: "limits", name: "Limits", vendor: "test", model_picker_enabled: true,
+          capabilities: { limits: { ...explicit, max_context_window_tokens: context } },
+        }] });
+        expect(model?.capabilities.maxInputTokens).toEqual(explicit.max_prompt_tokens === 128_000
+          ? { state: "value", value: 128_000 }
+          : { state: "malformed" });
+      }
+    }
+  });
+
+  it.each([
+    { name: "model-info", fields: (container: unknown) => ({ model_info: container, capabilities: { limits: { max_context_window_tokens: 144_000 } } }) },
+    { name: "capabilities", fields: (container: unknown) => ({ capabilities: container }) },
+    { name: "limits", fields: (container: unknown) => ({ capabilities: { limits: container } }) },
+  ])("keeps invalid input containers fail-closed even with valid input: $name", ({ fields }) => {
+    for (const container of [undefined, null, false, 128_000, "128000", []]) {
+      for (const explicit of [{}, { max_input_tokens: 128_000 }]) {
+        const [model] = parseCapiModels({ data: [{
+          id: "limits", name: "Limits", vendor: "test", model_picker_enabled: true,
+          ...explicit, ...fields(container),
+        }] });
+        expect(model?.capabilities.maxInputTokens).toEqual({ state: "malformed" });
+      }
+    }
+  });
+
   it("preserves explicit live capability fields without a global metadata map", async () => {
     const source = new HttpCopilotModelsSource(
       async () => ({ token: "token", endpoint: "https://api.githubcopilot.com" }),
@@ -102,8 +164,11 @@ describe("CAPI parse and cache", () => {
         model_picker_enabled: true,
         capabilities: {
           supported_endpoints: ["/responses", "/v1/chat/completions"],
-          max_input_tokens: "128000",
-          max_output_tokens: 64_000,
+          limits: {
+            max_prompt_tokens: "128000",
+            max_context_window_tokens: 144_000,
+            max_output_tokens: 64_000,
+          },
           chat_output_token_field: "max_completion_tokens",
         },
       }] })),
@@ -119,10 +184,20 @@ describe("CAPI parse and cache", () => {
       chatOutputTokenField: { state: "value", value: "max_completion_tokens" },
     });
     const effective = capabilitySnapshotFromCatalog(bound("github.com/1"), snapshot);
-    expect(JSON.parse(serializeOpenAiModels(effective)).data[0]).toMatchObject({
+    expect(JSON.parse(serializeOpenAiModels(effective)).data[0]).toEqual({
+      id: "native", object: "model", created: 1_677_610_602, owned_by: "openai",
       max_input_tokens: 128_000,
       max_output_tokens: 64_000,
     });
+    expect(JSON.parse(serializeAnthropicModels(effective)).data[0]).toEqual({
+      type: "model", id: "native", display_name: "native", created_at: "2023-02-28T18:56:42Z",
+      max_input_tokens: 128_000,
+      max_tokens: 64_000,
+    });
+    expect(effective.models[0]?.defaultOutputTokens).toMatchObject({
+      effective: 8192, source: "known_ceiling", valid: true,
+    });
+    await catalog.close();
   });
 
   it("does not write cache after invalidate generation change", async () => {

--- a/tests/e2e/admin_usage_refresh.spec.ts
+++ b/tests/e2e/admin_usage_refresh.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test, type Page } from "@playwright/test";
+import { ADMIN_FIXTURE_NOW_MS, installAdminFixture, sse, status, type AdminFixture } from "./fixtures/admin_fixture.js";
+import type { AdminUsagePage } from "../../web/src/types.js";
+
+test.use({ locale: "en-US" });
+
+async function openAccounts(page: Page): Promise<AdminFixture> {
+  await page.clock.install({ time: ADMIN_FIXTURE_NOW_MS });
+  const fixture = await installAdminFixture(page);
+  await page.goto("/admin/#bootstrap_token=refresh-fixture");
+  await page.getByRole("button", { name: "Accounts", exact: true }).click();
+  await expect(page.getByText("Octo Admin", { exact: true })).toBeVisible();
+  return fixture;
+}
+
+test("manual Accounts refresh dismisses a success notice without erasing the original action result", async ({ page }) => {
+  const fixture = await openAccounts(page);
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "Remove", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "No accounts connected" })).toBeVisible();
+  await expect(page.getByRole("status")).toHaveText("Account removed.");
+  fixture.state.accountsDelayMs = 300;
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(page.getByRole("status")).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "No accounts connected" })).toBeVisible();
+  expect(fixture.state.accounts.items[0]?.state).toBe("removed");
+});
+
+test("manual refresh dismisses old action failures but reports a new refresh failure", async ({ page }) => {
+  const fixture = await openAccounts(page);
+  fixture.state.failAccountRemoval = true;
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "Remove", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText("internal error");
+  await expect(page.getByText("removing", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await page.route("**/admin/api/v1/accounts", (route) => route.fulfill({
+    status: 503, json: { error: { code: "upstream_unavailable", requestId: "synthetic" } },
+  }), { times: 1 });
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(page.getByRole("alert")).toHaveText("upstream unavailable");
+});
+
+test("refresh clears copied feedback without canceling device authorization", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", { value: { writeText: async () => undefined } });
+  });
+  const fixture = await openAccounts(page);
+  await page.getByRole("button", { name: "Start login", exact: true }).click();
+  await page.getByRole("button", { name: "Copy device code", exact: true }).click();
+  await expect(page.getByText("Code copied.", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(page.getByText("Code copied.", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("ABCD-1234", { exact: true })).toBeVisible();
+  fixture.state.deviceNowMs += 5000;
+  await page.clock.fastForward(5000);
+  await expect.poll(() => fixture.requests.filter((request) => request.method() === "GET"
+    && request.url().endsWith("/device-flows/flow-1")).length).toBe(1);
+  expect(fixture.requests.some((request) => request.method() === "DELETE"
+    && request.url().includes("/device-flows/"))).toBe(false);
+});
+
+for (const outcome of ["resolve", "reject"] as const) {
+  test(`pre-refresh clipboard ${outcome} cannot restore dismissed feedback`, async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "clipboard", { value: {
+        writeText: () => new Promise<void>((resolve, reject) => {
+          window.addEventListener("finish-copy", (event) => {
+            if ((event as CustomEvent<string>).detail === "resolve") resolve();
+            else reject(new Error("synthetic clipboard failure"));
+          }, { once: true });
+        }),
+      } });
+    });
+    await openAccounts(page);
+    await page.getByRole("button", { name: "Start login", exact: true }).click();
+    const copy = page.getByRole("button", { name: "Copy device code", exact: true });
+    await copy.click();
+    await expect(copy).toBeDisabled();
+    await page.getByRole("button", { name: "Refresh", exact: true }).click();
+    await page.evaluate((value) => window.dispatchEvent(new CustomEvent("finish-copy", { detail: value })), outcome);
+    await expect(copy).toBeEnabled();
+    await expect(page.getByText("Code copied.", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("Could not copy. Select and copy the code manually.", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("ABCD-1234", { exact: true })).toBeVisible();
+  });
+}
+
+function usage(cacheTokens: number): AdminUsagePage {
+  return {
+    items: [{ utcHour: "2026-09-03T12:00:00.000Z", accountId: "github:1", protocol: "openai_chat",
+      resolvedModel: "synthetic", outcome: "success", requestCount: 1, errorCount: 0,
+      inputTokens: 7, outputTokens: 2, cacheTokens: cacheTokens === 0 ? 0 : 3, latencySumMs: 2, latencyMaxMs: 2 }],
+    nextCursor: "synthetic-next-page",
+    totals: { requestCount: 42, errorCount: 2, inputTokens: 2000000, outputTokens: 300000,
+      cacheTokens, latencySumMs: 900, latencyMaxMs: 120 },
+  };
+}
+
+for (const width of [1440, 900, 390]) {
+  for (const cacheTokens of [0, 987654]) {
+    test(`Overview cache totals use all buckets at ${width}px with ${cacheTokens} cache tokens`, async ({ page }, testInfo) => {
+      await page.setViewportSize({ width, height: 900 });
+      const fixture = await installAdminFixture(page);
+      await page.route(/\/admin\/api\/v1\/usage(?:\?|$)/u, (route) => route.fulfill({ json: { data: usage(cacheTokens) } }));
+      await page.goto("/admin/#bootstrap_token=usage-fixture");
+      const stats = page.locator(".stat-row");
+      await expect(stats.locator(":scope > div")).toHaveCount(5);
+      const cache = stats.locator("div").filter({ has: page.getByText("Cache tokens", { exact: true }) });
+      await expect(cache.locator("strong")).toHaveText(cacheTokens.toLocaleString("en-US"));
+      await expect(cache.locator("span")).toHaveAttribute("title", /read.*write.*included in input/iu);
+      await expect(stats.locator("div").filter({ has: page.getByText("Input tokens", { exact: true }) }).locator("strong")).toHaveText("2,000,000");
+      await expect(stats.locator("div").filter({ has: page.getByText("Output tokens", { exact: true }) }).locator("strong")).toHaveText("300,000");
+      await expect(page.getByText("Last 24 hours", { exact: true })).toBeVisible();
+      await expect(page.getByText("Content-free totals for the last 24 hours.", { exact: true })).toHaveCount(0);
+      await expect(page.locator(".chip").filter({ hasText: /buckets/u })).toHaveCount(0);
+      const boxes = await stats.locator(":scope > div").evaluateAll((elements) => elements.map((element) => {
+        const box = element.getBoundingClientRect();
+        return { top: box.top, left: box.left, right: box.right, width: box.width };
+      }));
+      for (const box of boxes) {
+        expect(box.left).toBeGreaterThanOrEqual(0);
+        expect(box.right).toBeLessThanOrEqual(width);
+        expect(Math.abs(box.width - boxes[0]!.width)).toBeLessThanOrEqual(1);
+        if (width > 600) expect(Math.abs(box.top - boxes[0]!.top)).toBeLessThanOrEqual(1);
+      }
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
+      expect(fixture.requests.filter((request) => request.url().includes("cursor="))).toHaveLength(0);
+      if (cacheTokens > 0) await page.screenshot({ path: testInfo.outputPath(`overview-${width}.png`), fullPage: true });
+    });
+  }
+}
+
+test("Overview refresh clears a previous failure while retaining genuine state warnings", async ({ page }) => {
+  const fixture = await installAdminFixture(page);
+  fixture.state.failStatus = true;
+  fixture.state.status = status("degraded");
+  fixture.state.streamBodies = [sse("performance", { kind: "performance", status: fixture.state.status })];
+  await page.goto("/admin/#bootstrap_token=overview-refresh");
+  await expect(page.getByRole("alert")).toContainText("Overview unavailable");
+  fixture.state.failStatus = false;
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByText("Usage ledger", { exact: false })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Gateway is degraded" })).toBeVisible();
+});

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -210,7 +210,7 @@ small, .small { font-size: 12px; }
 .hero-metrics article > strong { margin: auto 0 5px; font-size: 28px; line-height: 1.2; overflow-wrap: anywhere; }
 .hero-metrics article > small { color: var(--muted); }
 .hero-metrics meter { width: 100%; height: 6px; margin-top: 10px; accent-color: var(--ink); }
-.stat-row { grid-template-columns: repeat(4, minmax(0, 1fr)); margin-top: 14px; }
+.stat-row { grid-template-columns: repeat(5, minmax(0, 1fr)); margin-top: 14px; }
 .stat-row strong { display: block; font-size: 17px; overflow-wrap: anywhere; }
 .split-panels, .two-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 28px; }
 .plain-list, .metric-list, .storage-list { margin: 0; padding: 0; list-style: none; }

--- a/web/src/views/Accounts.svelte
+++ b/web/src/views/Accounts.svelte
@@ -14,6 +14,7 @@
   let failure = $state("");
   let copying = $state(false);
   let copyFeedback = $state("");
+  let copyFeedbackRevision = 0;
   let pollState: "idle" | "waiting" | "checking" | "retrying" = $state("idle");
   let hostInput: HTMLInputElement | null = null;
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -54,6 +55,13 @@
     } finally {
       if (requestGeneration === loadGeneration) loading = false;
     }
+  }
+
+  async function refresh(): Promise<void> {
+    message = "";
+    copyFeedback = "";
+    copyFeedbackRevision += 1;
+    await load();
   }
 
   async function start(): Promise<void> {
@@ -263,6 +271,7 @@
     const activeFlow = flow;
     if (activeFlow === null || copying || Date.now() >= Date.parse(activeFlow.expiresAt)) return;
     const generation = pollGeneration;
+    const feedbackRevision = copyFeedbackRevision;
     copying = true;
     copyFeedback = "";
     let feedback: string;
@@ -274,7 +283,9 @@
     }
     if (generation !== pollGeneration || flow?.flowId !== activeFlow.flowId) return;
     copying = false;
-    if (Date.now() < Date.parse(activeFlow.expiresAt)) copyFeedback = feedback;
+    if (feedbackRevision === copyFeedbackRevision && Date.now() < Date.parse(activeFlow.expiresAt)) {
+      copyFeedback = feedback;
+    }
   }
 
   function isAbort(error: unknown): boolean {
@@ -322,7 +333,7 @@
     <h1 tabindex="-1">Accounts</h1>
     <p>Connect GitHub.com or GHES and choose the identity used by new gateway requests.</p>
   </div>
-  <button onclick={() => void load()}>Refresh</button>
+  <button onclick={() => void refresh()}>Refresh</button>
 </header>
 
 {#if message}

--- a/web/src/views/Models.svelte
+++ b/web/src/views/Models.svelte
@@ -336,7 +336,7 @@
       <p>Discovered means the model is in the upstream catalog; Configured means an Admin override exists.</p>
       <p>Protocols identifies the source of native interface metadata: Upstream, Admin override, Built-in, or Unknown.
         These are metadata, not live inference validation or proof of account entitlement.</p>
-      <p>Token limits apply to each request, not account quota.</p>
+      <p>Token limits apply to each request, not account quota. The input limit may be lower than the model's full context window.</p>
     </details>
     <div class="table-scroll">
       <table class="model-table" aria-describedby="model-catalog-help">

--- a/web/src/views/Overview.svelte
+++ b/web/src/views/Overview.svelte
@@ -77,14 +77,14 @@
   <section class="section">
     <div class="section-heading">
       <h2><span class="section-number">[01]</span>Usage ledger</h2>
-      <span class="chip">{usage.items.length} buckets</span>
+      <span class="chip">Last 24 hours</span>
     </div>
-    <p class="muted small">Content-free totals for the last 24 hours.</p>
     <div class="stat-row">
       <div><span>Requests</span><strong>{number(usage.totals.requestCount)}</strong></div>
       <div><span>Errors</span><strong>{number(usage.totals.errorCount)}</strong></div>
       <div><span>Input tokens</span><strong>{number(usage.totals.inputTokens)}</strong></div>
       <div><span>Output tokens</span><strong>{number(usage.totals.outputTokens)}</strong></div>
+      <div><span title="Cache read + write tokens, already included in input tokens">Cache tokens</span><strong>{number(usage.totals.cacheTokens)}</strong></div>
     </div>
   </section>
   <section class="split-panels section">


### PR DESCRIPTION
## Summary

Closes #158

- Add a separate explicit Accounts Refresh path that dismisses old action and clipboard feedback, without clearing operation results during internal reloads or canceling active authorization. Pending pre-refresh clipboard completion cannot restore dismissed feedback; new refresh errors remain visible.
- Add Overview Cache tokens from the existing aggregate totals, truthfully labeled as cache reads plus writes included in input accounting. Remove the misleading page-bucket-count badge and verbose content-free sentence; keep a concise Last 24 hours scope and five aligned responsive metrics.
- Fix valid model input limits turning Unknown when prompt and context-window declarations differ. Resolve true input/prompt aliases first and consult the existing context-window fallback only for missing declarations. Malformed explicit input, invalid containers and conflicting true aliases still fail closed.
- Clarify that an input limit may be lower than the full model context window. No guessed model-specific numbers, builtin-map updates, accounting schema/backfill, protocol changes or running-daemon restart.

## Diagnosis and validation

The deterministic public-parser probe previously returned malformed for prompt=128000/context=144000, although each alone was valid. It now returns explicit input=128000; malformed explicit input still remains malformed rather than falling back. Regression-first evidence covers parser, real catalog/registry, account-scoped overrides, both model serializers and authenticated Admin metadata.

A read-only local CLI catalog check showed null inputs, but raw live upstream metadata was not captured; this PR does not claim that every live Unknown has this exact cause. Deploy/restart and refresh the catalog to use the corrected parser. Genuinely missing/invalid metadata remains Unknown.

- `npm run typecheck`, `npm run lint`, `npm run build`: passed.
- Scoped lint for the new browser spec: passed.
- `npm test`: **1026 passed, 4 existing skips**.
- `npm run e2e -- --workers=4`: **65 passed**, including 12 new refresh/usage cases.
- `npm run fixtures:verify`: **53 entries verified**.
- Desktop 1440/900px and mobile 390px Overview screenshots inspected; zero and paginated aggregate cache values remain correct and no root overflow occurs.
- All 90 prior capture hashes remain unchanged. No fixture/corpus edits, paid inference, official SDK suite, loose-key access or daemon restart.

## Independent review

Parallel Standards and Spec reviews inspected all changed/new files, public interfaces, tests and screenshots. Both found **no must-fix or safe-to-defer findings**. Independent focused model/Admin contracts and fixture verification also passed.

## Deferred follow-ups

None from this review. Existing CI checkpoint benchmark investigation #157 is outside this change; no benchmark or threshold modification is included.
