### PR TITLE
Enlarge Admin typography with a 12px minimum

### DIFF
--- a/tests/e2e/admin_typography.spec.ts
+++ b/tests/e2e/admin_typography.spec.ts
@@ -1,0 +1,188 @@
+import { expect, test, type Page } from "@playwright/test";
+import { ADMIN_FIXTURE_NOW_MS, installAdminFixture, operationalEvent } from "./fixtures/admin_fixture.js";
+
+test.use({ locale: "en-US" });
+
+async function expectReadableText(page: Page): Promise<void> {
+  const failures = await page.evaluate(() => {
+    const failures: { element: string; size: string; kind: string }[] = [];
+    const inspect = (element: Element, style: CSSStyleDeclaration, kind: string): void => {
+      if (Number.parseFloat(style.fontSize) < 12) failures.push({ element: element.tagName, size: style.fontSize, kind });
+    };
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let node: Node | null;
+    while ((node = walker.nextNode()) !== null) {
+      const element = node.parentElement;
+      if (!node.textContent?.trim() || element === null || element.closest("script, style, svg") || !element.getClientRects().length) continue;
+      const style = getComputedStyle(element);
+      if (style.visibility === "visible") inspect(element, style, "text");
+    }
+    for (const element of document.querySelectorAll("*")) {
+      if (!element.getClientRects().length || getComputedStyle(element).visibility !== "visible") continue;
+      for (const pseudo of ["::before", "::after"]) {
+        const style = getComputedStyle(element, pseudo);
+        if (!["none", "normal", "\"\""].includes(style.content)) inspect(element, style, pseudo);
+      }
+      if (element.matches("input, select, textarea, button")) inspect(element, getComputedStyle(element), "control");
+      if (element.hasAttribute("placeholder")) inspect(element, getComputedStyle(element, "::placeholder"), "placeholder");
+    }
+    return failures;
+  });
+  expect(failures, "all rendered text, generated labels and placeholders meet the 12px floor").toEqual([]);
+}
+
+async function expectContainedControls(page: Page): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    window.scrollTo({ left: 10000 });
+    const rootScrollX = window.scrollX;
+    window.scrollTo({ left: 0 });
+    const clipped = [...document.querySelectorAll<HTMLElement>("button, .button, .brand, .device-code code, h1")]
+      .filter((element) => element.getClientRects().length > 0 && element.clientWidth > 0
+        && (element.scrollWidth > element.clientWidth + 1 || element.scrollHeight > element.clientHeight + 1))
+      .map((element) => ({ tag: element.tagName, classes: element.className }));
+    return { rootScrollX, clipped };
+  });
+  expect(overflow).toEqual({ rootScrollX: 0, clipped: [] });
+}
+
+async function expectNavigationSettled(page: Page): Promise<void> {
+  if (!(await page.getByRole("button", { name: "Open navigation" }).isVisible())) return;
+  await expect.poll(() => page.locator("#admin-navigation").evaluate((element) => element.getBoundingClientRect().right))
+    .toBeLessThanOrEqual(0);
+}
+
+for (const width of [1440, 1100, 900, 851, 850, 601, 600, 390, 320]) {
+  test(`Admin typography remains readable and unclipped at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.clock.install({ time: ADMIN_FIXTURE_NOW_MS });
+    const fixture = await installAdminFixture(page);
+    const first = fixture.state.accounts.items[0]!;
+    fixture.state.accounts = { ...fixture.state.accounts, items: [first, {
+      ...first, accountId: "ghes:2", host: "github.example.test", login: "enterprise", displayName: "Enterprise Admin",
+    }] };
+    fixture.state.events = [{ ...operationalEvent(1), metadata: { source: "synthetic ".repeat(30) } }];
+    await page.goto("/admin/#bootstrap_token=typography-fixture");
+    await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeVisible();
+    await expect(page.locator("body")).toHaveCSS("font-size", "16px");
+    await expect(page.locator(".brand strong")).toHaveCSS("font-size", "20px");
+    for (const item of await page.locator(".nav-item").all()) await expect(item).toHaveCSS("font-size", "18px");
+
+    for (const view of ["Overview", "Accounts", "Models", "Configuration", "Events"]) {
+      const menu = page.getByRole("button", { name: "Open navigation" });
+      if (await menu.isVisible()) await menu.click();
+      const sidebar = page.getByRole("complementary", { name: "Primary navigation" });
+      expect(await sidebar.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+      await page.getByRole("navigation").getByRole("button", { name: view, exact: true }).click();
+      const title = page.getByRole("heading", { name: view, exact: true });
+      await expect(title).toBeFocused();
+      expect(await title.evaluate((element) => Number.parseFloat(getComputedStyle(element).fontSize))).toBeGreaterThanOrEqual(32);
+      if (view === "Overview") {
+        await expect(page.locator(".stat-row")).toBeVisible();
+        await expect(page.locator(".hero-metrics article > strong").first()).toHaveCSS("font-size", "32px");
+        await expect(page.locator(".stat-row strong").first()).toHaveCSS("font-size", "20px");
+      }
+      if (view === "Configuration") await expect(page.locator(".config-form")).toBeVisible();
+      if (view === "Accounts") {
+        await page.getByRole("button", { name: "Start login", exact: true }).click();
+        await expect(page.locator(".device-code code")).toHaveCSS("font-size", "28px");
+        const chosen = await page.getByRole("button", { name: "In use", exact: true }).boundingBox();
+        const other = await page.getByRole("button", { name: "Use this account", exact: true }).boundingBox();
+        expect(chosen).not.toBeNull();
+        expect(other).not.toBeNull();
+        expect(chosen!.width).toBeCloseTo(other!.width, 0);
+        expect(chosen!.height).toBeCloseTo(other!.height, 0);
+        expect(chosen!.height).toBeGreaterThanOrEqual(44);
+        const verification = await page.getByRole("link", { name: "Open verification page" }).boundingBox();
+        expect(verification).not.toBeNull();
+        expect(verification!.height).toBeGreaterThanOrEqual(44);
+      }
+      if (view === "Models") {
+        await page.getByText("About sources and token limits", { exact: true }).click();
+        await page.getByText("Capability details and override", { exact: true }).first().click();
+        await expect(page.locator("td").first()).toHaveCSS("font-size", "14px");
+        const selectedTextFits = await page.getByLabel("Chat output token field").first().evaluate((element) => {
+          const select = element as HTMLSelectElement;
+          const style = getComputedStyle(select);
+          const context = document.createElement("canvas").getContext("2d")!;
+          context.font = style.font;
+          const available = select.clientWidth - Number.parseFloat(style.paddingLeft) - Number.parseFloat(style.paddingRight) - 24;
+          return context.measureText(select.selectedOptions[0]?.text ?? "").width <= available;
+        });
+        expect(selectedTextFits, "default Chat budget selection remains readable without truncation").toBe(true);
+      }
+      if (view === "Events") await page.getByRole("list", { name: "Operational events" }).locator("summary").first().click();
+      if (await page.locator("h2").count()) await expect(page.locator("h2").first()).toHaveCSS("font-size", "20px");
+      await expectReadableText(page);
+      await expectContainedControls(page);
+      await expectNavigationSettled(page);
+      await page.screenshot({ path: testInfo.outputPath(`${view.toLowerCase()}-${width}.png`), fullPage: true });
+      if (view === "Accounts") await page.getByRole("button", { name: "Cancel", exact: true }).click();
+    }
+  });
+}
+
+for (const width of [851, 601]) {
+  test(`Configuration labels do not overlap inputs at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    await installAdminFixture(page);
+    await page.goto("/admin/#bootstrap_token=config-typography");
+    const menu = page.getByRole("button", { name: "Open navigation" });
+    if (await menu.isVisible()) await menu.click();
+    await page.getByRole("navigation").getByRole("button", { name: "Configuration", exact: true }).click();
+    await expect(page.locator(".config-form")).toBeVisible();
+    const collisions = await page.locator(".config-grid label").evaluateAll((labels) => labels.flatMap((label, index) => {
+      const input = label.querySelector("input")!.getBoundingClientRect();
+      const walker = document.createTreeWalker(label.querySelector("span")!, NodeFilter.SHOW_TEXT);
+      const collisions: { index: number; width: number }[] = [];
+      let text: Node | null;
+      while ((text = walker.nextNode()) !== null) {
+        if (!text.textContent?.trim()) continue;
+        const range = document.createRange();
+        range.selectNodeContents(text);
+        for (const rect of range.getClientRects()) {
+          const width = Math.min(rect.right, input.right) - Math.max(rect.left, input.left);
+          const height = Math.min(rect.bottom, input.bottom) - Math.max(rect.top, input.top);
+          if (width > 1 && height > 1) collisions.push({ index, width });
+        }
+      }
+      return collisions;
+    }));
+    await expectNavigationSettled(page);
+    await page.screenshot({ path: testInfo.outputPath(`configuration-boundary-${width}.png`), fullPage: true });
+    expect(collisions, "larger labels and descriptions do not intersect input controls").toEqual([]);
+  });
+}
+
+test("loading, signed-out, empty and error states preserve the font minimum", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 740 });
+  const fixture = await installAdminFixture(page);
+  await page.goto("/admin/");
+  await expect(page.getByRole("heading", { name: "Admin session closed" })).toBeVisible();
+  await expectReadableText(page);
+  await expectContainedControls(page);
+
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => { release = resolve; });
+  await page.route("**/admin/api/v1/auth/bootstrap", async (route) => { await pending; await route.fallback(); }, { times: 1 });
+  await page.evaluate(() => { location.hash = "bootstrap_token=loading-typography"; });
+  const loading = page.getByRole("button", { name: "Try current session" }).click();
+  try {
+    await expect(page.getByRole("heading", { name: "Establishing a secure session" })).toBeVisible();
+    await expectReadableText(page);
+    await expectContainedControls(page);
+  } finally { release(); }
+  await loading;
+  await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeVisible();
+  fixture.state.accounts = { ...fixture.state.accounts, defaultAccountId: null, items: [] };
+  await page.getByRole("button", { name: "Open navigation" }).click();
+  await page.getByRole("navigation").getByRole("button", { name: "Accounts", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "No accounts connected" })).toBeVisible();
+  await expectReadableText(page);
+  await expectContainedControls(page);
+  fixture.state.failStatus = true;
+  await page.getByRole("button", { name: "Open navigation" }).click();
+  await page.getByRole("navigation").getByRole("button", { name: "Overview", exact: true }).click();
+  await expect(page.getByRole("alert")).toBeVisible();
+  await expectReadableText(page);
+  await expectContainedControls(page);
+});

