### PR TITLE
Align Accounts row contents across selection states

### DIFF
--- a/tests/e2e/admin_accounts_polish.spec.ts
+++ b/tests/e2e/admin_accounts_polish.spec.ts
@@ -35,6 +35,40 @@ async function expectNoConnectionBanner(page: Page): Promise<void> {
     .toHaveCount(0);
 }
 
+for (const width of [1440, 1100, 390, 320]) {
+  test(`Accounts row contents align before and after selection at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    const fixture = await openAccounts(page);
+    await connectSecondAccount(page, fixture);
+    const rows = page.locator(".account-table tbody > tr");
+    await expect(rows).toHaveCount(2);
+    const positions = () => rows.evaluateAll((elements) => elements.map((row) => {
+      const left = row.getBoundingClientRect().left;
+      const selectors = [".avatar", ".identity strong", ".identity small", "[data-label='Authorization'] .badge", ".account-choice", ".remove-account"];
+      const coordinates = selectors.map((selector) => row.querySelector(selector)!.getBoundingClientRect().left - left);
+      const range = document.createRange();
+      range.selectNodeContents(row.querySelector("[data-label='Authenticated']")!);
+      return [...coordinates, range.getBoundingClientRect().left - left];
+    }));
+    const before = await positions();
+    for (const [index, x] of before[0]!.entries()) {
+      expect(Math.abs(x - before[1]![index]!), `column content ${index} is aligned`).toBeLessThanOrEqual(1);
+    }
+    await expect(page.locator(".account-table tr:not(.current-row) > td:first-child"))
+      .toHaveCSS("border-left-color", "rgba(0, 0, 0, 0)");
+    await expect(page.locator(".account-table tr.current-row > td:first-child"))
+      .toHaveCSS("border-left-color", "rgb(38, 119, 72)");
+    await page.getByRole("button", { name: "Use this account", exact: true }).click();
+    await expect(rows.nth(1).getByRole("button", { name: "In use", exact: true })).toBeDisabled();
+    const after = await positions();
+    for (const [index, x] of after[0]!.entries()) {
+      expect(Math.abs(x - after[1]![index]!), `column content ${index} remains aligned`).toBeLessThanOrEqual(1);
+      expect(Math.abs(x - before[0]![index]!), `selection does not move column content ${index}`).toBeLessThanOrEqual(1);
+    }
+    await page.locator(".account-table").screenshot({ path: testInfo.outputPath(`account-row-alignment-${width}.png`) });
+  });
+}
+
 for (const width of [1440, 390]) {
   test(`Accounts heading and equal-sized selection controls at ${width}px`, async ({ page }, testInfo) => {
     await page.setViewportSize({ width, height: 900 });

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -247,8 +247,9 @@ th:last-child, td:last-child { padding-right: 0; }
 .account-table { min-width: 780px; }
 .model-table { min-width: 980px; }
 tr.current-row { background: var(--soft); }
-tr.current-row > td:first-child { padding-left: 12px; border-left: 2px solid var(--ink); }
-tr.current-row > td:last-child { padding-right: 12px; }
+tr.current-row > td:first-child, .account-table tr > td:first-child { padding-left: 12px; border-left: 2px solid var(--ink); }
+tr.current-row > td:last-child, .account-table tr > td:last-child { padding-right: 12px; }
+.account-table tr:not(.current-row) > td:first-child { border-left-color: transparent; }
 .identity { display: flex; align-items: center; gap: 12px; min-width: 0; }
 .avatar {
   display: grid;
@@ -395,11 +396,11 @@ tr.current-row > td:last-child { padding-right: 12px; }
     letter-spacing: .5px;
     text-transform: uppercase;
   }
-  .account-table tr.current-row > td:first-child {
+  .account-table tr > td:first-child {
     padding-left: 10px;
     border-left: 2px solid var(--ink);
   }
-  .account-table tr.current-row > td:not(:first-child) { padding-left: 12px; }
+  .account-table tr > td:not(:first-child) { padding-left: 12px; }
   .account-table .row-actions { justify-content: flex-start; }
 }
 


### PR DESCRIPTION
## Summary

Closes #162

Give unselected Accounts rows the same interior gutters as the existing In use row. Reserve the leading border space transparently for unselected rows, retaining the selected background and green marker. Apply the same rule to responsive cards so selection changes do not move row contents.

Only Accounts-scoped CSS matching and browser regression tests change. Existing Models declarations, fonts, control sizes, component scripts and backend/API behavior remain unchanged. The user's personal screenshot/account data is not committed or published; visual evidence uses synthetic fixtures.

## Validation

- Regression-first tests reproduced 13px desktop / 12px card misalignment, then passed after the CSS fix.
- Four widths (1440/1100/390/320px) verify seven horizontal content anchors, before/after selection, and selected-only marker color. Synthetic table screenshots inspected.
- `npm run e2e -- --workers=4`: **81 passed**.
- `npm test`: **1026 passed, 4 existing skips**.
- Typecheck, lint, build, scoped browser-spec lint and whitespace checks passed; 53 fixture entries verified. All 90 prior capture hashes remain unchanged.
- No live authentication/inference, official SDK suite or user-daemon restart.

## Review

Independent Standards and Spec reviews found **no must-fix or safe-to-defer findings**.

## Existing CI follow-up

- #157: additional macOS x64 checkpoint timing instability observed. One initial repetition reached12.98ms; one same-commit rerun passed all three at1.33/1.84/1.25ms. All seven checks now pass. No runtime, benchmark, fixture or threshold was changed. The existing investigation records affected areas and acceptance criteria; no failing gate is bypassed for this CSS-only fix.
