### PR TITLE
Show cumulative usage windows and polish Admin refresh controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Admin security defaults:
 - bounded, replayable SSE monitoring with no WebSocket or remote Admin access
 
 The five views are Overview, Accounts, Models, Configuration, and Events.
+Overview shows cumulative usage for the last 24 hours, 7 days, and 28 days, using the gateway's clock
+and retained hourly Usage Buckets. These overlapping windows include only available data; shortening
+retention or clearing data cannot be undone by refreshing. Cache tokens are read + write tokens already included in input.
+Refresh reloads Overview statistics or the Accounts list; Accounts also clears old transient feedback.
+Feedback does not have a timed auto-dismiss. Models Refresh fetches a new account catalog; its generation
+and credential numbers are internal versions, and fetched is the last successful catalog-fetch time.
 Responses History is managed by the backend independently of the Admin UI; there is no dedicated history page.
 The Accounts view checks an active device authorization automatically at GitHub's required interval. Keep that
 view open until it reports completion; closing or leaving it stops browser polling, and no device code or token is

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -71,6 +71,11 @@ const RuntimeConfigUpdateSchema = Type.Object({
   config: RuntimeConfigSchema,
 }, { additionalProperties: false });
 
+const USAGE_WINDOWS_MS = new Map([
+  ["24h", 86_400_000],
+  ["7d", 7 * 86_400_000],
+  ["28d", 28 * 86_400_000],
+]);
 const PROTOCOLS = new Set(["openai_chat", "openai_responses_unknown", "openai_responses_native", "openai_responses_bridge", "anthropic", "ollama"]);
 const OUTCOMES = new Set(["success", "client_error", "authentication_error", "overloaded", "upstream_error", "timeout", "aborted", "internal_error"]);
 const EVENT_KINDS = new Set([
@@ -456,7 +461,7 @@ const ROUTES = new Map<string, Omit<MatchedRoute, "parameter">>([
   route("GET", "/admin/api/v1/auth/session", "session"),
   route("POST", "/admin/api/v1/auth/logout", "logout", false, true),
   route("GET", "/admin/api/v1/status", "status"),
-  route("GET", "/admin/api/v1/usage", "usage", false, false, ["from", "to", "limit", "cursor", "accountId", "protocol", "resolvedModel", "outcome"]),
+  route("GET", "/admin/api/v1/usage", "usage", false, false, ["window", "from", "to", "limit", "cursor", "accountId", "protocol", "resolvedModel", "outcome"]),
   route("GET", "/admin/api/v1/accounts", "accounts"),
   route("POST", "/admin/api/v1/device-flows", "deviceStart", true, true),
   route("PUT", "/admin/api/v1/accounts/default", "accountDefault", true, true),
@@ -615,7 +620,12 @@ function optionalQuery(url: URL, key: string): string | null {
 }
 
 function parseUsageQuery(url: URL, now: number): AdminUsageQuery {
-  const fromMs = parseUtc(url, "from") ?? now - 86_400_000;
+  const window = optionalQuery(url, "window");
+  const windowMs = window === null ? 86_400_000 : USAGE_WINDOWS_MS.get(window);
+  if (windowMs === undefined || (window !== null && (url.searchParams.has("from") || url.searchParams.has("to")))) {
+    throw new AdminApiError("validation_failed");
+  }
+  const fromMs = parseUtc(url, "from") ?? now - windowMs;
   const toMs = parseUtc(url, "to") ?? now;
   if (fromMs >= toMs || fromMs < now - 90 * 86_400_000 || toMs > now) {
     throw new AdminApiError("validation_failed");

--- a/tests/contract/admin_usage.test.ts
+++ b/tests/contract/admin_usage.test.ts
@@ -1,0 +1,207 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, onTestFinished } from "vitest";
+import { createAdminModule } from "../../src/admin/routes.js";
+import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
+import { parseStartupConfig } from "../../src/config/startup_config.js";
+import { createGateway } from "../../src/gateway/create_gateway.js";
+import { closeDatabase, openDatabase } from "../../src/persistence/database.js";
+import { embedMigration } from "../../src/persistence/migrations.js";
+import { migration as runtimeConfigMigration } from "../../src/persistence/migrations/001_runtime_config.js";
+import { migration as telemetryMigration } from "../../src/persistence/migrations/020_telemetry.js";
+import { SqliteAdminTelemetry, type AdminUsagePage } from "../../src/telemetry/admin.js";
+import { TelemetryRecorder, type UsageUpdate } from "../../src/telemetry/recorder.js";
+import { adminDependencies, login } from "./admin_test_harness.js";
+
+const ORIGIN = "http://127.0.0.1:31400";
+const NOW = Date.parse("2027-01-29T12:00:00.000Z");
+const ZERO_TOTALS = {
+  requestCount: 0, errorCount: 0, inputTokens: 0, outputTokens: 0,
+  cacheTokens: 0, latencySumMs: 0, latencyMaxMs: 0,
+};
+
+function usage(at: string, requestCount: number, overrides: Partial<UsageUpdate> = {}): UsageUpdate {
+  return {
+    occurredAtMs: Date.parse(at), accountId: "github.com/42", protocol: "openai_chat",
+    resolvedModel: "gpt-test", outcome: "upstream_error", requestCount, errorCount: 1,
+    inputTokens: 10, outputTokens: 5, cacheTokens: 7, latencyMs: 4,
+    ...overrides,
+  };
+}
+
+const BOUNDARY_USAGE = [
+  usage("2027-01-01T11:59:59.999Z", 64),
+  usage("2027-01-01T12:00:00.000Z", 32),
+  usage("2027-01-22T11:59:59.999Z", 16),
+  usage("2027-01-22T12:00:00.000Z", 8),
+  usage("2027-01-28T11:59:59.999Z", 4),
+  usage("2027-01-28T12:00:00.000Z", 2),
+  usage("2027-01-29T11:59:59.999Z", 1),
+  usage("2027-01-29T12:00:00.000Z", 128),
+  usage("2027-01-29T13:00:00.000Z", 256),
+];
+
+async function createHarness(updates: readonly UsageUpdate[] = [], now = NOW) {
+  const directory = await mkdtemp(path.join(tmpdir(), "ghcg-admin-usage-"));
+  const db = openDatabase({
+    path: path.join(directory, "state.db"),
+    migrations: [embedMigration(runtimeConfigMigration), embedMigration(telemetryMigration)],
+    nowMs: () => now,
+  });
+  const recorder = new TelemetryRecorder(db, () => now);
+  for (const update of updates) recorder.recordUsage(update);
+  await recorder.flush();
+  let token = 0;
+  const admin = createAdminModule({
+    ...adminDependencies({ value: now }),
+    telemetry: new SqliteAdminTelemetry(db, { recorder }),
+    createToken: () => `usage-token-${++token}`,
+  });
+  const gateway = await createGateway({
+    startup: parseStartupConfig([], {}, { homedir: directory }),
+    runtime: defaultRuntimeConfigSnapshot(),
+  }, [], { admin, createRequestId: () => "req_admin_usage" });
+  onTestFinished(async () => {
+    await gateway.close();
+    closeDatabase(db);
+    await rm(directory, { recursive: true, force: true });
+  });
+  const session = await login(gateway, admin);
+  const get = (query: string, cookie = session.cookie) => gateway.fetch(new Request(
+    `${ORIGIN}/admin/api/v1/usage?${query}`, { headers: { cookie } },
+  ));
+  return {
+    get,
+    async read(query: string): Promise<AdminUsagePage> {
+      const response = await get(query);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
+      const body = await response.json() as { data: AdminUsagePage };
+      expect(Object.keys(body)).toEqual(["data"]);
+      expect(Object.keys(body.data).sort()).toEqual(["items", "nextCursor", "totals"]);
+      return body.data;
+    },
+  };
+}
+
+describe("Admin usage HTTP windows", () => {
+  it.each([
+    ["", [2, 1], { requestCount: 3, errorCount: 2, inputTokens: 20, outputTokens: 10, cacheTokens: 14, latencySumMs: 8, latencyMaxMs: 4 }],
+    ["window=24h", [2, 1], { requestCount: 3, errorCount: 2, inputTokens: 20, outputTokens: 10, cacheTokens: 14, latencySumMs: 8, latencyMaxMs: 4 }],
+    ["window=7d", [8, 4, 2, 1], { requestCount: 15, errorCount: 4, inputTokens: 40, outputTokens: 20, cacheTokens: 28, latencySumMs: 16, latencyMaxMs: 4 }],
+    ["window=28d", [32, 16, 8, 4, 2, 1], { requestCount: 63, errorCount: 6, inputTokens: 60, outputTokens: 30, cacheTokens: 42, latencySumMs: 24, latencyMaxMs: 4 }],
+  ] as const)("uses server time and inclusive/exclusive hourly boundaries for '%s'", async (query, counts, totals) => {
+    const harness = await createHarness(BOUNDARY_USAGE);
+    const page = await harness.read(query);
+    expect(page.items.map((item) => item.requestCount)).toEqual(counts);
+    expect(page.nextCursor).toBeNull();
+    expect(page.totals).toEqual(totals);
+  });
+
+  it("preserves bucket-start comparisons when server time is between hours", async () => {
+    const harness = await createHarness([
+      usage("2027-01-28T12:45:00.000Z", 100),
+      usage("2027-01-28T13:00:00.000Z", 2),
+      usage("2027-01-29T12:15:00.000Z", 3),
+      usage("2027-01-29T13:00:00.000Z", 100),
+    ], Date.parse("2027-01-29T12:30:00.000Z"));
+    for (const query of ["", "window=24h"]) {
+      const page = await harness.read(query);
+      expect(page.items.map((item) => item.utcHour)).toEqual([
+        "2027-01-28T13:00:00.000Z", "2027-01-29T12:00:00.000Z",
+      ]);
+      expect(page.totals).toEqual({
+        requestCount: 5, errorCount: 2, inputTokens: 20, outputTokens: 10,
+        cacheTokens: 14, latencySumMs: 8, latencyMaxMs: 4,
+      });
+    }
+  });
+
+  it("returns zero totals for empty retained data in every window", async () => {
+    const harness = await createHarness();
+    for (const query of ["", "window=24h", "window=7d", "window=28d"]) {
+      expect(await harness.read(query)).toEqual({ items: [], nextCursor: null, totals: ZERO_TOTALS });
+    }
+  });
+
+  it("totals all filtered buckets independently of limit and cursor", async () => {
+    const harness = await createHarness([
+      usage("2027-01-28T12:00:00.000Z", 2),
+      usage("2027-01-29T11:00:00.000Z", 3),
+      usage("2027-01-28T12:00:00.000Z", 100, { accountId: "github.com/99" }),
+      usage("2027-01-28T12:00:00.000Z", 100, { protocol: "anthropic" }),
+      usage("2027-01-28T12:00:00.000Z", 100, { resolvedModel: "other-model" }),
+      usage("2027-01-28T12:00:00.000Z", 100, { outcome: "success", errorCount: 0 }),
+    ]);
+    const query = "window=7d&limit=1&accountId=github.com%2F42&protocol=openai_chat&resolvedModel=gpt-test&outcome=upstream_error";
+    const totals = {
+      requestCount: 5, errorCount: 2, inputTokens: 20, outputTokens: 10,
+      cacheTokens: 14, latencySumMs: 8, latencyMaxMs: 4,
+    };
+    const first = await harness.read(query);
+    expect(first.items).toEqual([{
+      utcHour: "2027-01-28T12:00:00.000Z", accountId: "github.com/42", protocol: "openai_chat",
+      resolvedModel: "gpt-test", outcome: "upstream_error", requestCount: 2, errorCount: 1,
+      inputTokens: 10, outputTokens: 5, cacheTokens: 7, latencySumMs: 4, latencyMaxMs: 4,
+    }]);
+    expect(first.nextCursor).toMatch(/^[A-Za-z0-9_-]+$/u);
+    expect(first.totals).toEqual(totals);
+    const second = await harness.read(`${query}&cursor=${first.nextCursor}`);
+    expect(second.items).toHaveLength(1);
+    expect(second.items[0]).toMatchObject({ utcHour: "2027-01-29T11:00:00.000Z", requestCount: 3 });
+    expect(second.nextCursor).toBeNull();
+    expect(second.totals).toEqual(totals);
+    expect(await harness.read("window=28d&accountId=github.com%2Fmissing")).toEqual({
+      items: [], nextCursor: null, totals: ZERO_TOTALS,
+    });
+  });
+
+  it("preserves explicit from/to defaults and the inclusive 90-day lower bound", async () => {
+    const harness = await createHarness(BOUNDARY_USAGE);
+    for (const [query, counts] of [
+      ["from=2027-01-22T12:00:00.000Z", [8, 4, 2, 1]],
+      ["to=2027-01-29T11:00:00.000Z", [2]],
+      ["from=2027-01-22T12:00:00.000Z&to=2027-01-28T12:00:00.000Z", [8, 4]],
+      ["from=2026-10-31T12:00:00.000Z", [64, 32, 16, 8, 4, 2, 1]],
+    ] as const) {
+      expect((await harness.read(query)).items.map((item) => item.requestCount)).toEqual(counts);
+    }
+  });
+
+  it("rejects invalid, duplicate, conflicting, and out-of-bounds queries without echoing input", async () => {
+    const harness = await createHarness();
+    for (const query of [
+      "window", "window=", "window=1d", "window=90d", "window=24H", "window=%2024h", "window=private-input",
+      "window=24h&window=24h", "window=7d&window=28d", "window=24h&%77indow=7d",
+      "window=24h&from=2027-01-28T12:00:00.000Z", "window=7d&to=2027-01-29T12:00:00.000Z",
+      "window=28d&from=2027-01-01T12:00:00.000Z&to=2027-01-29T12:00:00.000Z",
+      "window=24h&from=", "window=24h&to=", "window=24h&from=invalid",
+      "from=2026-10-31T11:59:59.999Z", "to=2027-01-29T12:00:00.001Z",
+      "from=2027-01-29T12:00:00.000Z", "from=2027-01-29T13:00:00.000Z",
+      "window=24h&limit=0", "window=7d&limit=501", "window=28d&limit=1&limit=2",
+      "window=24h&cursor=bad", "window=24h&protocol=invalid", "window=7d&outcome=invalid",
+      "window=28d&accountId=", "window=28d&resolvedModel=", "window=7d&now=2027-01-01T00:00:00.000Z",
+    ]) {
+      const response = await harness.get(query);
+      expect(response.status, query).toBe(400);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(await response.json()).toEqual({
+        error: { code: "validation_failed", message: "validation failed", requestId: "req_admin_usage" },
+      });
+    }
+  });
+
+  it("requires an Admin Session for every relative window", async () => {
+    const harness = await createHarness(BOUNDARY_USAGE);
+    for (const query of ["", "window=24h", "window=7d", "window=28d"]) {
+      const response = await harness.get(query, "");
+      expect(response.status).toBe(401);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(await response.json()).toEqual({
+        error: { code: "unauthenticated", message: "unauthenticated", requestId: "req_admin_usage" },
+      });
+    }
+  });
+});

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -284,7 +284,7 @@ test("model-refresh-invalidates-preference", async ({ page }) => {
   await page.getByRole("button", { name: "Models" }).click();
   await expect(page.getByRole("heading", { name: "Models", exact: true })).toBeFocused();
   await expect(page.getByText("gpt-alpha", { exact: true })).toBeVisible();
-  await page.getByRole("button", { name: "Refresh catalog" }).click();
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Preferred model unavailable" })).toBeVisible();
   fixture.state.conflictModel = true;
   await page.getByRole("button", { name: "Set preferred" }).click();

--- a/tests/e2e/admin_models_polish.spec.ts
+++ b/tests/e2e/admin_models_polish.spec.ts
@@ -16,6 +16,50 @@ async function openModels(page: Page, configure?: (fixture: AdminFixture) => voi
   return fixture;
 }
 
+for (const width of [1440, 1100, 390, 320]) {
+  test(`Models account diagnostics align or wrap without clipping at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    await openModels(page);
+    const toolbar = page.locator(".toolbar").first();
+    const label = (await toolbar.locator("label").boundingBox())!;
+    const metadata = toolbar.locator(".subtle");
+    await expect(metadata).toContainText("Generation 1 · credential 1 · fetched");
+    const box = (await metadata.boundingBox())!;
+    if (width === 1440) {
+      expect(Math.abs(label.y + label.height / 2 - box.y - box.height / 2)).toBeLessThanOrEqual(1);
+    }
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(width);
+    expect(await metadata.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
+    await toolbar.screenshot({ path: testInfo.outputPath(`model-account-toolbar-${width}.png`) });
+  });
+}
+
+test("Models hides the previous account diagnostics while the next catalog loads", async ({ page }) => {
+  const fixture = await openModels(page, (fixture) => {
+    const first = fixture.state.accounts.items[0]!;
+    fixture.state.accounts = { ...fixture.state.accounts, items: [first, {
+      ...first, accountId: "ghes:2", host: "github.example.test", login: "enterprise", displayName: "Enterprise Admin",
+    }] };
+  });
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => { release = resolve; });
+  await page.route(/\/models\?accountId=ghes%3A2$/u, async (route) => {
+    await pending;
+    await route.fulfill({ json: { data: { ...fixture.state.models,
+      accountId: "ghes:2", catalogGeneration: 9, credentialGeneration: 4,
+    } } });
+  });
+  const metadata = page.locator(".toolbar").first().locator(".subtle");
+  try {
+    await page.getByLabel("Account", { exact: true }).selectOption("ghes:2");
+    await expect(page.getByText("Loading model catalog...", { exact: true })).toBeVisible();
+    await expect(metadata).toHaveCount(0);
+  } finally { release(); }
+  await expect(metadata).toContainText("Generation 9 · credential 4 · fetched");
+});
+
 function metadataCases(fixture: AdminFixture): void {
   const base = fixture.state.models.items[0]!;
   fixture.state.models = {
@@ -196,7 +240,7 @@ test("models refresh clears stale success, stays quiet on success, and retains e
   const fixture = await openModels(page);
   await page.locator("tbody[data-model-id=\"claude-beta\"]").getByRole("button", { name: "Set preferred" }).click();
   await expect(page.getByRole("status")).toHaveText("claude-beta is now preferred.");
-  const refresh = page.getByRole("button", { name: "Refresh catalog" });
+  const refresh = page.getByRole("button", { name: "Refresh", exact: true });
   await page.route("**/admin/api/v1/models/refresh", async (route) => {
     await route.fulfill({ status: 200, json: { data: fixture.state.models } });
   }, { times: 1 });

--- a/tests/e2e/admin_typography.spec.ts
+++ b/tests/e2e/admin_typography.spec.ts
@@ -77,7 +77,8 @@ for (const width of [1440, 1100, 900, 851, 850, 601, 600, 390, 320]) {
       await expect(title).toBeFocused();
       expect(await title.evaluate((element) => Number.parseFloat(getComputedStyle(element).fontSize))).toBeGreaterThanOrEqual(32);
       if (view === "Overview") {
-        await expect(page.locator(".stat-row")).toBeVisible();
+        await expect(page.locator(".stat-row")).toHaveCount(3);
+        for (const row of await page.locator(".stat-row").all()) await expect(row).toBeVisible();
         await expect(page.locator(".hero-metrics article > strong").first()).toHaveCSS("font-size", "32px");
         await expect(page.locator(".stat-row strong").first()).toHaveCSS("font-size", "20px");
       }

--- a/tests/e2e/admin_usage_refresh.spec.ts
+++ b/tests/e2e/admin_usage_refresh.spec.ts
@@ -13,11 +13,26 @@ async function openAccounts(page: Page): Promise<AdminFixture> {
   return fixture;
 }
 
+test("Overview, Accounts and Models use the same black Refresh control", async ({ page }) => {
+  await installAdminFixture(page);
+  await page.goto("/admin/#bootstrap_token=refresh-controls");
+  for (const view of ["Overview", "Accounts", "Models"]) {
+    await page.getByRole("navigation").getByRole("button", { name: view, exact: true }).click();
+    const refresh = page.getByRole("button", { name: "Refresh", exact: true });
+    await expect(refresh).toBeEnabled();
+    await expect(refresh).toHaveCSS("background-color", "rgb(32, 29, 29)");
+    await expect(refresh).toHaveCSS("color", "rgb(253, 252, 252)");
+    await expect(page.getByRole("button", { name: "Refresh catalog", exact: true })).toHaveCount(0);
+  }
+});
+
 test("manual Accounts refresh dismisses a success notice without erasing the original action result", async ({ page }) => {
   const fixture = await openAccounts(page);
   page.once("dialog", (dialog) => dialog.accept());
   await page.getByRole("button", { name: "Remove", exact: true }).click();
   await expect(page.getByRole("heading", { name: "No accounts connected" })).toBeVisible();
+  await expect(page.getByRole("status")).toHaveText("Account removed.");
+  await page.clock.fastForward(60_000);
   await expect(page.getByRole("status")).toHaveText("Account removed.");
   fixture.state.accountsDelayMs = 300;
   await page.getByRole("button", { name: "Refresh", exact: true }).click();
@@ -87,6 +102,136 @@ for (const outcome of ["resolve", "reject"] as const) {
   });
 }
 
+test("Overview shows three cumulative windows from totals and refreshes without hiding missing data", async ({ page }) => {
+  await page.clock.install({ time: Date.parse("2040-01-01T00:00:00Z") });
+  await installAdminFixture(page);
+  const totals = {
+    "24h": { requestCount: 42, errorCount: 2, inputTokens: 2000000, outputTokens: 300000, cacheTokens: 987654 },
+    "7d": { requestCount: 99, errorCount: 4, inputTokens: 4000000, outputTokens: 500000, cacheTokens: 1987654 },
+    "28d": { requestCount: 500, errorCount: 9, inputTokens: 9000000, outputTokens: 800000, cacheTokens: 2987654 },
+  };
+  const queries: URLSearchParams[] = [];
+  let missingWeek = false;
+  let empty = false;
+  await page.route(/\/admin\/api\/v1\/usage(?:\?|$)/u, async (route) => {
+    const query = new URL(route.request().url()).searchParams;
+    queries.push(query);
+    const window = query.get("window") as keyof typeof totals;
+    if (!(window in totals) || (missingWeek && window === "7d")) {
+      await route.fulfill({ status: 503, json: { error: { code: "upstream_unavailable", requestId: "synthetic" } } });
+      return;
+    }
+    const pageData = usage(3);
+    await route.fulfill({ json: { data: { ...pageData, totals: { ...pageData.totals,
+      ...(empty ? { requestCount: 0, errorCount: 0, inputTokens: 0, outputTokens: 0, cacheTokens: 0 } : totals[window]),
+    } } } });
+  });
+  await page.goto("/admin/#bootstrap_token=usage-windows");
+  const expectations = [
+    ["Last 24 hours", ["42", "2", "2,000,000", "300,000", "987,654"]],
+    ["Last 7 days", ["99", "4", "4,000,000", "500,000", "1,987,654"]],
+    ["Last 28 days", ["500", "9", "9,000,000", "800,000", "2,987,654"]],
+  ] as const;
+  for (const [label, values] of expectations) {
+    await expect(page.getByRole("region", { name: label, exact: true }).locator(".stat-row strong")).toHaveText([...values]);
+  }
+  expect(queries.map((query) => query.get("window")).sort()).toEqual(["24h", "28d", "7d"]);
+  for (const query of queries) {
+    expect(query.has("from") || query.has("to") || query.has("cursor")).toBe(false);
+    expect(query.get("limit")).toBe("1");
+  }
+  await expect(page.getByText("Only retained hourly usage buckets are included.", { exact: true })).toBeVisible();
+  missingWeek = true;
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText("Overview unavailable");
+  await expect(page.getByRole("region", { name: "Last 7 days", exact: true })).toHaveCount(0);
+  missingWeek = false;
+  empty = true;
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  for (const [label] of expectations) {
+    await expect(page.getByRole("region", { name: label, exact: true }).locator(".stat-row strong"))
+      .toHaveText(["0", "0", "0", "0", "0"]);
+  }
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  expect(queries).toHaveLength(9);
+});
+
+test("Overview waits for every usage window before enabling another refresh", async ({ page }) => {
+  await installAdminFixture(page);
+  await page.goto("/admin/#bootstrap_token=usage-pending");
+  const refresh = page.getByRole("button", { name: "Refresh", exact: true });
+  await expect(refresh).toBeEnabled();
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => { release = resolve; });
+  await page.route(/\/usage\?limit=1&window=28d$/u, async (route) => {
+    await pending;
+    await route.fulfill({ json: { data: usage(3) } });
+  }, { times: 1 });
+  try {
+    await refresh.click();
+    await expect(page.getByLabel("Loading overview", { exact: true })).toBeVisible();
+    await expect(refresh).toBeDisabled();
+    await expect(page.getByRole("region", { name: "Last 24 hours", exact: true })).toHaveCount(0);
+  } finally { release(); }
+  await expect(refresh).toBeEnabled();
+  await expect(page.getByRole("region", { name: "Last 28 days", exact: true }).locator(".stat-row strong"))
+    .toHaveText(["42", "2", "2,000,000", "300,000", "3"]);
+});
+
+for (const [exit, endpoint] of [
+  ["failure", "/status"], ["failure", "/usage?limit=1&window=28d"],
+  ["navigation", "/status"], ["navigation", "/usage?limit=1&window=28d"],
+] as const) {
+  test(`Overview cancels unfinished ${endpoint} on ${exit} without blocking later loads`, async ({ page }) => {
+    const fixture = await installAdminFixture(page);
+    await page.goto("/admin/#bootstrap_token=usage-cancellation");
+    const refresh = page.getByRole("button", { name: "Refresh", exact: true });
+    await expect(refresh).toBeEnabled();
+    let release!: () => void;
+    let started!: () => void;
+    let finished!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    const requestStarted = new Promise<void>((resolve) => { started = resolve; });
+    const requestFinished = new Promise<void>((resolve) => { finished = resolve; });
+    let aborted = 0;
+    page.on("requestfailed", (request) => {
+      if (request.url().endsWith(endpoint)) aborted += 1;
+    });
+    await page.route((url) => url.pathname + url.search === `/admin/api/v1${endpoint}`, async (route) => {
+      started();
+      await pending;
+      try {
+        await route.fulfill({ json: { data: endpoint === "/status" ? fixture.state.status : usage(987654) } });
+      } finally { finished(); }
+    }, { times: 1 });
+    if (exit === "failure") {
+      await page.route(/\/usage\?limit=1&window=7d$/u, async (route) => {
+        await requestStarted;
+        await route.fulfill({ status: 503, json: { error: { code: "upstream_unavailable", requestId: "synthetic" } } });
+      }, { times: 1 });
+    }
+    try {
+      await refresh.click();
+      await requestStarted;
+      if (exit === "failure") {
+        await expect(page.getByRole("alert")).toContainText("upstream unavailable");
+      } else {
+        await page.getByRole("navigation").getByRole("button", { name: "Accounts", exact: true }).click();
+        await expect(page.getByText("Octo Admin", { exact: true })).toBeVisible();
+      }
+      await expect.poll(() => aborted).toBe(1);
+      if (exit === "failure") await refresh.click();
+      else await page.getByRole("navigation").getByRole("button", { name: "Overview", exact: true }).click();
+      const stats = page.getByRole("region", { name: "Last 28 days", exact: true }).locator(".stat-row strong");
+      await expect(stats).toHaveText(["42", "2", "12,000", "3,400", "800"]);
+      release();
+      await requestFinished;
+      await expect(stats).toHaveText(["42", "2", "12,000", "3,400", "800"]);
+      await expect(page.getByRole("alert")).toHaveCount(0);
+    } finally { release(); }
+  });
+}
+
 function usage(cacheTokens: number): AdminUsagePage {
   return {
     items: [{ utcHour: "2026-09-03T12:00:00.000Z", accountId: "github:1", protocol: "openai_chat",
@@ -105,7 +250,7 @@ for (const width of [1440, 900, 390]) {
       const fixture = await installAdminFixture(page);
       await page.route(/\/admin\/api\/v1\/usage(?:\?|$)/u, (route) => route.fulfill({ json: { data: usage(cacheTokens) } }));
       await page.goto("/admin/#bootstrap_token=usage-fixture");
-      const stats = page.locator(".stat-row");
+      const stats = page.getByRole("region", { name: "Last 24 hours", exact: true }).locator(".stat-row");
       await expect(stats.locator(":scope > div")).toHaveCount(5);
       const cache = stats.locator("div").filter({ has: page.getByText("Cache tokens", { exact: true }) });
       await expect(cache.locator("strong")).toHaveText(cacheTokens.toLocaleString("en-US"));

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -45,8 +45,15 @@ export class AdminClient {
     return session;
   }
 
-  status(): Promise<AdminStatus> { return this.request("/status"); }
-  usage(): Promise<AdminUsagePage> { return this.request("/usage?limit=100"); }
+  status(signal?: AbortSignal): Promise<AdminStatus> {
+    return this.request("/status", signal === undefined ? undefined : { signal });
+  }
+  usage(window?: "24h" | "7d" | "28d", signal?: AbortSignal): Promise<AdminUsagePage> {
+    return this.request(
+      window === undefined ? "/usage?limit=100" : `/usage?limit=1&window=${window}`,
+      signal === undefined ? undefined : { signal },
+    );
+  }
   accounts(): Promise<AdminAccounts> { return this.request("/accounts"); }
   models(accountId?: string): Promise<AdminModels> {
     return this.request(`/models${accountId === undefined ? "" : `?accountId=${encodeURIComponent(accountId)}`}`);

--- a/web/src/views/Accounts.svelte
+++ b/web/src/views/Accounts.svelte
@@ -333,7 +333,7 @@
     <h1 tabindex="-1">Accounts</h1>
     <p>Connect GitHub.com or GHES and choose the identity used by new gateway requests.</p>
   </div>
-  <button onclick={() => void refresh()}>Refresh</button>
+  <button class="primary" onclick={() => void refresh()}>Refresh</button>
 </header>
 
 {#if message}

--- a/web/src/views/Models.svelte
+++ b/web/src/views/Models.svelte
@@ -266,19 +266,19 @@
     <p>Inspect the account catalog and native interface metadata, or configure explicit overrides.</p>
   </div>
   <button class="primary" onclick={refresh} disabled={!accountId || busy === "refresh"}>
-    {busy === "refresh" ? "Refreshing..." : "Refresh catalog"}
+    {busy === "refresh" ? "Refreshing..." : "Refresh"}
   </button>
 </header>
 
-<section class="toolbar">
+<section class="toolbar account-toolbar">
   <label for="model-account">Account</label>
   <select id="model-account" bind:value={accountId} onchange={() => void load()}>
     {#each accounts?.items.filter((account) => account.state === "active") ?? [] as account (account.accountId)}
       <option value={account.accountId}>{account.login ?? account.host} · {account.host}</option>
     {/each}
   </select>
-  {#if data}
-    <span class="subtle">
+  {#if data && data.accountId === accountId}
+    <span class="subtle" title="Catalog cache version, account credential version and last successful catalog fetch time.">
       Generation {data.catalogGeneration} · credential {data.credentialGeneration} · fetched {new Date(data.fetchedAt).toLocaleString()}
     </span>
   {/if}
@@ -523,6 +523,9 @@
 {/if}
 
 <style>
+  .account-toolbar { align-items: center; }
+  .account-toolbar label { margin-bottom: 0; }
+
   .configured-model-form {
     display: grid;
     grid-template-columns: max-content minmax(0, 260px) max-content;

--- a/web/src/views/Overview.svelte
+++ b/web/src/views/Overview.svelte
@@ -8,23 +8,54 @@
     liveStatus,
     pageNumber,
   }: { client: AdminClient; liveStatus: AdminStatus | null; pageNumber: string } = $props();
+  const windows = [
+    { key: "24h", label: "Last 24 hours" },
+    { key: "7d", label: "Last 7 days" },
+    { key: "28d", label: "Last 28 days" },
+  ] as const;
   let status: AdminStatus | null = $state(null);
-  let usage: AdminUsagePage | null = $state(null);
+  let usage: { label: string; totals: AdminUsagePage["totals"] }[] | null = $state(null);
   let loading = $state(true);
   let failure = $state("");
   let current = $derived(liveStatus ?? status);
 
-  onMount(load);
+  let loadAbort: AbortController | null = null;
+  let disposed = false;
+
+  onMount(() => {
+    void load();
+    return () => {
+      disposed = true;
+      loadAbort?.abort();
+    };
+  });
 
   async function load(): Promise<void> {
+    if (loadAbort !== null || disposed) return;
+    const controller = new AbortController();
+    loadAbort = controller;
     loading = true;
     failure = "";
+    const requests = [
+      client.status(controller.signal),
+      ...windows.map(async (window) => ({
+        label: window.label,
+        totals: (await client.usage(window.key, controller.signal)).totals,
+      })),
+    ] as const;
     try {
-      [status, usage] = await Promise.all([client.status(), client.usage()]);
+      const [loadedStatus, ...loadedUsage] = await Promise.all(requests);
+      if (!disposed) {
+        status = loadedStatus;
+        usage = loadedUsage;
+      }
     } catch (error: unknown) {
-      failure = errorMessage(error);
+      controller.abort();
+      await Promise.allSettled(requests);
+      if (!disposed) failure = errorMessage(error);
     } finally {
-      loading = false;
+      loadAbort = null;
+      if (!disposed) loading = false;
     }
   }
 
@@ -37,7 +68,7 @@
     <h1 tabindex="-1">Overview</h1>
     <p>Health, usage, performance and bounded storage from the running gateway.</p>
   </div>
-  <button onclick={load}>Refresh</button>
+  <button class="primary" onclick={load} disabled={loading}>Refresh</button>
 </header>
 
 {#if loading}
@@ -77,15 +108,20 @@
   <section class="section">
     <div class="section-heading">
       <h2><span class="section-number">[01]</span>Usage ledger</h2>
-      <span class="chip">Last 24 hours</span>
     </div>
-    <div class="stat-row">
-      <div><span>Requests</span><strong>{number(usage.totals.requestCount)}</strong></div>
-      <div><span>Errors</span><strong>{number(usage.totals.errorCount)}</strong></div>
-      <div><span>Input tokens</span><strong>{number(usage.totals.inputTokens)}</strong></div>
-      <div><span>Output tokens</span><strong>{number(usage.totals.outputTokens)}</strong></div>
-      <div><span title="Cache read + write tokens, already included in input tokens">Cache tokens</span><strong>{number(usage.totals.cacheTokens)}</strong></div>
-    </div>
+    <p class="usage-note">Only retained hourly usage buckets are included.</p>
+    {#each usage as window (window.label)}
+      <section class="usage-window" aria-label={window.label}>
+        <h3>{window.label}</h3>
+        <div class="stat-row">
+          <div><span>Requests</span><strong>{number(window.totals.requestCount)}</strong></div>
+          <div><span>Errors</span><strong>{number(window.totals.errorCount)}</strong></div>
+          <div><span>Input tokens</span><strong>{number(window.totals.inputTokens)}</strong></div>
+          <div><span>Output tokens</span><strong>{number(window.totals.outputTokens)}</strong></div>
+          <div><span title="Cache read + write tokens, already included in input tokens">Cache tokens</span><strong>{number(window.totals.cacheTokens)}</strong></div>
+        </div>
+      </section>
+    {/each}
   </section>
   <section class="split-panels section">
     <article>
@@ -113,3 +149,8 @@
     </article>
   </section>
 {/if}
+
+<style>
+  .usage-note { color: var(--muted); font-size: 13px; }
+  .usage-window + .usage-window { margin-top: 24px; }
+</style>


### PR DESCRIPTION
## Summary

Closes #164

- Show Last 24 hours, Last 7 days and Last 28 days together in Overview, each with requests/errors/input/output/cache totals.
- Add strict optional `window=24h|7d|28d` on the existing authenticated usage API. Resolve bounds against server time, retaining default/explicit bounds, hourly bucket comparisons, filters, pagination, DTOs and security. UI uses total aggregates, not the first page, and requests only one bucket per window.
- Keep useful manual Refresh controls, style Overview/Accounts black like Models, and rename Models Refresh catalog to Refresh. Existing Accounts message lifetime, clipboard guards and authorization polling remain unchanged; no auto-dismiss timer.
- Center Models version/fetched diagnostics with Account, wrap on narrow screens, add a concise explanation, and suppress previous-account diagnostics while switching.
- Bound the Overview request batch: cancel siblings on failure and on unmount, settle before reuse, and prevent disposed/late state updates.

## Validation

- **1036 regular tests passed, 4 existing skips**; **93 Chromium browser tests passed**.
- Typecheck, repository lint, build, SQLite smoke and all **53 fixture entries** passed.
- Real SQLite/TelemetryRecorder through authenticated Admin HTTP: literal boundary totals, empty data, paging/filter parity, server time, invalid/duplicate/conflicting windows, and auth/no-store/error envelopes.
- Browser fixtures: independent totals for all three windows despite a deliberately different browser clock, partial failure/recovery and genuine zeros, delayed loads, cancellation of both status and usage reads on failure/navigation, retry and late-response isolation.
- Regression-first evidence: missing windows/light controls, 6.83px metadata center offset, stale account diagnostics, and missing request cancellation each failed before fixes.
- Desktop/mobile screenshots inspected; font minimum, existing row alignment and controls remain covered.
- All 90 original capture hashes unchanged; no live/SDK suite or real daemon restart. Extra ad hoc lint of the legacy `admin.spec.ts` file reports seven unchanged quote diagnostics also reproduced at the base; repository lint passes and unrelated formatting was not altered.

## Review

Independent Standards and Spec reviews completed. The first Standards review found unfinished sibling requests after fail-fast rejection; actual browser regressions reproduced it and the cancellation/settlement fix resolved it. Fresh final reviews found **no remaining must-fix or safe-to-defer findings**.

## Deliberately unchanged limits

Totals include retained hourly Usage Buckets, not reconstructed per-request timestamps or deleted history. Each window resolves its own server-time range; this does not introduce a cross-request atomic snapshot or new pagination guarantee. Retention and benchmark thresholds are unchanged.

## Existing CI follow-up

- #157: macOS ARM64 checkpoint p95 had one13.17ms spike, then one same-commit rerun passed at0.723/1.315/0.915ms. All seven checks pass. Root cause remains unproven; evidence retained in the existing investigation. No threshold, sample selection, automatic retry or source workaround was introduced; no failing dependency/gate is bypassed.