--- a/tests/e2e/admin_usage_refresh.spec.ts
+++ b/tests/e2e/admin_usage_refresh.spec.ts
@@ -122,8 +122,9 @@ for (const width of [1440, 900, 390]) {
       for (const box of boxes) {
         expect(box.left).toBeGreaterThanOrEqual(0);
         expect(box.right).toBeLessThanOrEqual(width);
-        expect(Math.abs(box.width - boxes[0]!.width)).toBeLessThanOrEqual(1);
-        if (width > 600) expect(Math.abs(box.top - boxes[0]!.top)).toBeLessThanOrEqual(1);
+        const row = boxes.filter((candidate) => Math.abs(candidate.top - box.top) <= 1);
+        expect(Math.abs(box.width - row[0]!.width)).toBeLessThanOrEqual(1);
+        if (width > 1100) expect(Math.abs(box.top - boxes[0]!.top)).toBeLessThanOrEqual(1);
       }
       expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
       expect(fixture.requests.filter((request) => request.url().includes("cursor="))).toHaveLength(0);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -13,15 +13,15 @@
   --amber: #92630a;
   --red: #b42920;
   --focus: #006bd6;
-  --sidebar-width: 248px;
+  --sidebar-width: 272px;
 }
 
 * { box-sizing: border-box; }
 html, body, #app { min-width: 320px; min-height: 100%; max-width: 100%; overflow-x: clip; }
-body { margin: 0; background: var(--canvas); font-size: 14px; line-height: 1.65; }
-button, input, select, textarea { font: inherit; }
+body { margin: 0; background: var(--canvas); font-size: 16px; line-height: 1.65; }
+button, input, select, textarea, .button { font: inherit; line-height: 1.5; }
 button, .button {
-  min-height: 36px;
+  min-height: 44px;
   padding: 6px 13px;
   border: 1px solid var(--line);
   border-radius: 4px;
@@ -30,12 +30,13 @@ button, .button {
   cursor: pointer;
   text-decoration: none;
 }
+.button { display: inline-flex; align-items: center; justify-content: center; }
 button:hover, .button:hover { background: var(--panel); border-color: #8d8585; }
 button:disabled { color: #8d8585; background: var(--soft); cursor: default; }
 button.primary, .button.primary { background: var(--ink); border-color: var(--ink); color: var(--canvas); }
 button.primary:hover, .button.primary:hover { background: #0f0000; }
 button.primary:disabled { background: var(--panel); border-color: var(--line); color: var(--muted); }
-button.text-button { min-height: 28px; padding: 2px 5px; border-color: transparent; background: transparent; }
+button.text-button { min-height: 36px; padding: 2px 5px; border-color: transparent; background: transparent; }
 button.danger { color: var(--red); }
 button:focus-visible, .button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible,
 textarea:focus-visible, summary:focus-visible, [tabindex]:focus-visible {
@@ -51,17 +52,18 @@ input, select, textarea {
   color: var(--ink);
   background: var(--soft);
 }
+input:not([type="checkbox"]), select, textarea { min-height: 44px; font-size: 16px; }
 input:focus, select:focus, textarea:focus { background: var(--canvas); }
 input[type="checkbox"] { accent-color: var(--ink); }
 a { color: inherit; text-underline-offset: 4px; }
 h1, h2, h3, p { margin-top: 0; }
-h1 { margin-bottom: 9px; font-size: clamp(26px, 2.4vw, 36px); line-height: 1.3; letter-spacing: -1px; }
-h2 { margin-bottom: 9px; font-size: 16px; line-height: 1.5; }
-h3 { margin-bottom: 7px; font-size: 14px; }
+h1 { margin-bottom: 9px; font-size: clamp(32px, 2.6vw, 40px); line-height: 1.3; letter-spacing: -1px; }
+h2 { margin-bottom: 9px; font-size: 20px; line-height: 1.5; }
+h3 { margin-bottom: 7px; font-size: 18px; }
 code, pre { font: inherit; }
 code { overflow-wrap: anywhere; }
 pre { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
-small, .small { font-size: 12px; }
+small, .small { font-size: 14px; }
 [hidden] { display: none !important; }
 .visually-hidden {
   position: absolute;
@@ -75,7 +77,7 @@ small, .small { font-size: 12px; }
   border: 0;
 }
 .muted, .subtle { color: var(--muted); }
-.eyebrow { margin: 0 0 12px; color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 1px; }
+.eyebrow { margin: 0 0 12px; color: var(--muted); font-size: 13px; font-weight: 700; letter-spacing: 1px; }
 .skip-link { position: fixed; top: -70px; left: 16px; z-index: 100; padding: 10px; background: var(--canvas); }
 .skip-link:focus { top: 12px; }
 
@@ -103,8 +105,8 @@ small, .small { font-size: 12px; }
 }
 .brand { display: flex; align-items: center; gap: 10px; padding: 0 10px 34px; }
 .brand-mark { width: 36px; height: 36px; flex: 0 0 36px; color: var(--ink); }
-.brand strong { font-size: 16px; letter-spacing: -.5px; }
-.nav-caption { margin: 0; padding: 0 10px 10px; color: var(--muted); font-size: 11px; letter-spacing: 1px; }
+.brand strong { font-size: 20px; letter-spacing: -.5px; }
+.nav-caption { margin: 0; padding: 0 10px 10px; color: var(--muted); font-size: 13px; letter-spacing: 1px; }
 .sidebar nav { display: grid; gap: 4px; }
 .nav-item {
   display: flex;
@@ -112,11 +114,11 @@ small, .small { font-size: 12px; }
   gap: 11px;
   padding: 11px 10px;
   border-color: transparent;
-  font-size: 14px;
+  font-size: 18px;
   text-align: left;
   white-space: nowrap;
 }
-.nav-item .nav-index { flex-shrink: 0; color: #8b8585; font-size: 11px; }
+.nav-item .nav-index { flex-shrink: 0; color: #8b8585; font-size: 13px; }
 .nav-item.active { background: var(--panel); color: var(--ink); }
 .nav-item.active .nav-index { color: var(--ink); }
 .sidebar-foot {
@@ -126,7 +128,7 @@ small, .small { font-size: 12px; }
   padding: 18px 10px 0;
   border-top: 1px solid var(--line);
   color: var(--muted);
-  font-size: 11px;
+  font-size: 13px;
 }
 .sidebar-foot .text-button { justify-self: start; margin-top: 8px; padding-inline: 0; }
 .stream-state { display: flex; align-items: center; gap: 7px; text-transform: uppercase; }
@@ -134,17 +136,17 @@ small, .small { font-size: 12px; }
 .status-dot.reconnecting, .status-dot.stopped { background: var(--amber); }
 .main-column { min-width: 0; padding: 30px clamp(24px, 3vw, 56px) 48px; }
 .content-frame { width: 100%; max-width: 1100px; min-width: 0; margin-inline: auto; }
-.mobile-menu { display: none; min-height: 36px; margin-bottom: 20px; padding: 4px 9px; }
+.mobile-menu { display: none; min-height: 44px; margin-bottom: 20px; padding: 4px 9px; }
 .workspace { min-width: 0; }
 
 .page-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 28px; }
 .page-head > div:first-child { min-width: 0; }
-.page-head p:last-child { max-width: 680px; margin: 0; color: var(--muted); font-size: 13px; }
+.page-head p:last-child { max-width: 680px; margin: 0; color: var(--muted); font-size: 15px; }
 .page-head > button, .page-head > .revision, .page-head > .live-badge { flex-shrink: 0; }
 .section { min-width: 0; max-width: 100%; margin-top: 30px; padding-top: 23px; border-top: 1px solid var(--line); }
 .section-heading, .section-title { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin-bottom: 14px; }
 .section-heading h2, .section-title h2 { margin: 0; }
-.section-number { margin-right: 11px; color: var(--muted); font-size: 11px; }
+.section-number { margin-right: 11px; color: var(--muted); font-size: 13px; }
 .section-block { min-width: 0; }
 .chip, .revision, .badge {
   display: inline-flex;
@@ -155,7 +157,7 @@ small, .small { font-size: 12px; }
   border: 1px solid var(--line);
   border-radius: 4px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: 12px;
   line-height: 1.7;
   text-transform: uppercase;
   white-space: nowrap;
@@ -181,7 +183,7 @@ small, .small { font-size: 12px; }
 .skeleton-grid i { height: 150px; border-right: 1px solid var(--line); background: var(--soft); }
 .skeleton-grid i:last-child { border: 0; }
 .empty { padding: 40px 24px; border: 1px dashed #c8c0c0; color: var(--muted); text-align: center; }
-.empty span { display: block; margin-bottom: 4px; color: var(--ink); font-size: 20px; }
+.empty span { display: block; margin-bottom: 4px; color: var(--ink); font-size: 24px; }
 .empty h2 { color: var(--ink); }
 
 .fact-strip, .hero-metrics, .stat-row {
@@ -200,18 +202,19 @@ small, .small { font-size: 12px; }
   display: block;
   margin-bottom: 7px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: 12px;
   letter-spacing: .6px;
   text-transform: uppercase;
 }
-.fact-strip strong { font-size: 15px; overflow-wrap: anywhere; }
+.fact-strip strong { font-size: 18px; overflow-wrap: anywhere; }
 .hero-metrics { margin-bottom: 30px; }
 .hero-metrics article { display: flex; min-height: 145px; flex-direction: column; }
-.hero-metrics article > strong { margin: auto 0 5px; font-size: 28px; line-height: 1.2; overflow-wrap: anywhere; }
+.hero-metrics article > strong { margin: auto 0 5px; font-size: 32px; line-height: 1.2; overflow-wrap: anywhere; }
 .hero-metrics article > small { color: var(--muted); }
 .hero-metrics meter { width: 100%; height: 6px; margin-top: 10px; accent-color: var(--ink); }
-.stat-row { grid-template-columns: repeat(5, minmax(0, 1fr)); margin-top: 14px; }
-.stat-row strong { display: block; font-size: 17px; overflow-wrap: anywhere; }
+.stat-row { display: flex; flex-wrap: wrap; gap: 1px; margin-top: 14px; background: var(--line); }
+.stat-row > div { flex: 1 1 180px; border: 0; background: var(--canvas); }
+.stat-row strong { display: block; font-size: 20px; overflow-wrap: anywhere; }
 .split-panels, .two-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 28px; }
 .plain-list, .metric-list, .storage-list { margin: 0; padding: 0; list-style: none; }
 .plain-list li, .metric-list li, .storage-list li {
@@ -221,7 +224,7 @@ small, .small { font-size: 12px; }
   gap: 18px;
   padding: 12px 0;
   border-bottom: 1px solid var(--line);
-  font-size: 12px;
+  font-size: 14px;
 }
 .metric-list li { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; }
 .plain-list li span:first-child, .metric-list small, .storage-list span { color: var(--muted); }
@@ -233,12 +236,12 @@ th {
   border-top: 1px solid var(--line);
   border-bottom: 1px solid var(--line);
   color: var(--muted);
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 400;
   letter-spacing: .5px;
   text-transform: uppercase;
 }
-td { padding: 16px 13px; border-bottom: 1px solid var(--line); font-size: 12px; vertical-align: middle; }
+td { padding: 16px 13px; border-bottom: 1px solid var(--line); font-size: 14px; vertical-align: middle; }
 th:first-child, td:first-child { padding-left: 0; }
 th:last-child, td:last-child { padding-right: 0; }
 .account-table { min-width: 780px; }
@@ -257,10 +260,10 @@ tr.current-row > td:last-child { padding-right: 12px; }
   border-radius: 4px;
   background: var(--soft);
   color: var(--muted);
-  font-size: 11px;
+  font-size: 13px;
 }
 .identity strong, .identity small { display: block; overflow-wrap: anywhere; }
-.identity small { color: var(--muted); font-size: 11px; }
+.identity small { color: var(--muted); font-size: 13px; }
 .row-actions { display: flex; align-items: center; justify-content: flex-end; gap: 7px; }
 .state-removing { color: var(--amber); }
 .muted-row { color: var(--muted); }
@@ -273,7 +276,7 @@ tr.current-row > td:last-child { padding-right: 12px; }
   border-radius: 4px;
   background: var(--panel);
 }
-.command-lines { display: grid; gap: 5px; font-size: 12px; }
+.command-lines { display: grid; gap: 5px; font-size: 14px; }
 .connect-panel {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(340px, 1.4fr);
@@ -283,7 +286,7 @@ tr.current-row > td:last-child { padding-right: 12px; }
   border: 1px solid var(--line);
 }
 .connect-panel h2 { margin: 0; }
-.connect-panel label, .toolbar label { display: block; margin-bottom: 6px; font-size: 12px; font-weight: 700; }
+.connect-panel label, .toolbar label { display: block; margin-bottom: 6px; font-size: 14px; font-weight: 700; }
 .inline-form { display: flex; gap: 7px; }
 .inline-form input { flex: 1; }
 .device-flow {
@@ -296,14 +299,14 @@ tr.current-row > td:last-child { padding-right: 12px; }
   border: 1px solid rgba(38, 119, 72, .4);
   background: var(--soft);
 }
-.device-flow code { display: block; margin: 9px 0; font-size: 25px; letter-spacing: .14em; }
+.device-flow code { display: block; margin: 9px 0; font-size: 28px; letter-spacing: .1em; }
 
 .toolbar { display: flex; align-items: flex-end; flex-wrap: wrap; gap: 13px; margin: 20px 0; }
 .toolbar .grow { flex: 1; }
-.toolbar .subtle { font-size: 11px; }
+.toolbar .subtle { font-size: 13px; }
 .model-summary { max-width: 240px; }
 .model-summary strong, .model-summary code { display: block; }
-.model-summary code { color: var(--muted); font-size: 11px; }
+.model-summary code { color: var(--muted); font-size: 13px; }
 .tag-group { display: flex; flex-wrap: wrap; gap: 5px; }
 .model-editor-row td { padding: 0 0 18px; }
 .model-editor { padding: 18px 20px; border: 1px solid var(--line); border-top: 0; background: var(--soft); }
@@ -331,16 +334,16 @@ tr.current-row > td:last-child { padding-right: 12px; }
 
 .config-form { display: grid; gap: 24px; }
 .config-form fieldset { margin: 0; padding: 18px 20px; border: 1px solid var(--line); }
-.config-form legend { padding: 0 8px; font-size: 12px; font-weight: 700; text-transform: uppercase; }
+.config-form legend { padding: 0 8px; font-size: 14px; font-weight: 700; text-transform: uppercase; }
 .config-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 34px; }
 .config-grid label { display: grid; grid-template-columns: minmax(0, 1fr) 145px; gap: 4px 14px; align-items: center; padding: 15px 0; border-bottom: 1px solid var(--line); }
 .config-grid label span { display: grid; }
 .config-grid small { color: var(--muted); }
-.config-grid .range { grid-column: 2; font-size: 10px; }
+.config-grid .range { grid-column: 2; font-size: 12px; }
 .sticky-save { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding-top: 18px; border-top: 1px solid var(--line); }
-.sticky-save p { margin: 0; color: var(--muted); font-size: 11px; }
+.sticky-save p { margin: 0; color: var(--muted); font-size: 13px; }
 
-.live-badge { display: flex; align-items: center; gap: 7px; color: var(--muted); font-size: 11px; text-transform: uppercase; }
+.live-badge { display: flex; align-items: center; gap: 7px; color: var(--muted); font-size: 13px; text-transform: uppercase; }
 .event-list { margin: 0; padding: 0; list-style: none; }
 .event-row {
   display: grid;
@@ -349,12 +352,12 @@ tr.current-row > td:last-child { padding-right: 12px; }
   align-items: start;
   padding: 16px 0;
   border-bottom: 1px solid var(--line);
-  font-size: 12px;
+  font-size: 14px;
 }
-.event-row time, .event-id { color: var(--muted); font-size: 11px; }
+.event-row time, .event-id { color: var(--muted); font-size: 13px; }
 .event-row details { min-width: 0; }
 .event-row summary { cursor: pointer; font-weight: 700; text-transform: capitalize; }
-.event-row pre { margin-top: 10px; padding: 12px; background: var(--soft); color: var(--muted); font-size: 11px; }
+.event-row pre { margin-top: 10px; padding: 12px; background: var(--soft); color: var(--muted); font-size: 13px; }
 .load-more { margin-top: 18px; }
 
 .auth-stage { display: grid; min-height: 100vh; place-content: center; padding: 32px; text-align: center; }
@@ -363,10 +366,10 @@ tr.current-row > td:last-child { padding-right: 12px; }
 .signed-out .status-dot { margin-bottom: 15px; }
 
 @media (max-width: 1100px) {
-  :root { --sidebar-width: 232px; }
+  :root { --sidebar-width: 256px; }
   .main-column { padding-inline: 25px; }
   .fact-strip > div, .hero-metrics article, .stat-row > div { padding: 15px; }
-  .capability-grid { grid-template-columns: 1fr; }
+  .capability-grid, .config-grid { grid-template-columns: 1fr; }
   .account-table { min-width: 0; }
   .account-table thead {
     position: absolute;
@@ -388,7 +391,7 @@ tr.current-row > td:last-child { padding-right: 12px; }
   .account-table td::before {
     content: attr(data-label);
     color: var(--muted);
-    font-size: 10px;
+    font-size: 12px;
     letter-spacing: .5px;
     text-transform: uppercase;
   }
@@ -430,16 +433,16 @@ tr.current-row > td:last-child { padding-right: 12px; }
 }
 
 @media (max-width: 600px) {
-  body { font-size: 13px; }
   .main-column { padding-inline: 18px; }
   .page-head { display: block; }
   .page-head > button, .page-head > .revision, .page-head > .live-badge { margin-top: 18px; }
-  .page-head p:last-child { font-size: 12px; }
-  .fact-strip, .stat-row { grid-template-columns: 1fr; }
-  .fact-strip > div, .stat-row > div { border-right: 0; border-bottom: 1px solid var(--line); padding: 12px 16px; }
-  .fact-strip > div:last-child, .stat-row > div:last-child { border-bottom: 0; }
+  .page-head p:last-child { font-size: 14px; }
+  .fact-strip { grid-template-columns: 1fr; }
+  .stat-row > div { flex-basis: 100%; padding: 12px 16px; }
+  .fact-strip > div { border-right: 0; border-bottom: 1px solid var(--line); padding: 12px 16px; }
+  .fact-strip > div:last-child { border-bottom: 0; }
   .fact-strip span { display: inline; margin-right: 10px; }
-  .fact-strip strong { font-size: 13px; }
+  .fact-strip strong { font-size: 16px; }
   .split-panels, .two-columns, .config-grid, .override-form { grid-template-columns: 1fr; }
   .metric-list li { grid-template-columns: minmax(0, 1fr) auto; }
   .metric-list small { grid-column: 1 / -1; }
@@ -454,6 +457,13 @@ tr.current-row > td:last-child { padding-right: 12px; }
   .event-row { grid-template-columns: 80px minmax(0, 1fr); gap: 8px 12px; }
   .event-row details { grid-column: 1 / -1; }
   .event-id { text-align: right; }
+}
+
+@media (max-width: 380px) {
+  .account-table td, .account-table td:first-child, .account-table td:last-child {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 4px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/web/src/views/Accounts.svelte
+++ b/web/src/views/Accounts.svelte
@@ -548,23 +548,24 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    flex: 0 0 36px;
-    width: 36px;
-    height: 36px;
+    flex: 0 0 44px;
+    width: 44px;
+    height: 44px;
     padding: 0;
   }
 
   .copy-feedback {
     margin: 0;
-    font-size: 12px;
+    font-size: 14px;
   }
 
   .account-choice {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 152px;
-    height: 36px;
+    width: 180px;
+    max-width: 100%;
+    height: 44px;
     padding: 6px 13px;
     white-space: nowrap;
   }

--- a/web/src/views/Models.svelte
+++ b/web/src/views/Models.svelte
@@ -491,7 +491,7 @@
                             placeholder="Automatic policy"
                           />
                         </label>
-                        <label for={`chat-field-${index}`}>
+                        <label class="wide-control" for={`chat-field-${index}`}>
                           Chat output token field
                           <select id={`chat-field-${index}`} bind:value={editor.chatOutputTokenField}>
                             <option value="">Use upstream/built-in/unknown</option>
@@ -536,15 +536,19 @@
 
   .configured-model-form input,
   .configured-model-form button {
-    min-height: 40px;
+    min-height: 44px;
     padding: 8px 11px;
     line-height: 1.5;
+  }
+
+  .wide-control {
+    grid-column: 1 / -1;
   }
 
   .catalog-help {
     margin-bottom: 16px;
     color: var(--muted);
-    font-size: 12px;
+    font-size: 14px;
   }
 
   .catalog-help summary {


### PR DESCRIPTION
## Summary

Closes #160

- Raise the minimum Admin text size to **12 CSS px**, with 16px body/general inputs, 14px tables/details, 13–14px secondary text, 20px section headings, 32–40px page headings and 20–32px primary metrics. Mobile no longer reduces body text to 13px.
- Set the top-left **ghc-gateway brand to 20px** and **sidebar navigation labels to 18px**, preserving the existing font-family stack.
- Widen the sidebar and enlarge primary controls. Preserve equal 180×44px account-selection controls, 44px copy controls and aligned model-add controls. Button-styled links now honor their height, and the long model budget selector spans its grid.
- Adapt layout rather than shrinking text: balanced wrapping usage metrics, stacked account fields on very narrow screens, and single-column Configuration groups through the existing 1100px breakpoint. Source tags remain inline inside the table scroller.

Only styling, one presentation class and browser tests change. Business scripts, backend, APIs, model/usage/account behavior, fixtures and font family remain unchanged.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run build`: passed.
- Scoped lint for new/updated browser specs: passed.
- `npm test`: **1026 passed, 4 existing skips**.
- `npm run e2e -- --workers=4`: **77 passed**.
- `npm run fixtures:verify`: **53 entries verified**; all 90 prior raw capture hashes remain unchanged.
- Computed-font tests cover text, generated labels, controls and placeholders across all five views at 1440, 1100, 900, 851, 850, 601, 600, 390 and 320px, plus loading, signed-out, empty and error states.
- Checks retain actual control-content bounds, equal account buttons, long selector readability, sticky/drawer/focus/logout and the original data/interaction assertions. Usage assertions allow responsive row wrapping without weakening totals or pagination checks.
- Synthetic desktop/mobile screenshots inspected; screenshots wait for mobile drawer transitions. No live authorization/inference, official SDK suite or user-daemon restart.

## Independent review and fixes

Parallel Standards/Spec review identified a real Configuration text/input overlap near the 851px and 601px breakpoints. Regression-first DOM Range checks measured 10.58px / 4.58px intersections. The responsive single-column fix resolves both without reducing fonts; boundary screenshots and tests verify it.

Fresh final Standards and Spec reviews found **no remaining must-fix or safe-to-defer findings**.

## Deferred follow-ups

None from this change. Existing checkpoint benchmark investigation #157 is unrelated; no benchmark or threshold changes are included.
