### PR TITLE
Add reversible Admin configuration for Claude Code and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,15 @@ Admin security defaults:
 - sessions invalidated when the gateway restarts
 - bounded, replayable SSE monitoring with no WebSocket or remote Admin access
 
-The five views are Overview, Accounts, Models, Configuration, and Events.
+The six views are Overview, Accounts, Models, Agents, Configuration, and Events.
+The Agents view can reversibly point this machine's global Claude Code and Codex configuration at the gateway.
+Each agent edits a Model mapping of display names to exact Copilot model IDs; the first row is the client's startup model.
+Claude Code maps its Sonnet, Opus, and Haiku roles (with an optional subagent mapping), and Codex gets a generated multi-model catalog, so Codex's own model menu can switch between the mapped models.
+**Apply changes** writes the gateway endpoint and model fields only; unrelated settings, hooks, MCP servers, Codex `auth.json`, and Claude login credentials are left untouched.
+Before the first apply, the gateway privately stores the original configuration bytes and access metadata under the Gateway process user's home directory; later applies keep that first baseline.
+**Restore** writes the original bytes back (or removes files the gateway created) only while the live files still match what the gateway last wrote; outside edits are reported as conflicts and are never overwritten.
+Apply validates mappings against the current Copilot model catalog, so a signed-in account is required; inspection and restore work without one.
+Status means configuration installed, not a tested client connection. Restart the client after applying or restoring.
 Overview shows cumulative usage for the last 24 hours, 7 days, and 28 days, using the gateway's clock
 and retained hourly Usage Buckets. These overlapping windows include only available data; shortening
 retention or clearing data cannot be undone by refreshing. Cache tokens are read + write tokens already included in input.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@hono/node-server": "2.1.1",
         "@sinclair/typebox": "0.34.52",
         "hono": "4.13.4",
+        "smol-toml": "1.8.0",
         "undici": "8.10.0"
       },
       "bin": {
@@ -3667,6 +3668,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha1-3F4JNoJfH+83vfLFaQgfcJ2KAJ8=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@hono/node-server": "2.1.1",
     "@sinclair/typebox": "0.34.52",
     "hono": "4.13.4",
+    "smol-toml": "1.8.0",
     "undici": "8.10.0"
   },
   "devDependencies": {

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+import { AgentError, type AgentErrorCode, type AgentsManager, type AgentsView, type AgentApplyRequest, type AgentRestoreRequest, type AgentStatus } from "../agents/types.js";
 import type { DeviceFlowCancelResult } from "../accounts/device_flow.js";
 import type { RuntimeConfigSnapshot } from "../config/schema.js";
 import type { BoundAccount } from "../accounts/account_directory.js";
@@ -20,7 +22,7 @@ import type { PerformanceSnapshot } from "../telemetry/performance.js";
 import { THRESHOLDS } from "../telemetry/performance.js";
 import { toIso } from "./auth.js";
 
-export type AdminErrorCode =
+export type AdminErrorCode = AgentErrorCode
   | "validation_failed"
   | "unauthenticated"
   | "forbidden"
@@ -275,6 +277,7 @@ export interface AdminCapabilityRegistry {
     }[];
   }>;
   invalidate(accountId: string): void;
+  isCurrent(snapshot: Awaited<ReturnType<AdminCapabilityRegistry["get"]>>): boolean;
 }
 
 export interface AdminAccountCaches {
@@ -330,6 +333,7 @@ export interface AdminHistory {
 }
 
 export interface AdminApiDependencies {
+  readonly agents?: AgentsManager;
   readonly accounts: AdminAccountDirectory;
   readonly deviceFlows: AdminDeviceFlows;
   readonly registry: AdminCapabilityRegistry;
@@ -344,6 +348,7 @@ export interface AdminApiDependencies {
 
 export class AdminManagementApi {
   private readonly modelMutations = new Map<string, Promise<void>>();
+  private readonly agentMutations = new Set<string>();
 
   constructor(private readonly dependencies: Readonly<AdminApiDependencies>) {}
 
@@ -454,6 +459,70 @@ export class AdminManagementApi {
     const defaultRevision = await this.dependencies.accounts.use(accountId, expectedRevision, signal);
     signal.throwIfAborted();
     return { defaultAccountId: accountId, defaultRevision };
+  }
+
+  async agents(origin: string, signal: AbortSignal): Promise<AgentsView> {
+    signal.throwIfAborted();
+    const items = await this.requireAgents().inspect(origin);
+    try {
+      const catalog = await this.agentCatalog(signal);
+      return { items, catalogRevision: catalog.revision, modelsAvailable: true };
+    } catch (error: unknown) {
+      signal.throwIfAborted();
+      if (error instanceof DOMException && error.name === "AbortError") throw error;
+      return { items, catalogRevision: null, modelsAvailable: false };
+    }
+  }
+
+  async applyAgent(request: AgentApplyRequest, origin: string, signal: AbortSignal): Promise<AgentStatus> {
+    if (this.agentMutations.has(request.agent)) throw new AgentError("agent_busy");
+    this.agentMutations.add(request.agent);
+    try {
+      const captured = await this.agentCatalog(signal);
+      if (captured.revision !== request.catalogRevision) throw new AdminApiError("revision_conflict");
+      await this.requireSameCredentialGeneration(captured.account.accountId, captured.account, signal);
+      const models = captured.catalog.models.filter((model) => model.protocols.value !== null
+        && model.protocols.value.length > 0
+        && model.defaultOutputTokens.valid
+        && (!model.protocols.value.every((protocol) => protocol === "chat") || model.profile.chatOutputTokenField.value !== null))
+        .map((model) => ({ modelId: model.modelId, maxInputTokens: model.maxInputTokens.value }));
+      return await this.requireAgents().apply(request, origin, models, () => {
+        signal.throwIfAborted();
+        if (!this.dependencies.registry.isCurrent(captured.catalog)
+          || JSON.stringify(this.dependencies.accounts.defaultState()) !== captured.defaultState
+          || this.requireActiveAccount(captured.account.accountId).revision !== captured.accountRevision) {
+          throw new AdminApiError("revision_conflict");
+        }
+      }, signal);
+    } finally { this.agentMutations.delete(request.agent); }
+  }
+
+  async restoreAgent(request: AgentRestoreRequest, origin: string, signal: AbortSignal): Promise<AgentStatus> {
+    return await this.requireAgents().restore(request, origin, signal);
+  }
+
+  private requireAgents(): AgentsManager {
+    if (this.dependencies.agents === undefined) throw new AdminApiError("not_found");
+    return this.dependencies.agents;
+  }
+
+  private async agentCatalog(signal: AbortSignal) {
+    signal.throwIfAborted();
+    const defaults = this.dependencies.accounts.defaultState();
+    const active = this.dependencies.accounts.list().filter((item) => item.state === "active");
+    // Same fallback as AccountDirectory.bindDefault: only an unambiguous account.
+    const id = defaults.defaultAccountId ?? (active.length === 1 ? active[0]!.accountId : null);
+    if (id === null) throw new AgentError("agent_models_unavailable");
+    const summary = this.requireActiveAccount(id);
+    const account = await this.dependencies.accounts.bindAccount(id, signal);
+    const catalog = await this.dependencies.registry.get(account, signal);
+    signal.throwIfAborted();
+    if (!this.dependencies.registry.isCurrent(catalog)) throw new AgentError("agent_models_unavailable");
+    const revision = createHash("sha256").update(JSON.stringify({
+      defaults, accountId: id, accountRevision: summary.revision, credentialGeneration: account.credentialGeneration,
+      catalogGeneration: catalog.catalogGeneration,
+    })).digest("hex");
+    return { catalog, account, revision, accountRevision: summary.revision, defaultState: JSON.stringify(defaults) };
   }
 
   async models(accountId: string | null, signal: AbortSignal): Promise<AdminModels> {
@@ -691,6 +760,7 @@ export function mapAdminError(error: unknown): AdminApiError {
   if (error instanceof AdminApiError) {
     return error;
   }
+  if (error instanceof AgentError) return new AdminApiError(error.code);
   if (error instanceof DOMException && error.name === "AbortError") {
     throw error;
   }

--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -33,6 +33,21 @@ const PreferredModelSchema = Type.Object({
   expectedRevision: Type.Integer({ minimum: 0 }),
 }, { additionalProperties: false });
 const RefreshModelsSchema = Type.Object({ accountId: Type.String({ minLength: 1 }) }, { additionalProperties: false });
+const ModelIdSchema = Type.String({
+  minLength: 1,
+  maxLength: 128,
+  pattern: "^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+});
+const AgentIdSchema = Type.Union([Type.Literal("claude"), Type.Literal("codex")]);
+const AgentRevisionSchema = Type.String({ minLength: 64, maxLength: 64, pattern: "^[a-f0-9]{64}$" });
+const AgentApplySchema = Type.Object({
+  agent: AgentIdSchema, expectedRevision: AgentRevisionSchema, catalogRevision: AgentRevisionSchema,
+  mappings: Type.Array(Type.Object({
+    displayName: Type.String({ minLength: 1, maxLength: 80, pattern: "^[^\\u0000-\\u001f\\u007f]+$" }),
+    modelId: ModelIdSchema,
+  }, { additionalProperties: false }), { minItems: 1, maxItems: 16 }),
+}, { additionalProperties: false });
+const AgentRestoreSchema = Type.Object({ agent: AgentIdSchema, expectedRevision: AgentRevisionSchema }, { additionalProperties: false });
 const RuntimeConfigUpdateSchema = Type.Object({
   expectedRevision: Type.Integer({ minimum: 0 }),
   config: RuntimeConfigSchema,
@@ -116,6 +131,7 @@ export function createAdminModule(dependencies: Readonly<AdminModuleDependencies
         return;
       }
       closed = true;
+      dependencies.agents?.close();
       eventHub.close();
       flowOwners.close();
       auth.close();
@@ -231,6 +247,15 @@ async function dispatch(
     response = success(await api.setPreferredModel(value.accountId, value.modelId, value.expectedRevision, context.signal), context.requestId);
     break;
   }
+  case "agentsGet":
+    response = success(await api.agents(context.listenerOrigin, context.signal), context.requestId);
+    break;
+  case "agentsApply":
+    response = success(await api.applyAgent(checked(AgentApplySchema, body), context.listenerOrigin, context.signal), context.requestId);
+    break;
+  case "agentsRestore":
+    response = success(await api.restoreAgent(checked(AgentRestoreSchema, body), context.listenerOrigin, context.signal), context.requestId);
+    break;
   case "configGet":
     response = success(api.runtimeConfig(), context.requestId);
     break;
@@ -355,6 +380,7 @@ class AdminDeviceFlowOwners {
 
 type RouteId = "bootstrap" | "session" | "logout" | "status" | "usage" | "accounts" | "deviceStart"
   | "devicePoll" | "deviceCancel" | "accountDelete" | "accountDefault" | "models" | "modelsRefresh" | "modelsPreferred"
+  | "agentsGet" | "agentsApply" | "agentsRestore"
   | "configGet" | "configPut" | "historyGet" | "historyDelete" | "events" | "eventStream";
 
 interface MatchedRoute {
@@ -406,6 +432,9 @@ const ROUTES = new Map<string, Omit<MatchedRoute, "parameter">>([
   route("GET", "/admin/api/v1/accounts", "accounts"),
   route("POST", "/admin/api/v1/device-flows", "deviceStart", true, true),
   route("PUT", "/admin/api/v1/accounts/default", "accountDefault", true, true),
+  route("GET", "/admin/api/v1/agents", "agentsGet"),
+  route("POST", "/admin/api/v1/agents/apply", "agentsApply", true, true),
+  route("POST", "/admin/api/v1/agents/restore", "agentsRestore", true, true),
   route("GET", "/admin/api/v1/models", "models", false, false, ["accountId"]),
   route("POST", "/admin/api/v1/models/refresh", "modelsRefresh", true, true),
   route("PUT", "/admin/api/v1/models/preferred", "modelsPreferred", true, true),
@@ -667,6 +696,12 @@ function failure(error: AdminApiError, requestId: string): Response {
 
 function statusFor(code: AdminApiError["code"]): number {
   return {
+    agent_conflict: 409,
+    agent_recovery_required: 409,
+    agent_unsafe_path: 409,
+    agent_invalid_config: 400,
+    agent_models_unavailable: 400,
+    agent_busy: 409,
     validation_failed: 400,
     unauthenticated: 401,
     forbidden: 403,

--- a/src/agents/files.ts
+++ b/src/agents/files.ts
@@ -1,0 +1,238 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+import { createHash } from "node:crypto";
+import { AgentError } from "./types.js";
+
+export const MAX_FILE_BYTES = 1024 * 1024;
+export interface FileImage {
+  readonly bytes: string;
+  readonly mode: number;
+  readonly acl: string | null;
+}
+export function digest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+export function exists(target: string): boolean {
+  try { fs.lstatSync(target); return true; } catch (error: unknown) {
+    if (isMissing(error)) return false;
+    throw error;
+  }
+}
+export function isMissing(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+export function canonical(target: string): string {
+  const absolute = path.resolve(target);
+  assertNoLinks(absolute);
+  let ancestor = absolute;
+  const suffix: string[] = [];
+  while (!exists(ancestor)) { suffix.unshift(path.basename(ancestor)); ancestor = path.dirname(ancestor); }
+  const result = path.join(fs.realpathSync.native(ancestor), ...suffix);
+  return process.platform === "win32" ? result.toLowerCase() : result;
+}
+export function assertNoLinks(target: string): void {
+  let current = path.resolve(target);
+  while (true) {
+    if (exists(current)) {
+      const stat = fs.lstatSync(current);
+      if (stat.isSymbolicLink()) throw new AgentError("agent_unsafe_path");
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+}
+export async function assertOwned(target: string, directory: boolean, allowedLink?: string): Promise<string | null> {
+  assertNoLinks(target);
+  const stat = fs.lstatSync(target);
+  const linked = allowedLink !== undefined && exists(allowedLink) ? fs.lstatSync(allowedLink) : null;
+  if ((directory ? !stat.isDirectory() : !stat.isFile()) || (!directory && stat.nlink !== 1
+    && !(stat.nlink === 2 && linked?.ino === stat.ino && linked.dev === stat.dev))) {
+    throw new AgentError("agent_unsafe_path");
+  }
+  if (process.platform !== "win32") {
+    if (stat.uid !== process.getuid?.() || (stat.mode & 0o022) !== 0) throw new AgentError("agent_unsafe_path");
+    return null;
+  }
+  return await windowsAcl(target);
+}
+export async function readImage(target: string, allowedLink?: string): Promise<FileImage | null> {
+  assertNoLinks(target);
+  if (!exists(target)) return null;
+  const recordedAcl = await assertOwned(target, false, allowedLink);
+  const before = fs.lstatSync(target);
+  if (before.size > MAX_FILE_BYTES) throw new AgentError("agent_invalid_config");
+  const fd = fs.openSync(target, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+  try {
+    const stat = fs.fstatSync(fd);
+    if (stat.ino !== before.ino || stat.dev !== before.dev || stat.size > MAX_FILE_BYTES) throw new AgentError("agent_conflict");
+    const data = Buffer.alloc(MAX_FILE_BYTES + 1);
+    let size = 0;
+    while (size < data.length) {
+      const read = fs.readSync(fd, data, size, data.length - size, null);
+      if (read === 0) break;
+      size += read;
+    }
+    const after = fs.fstatSync(fd);
+    const named = fs.lstatSync(target);
+    if (size > MAX_FILE_BYTES || stat.size !== after.size || stat.mtimeMs !== after.mtimeMs
+      || named.ino !== stat.ino || named.dev !== stat.dev) throw new AgentError("agent_conflict");
+    return { bytes: data.subarray(0, size).toString("base64"), mode: stat.mode & 0o777, acl: recordedAcl };
+  } finally { fs.closeSync(fd); }
+}
+export function sameImage(a: FileImage | null, b: FileImage | null): boolean {
+  return digest(a) === digest(b);
+}
+
+export function sameDisplacedContent(a: FileImage | null, b: FileImage | null): boolean {
+  if (a === null || b === null) return a === b;
+  // Windows may recompute inherited ACLs when a file is renamed into the
+  // private scratch directory. The durable baseline keeps the original SDDL
+  // for restoration; post-rename verification proves the displaced payload,
+  // while the full image was already compared immediately before the move.
+  return a.bytes === b.bytes && (process.platform === "win32" || a.mode === b.mode);
+}
+export async function privateDirectory(target: string): Promise<void> {
+  assertNoLinks(target);
+  if (exists(target)) { await assertPrivate(target, true); return; }
+  fs.mkdirSync(target, { mode: 0o700 });
+  if (process.platform === "win32") {
+    restrictWindowsAcl(target, true);
+  }
+  await assertPrivate(target, true);
+}
+export async function assertPrivate(target: string, directory: boolean): Promise<void> {
+  assertNoLinks(target);
+  const stat = fs.lstatSync(target);
+  if (directory ? !stat.isDirectory() : !stat.isFile()) throw new AgentError("agent_unsafe_path");
+  if (process.platform !== "win32") {
+    if (stat.uid !== process.getuid?.() || (stat.mode & 0o077) !== 0) throw new AgentError("agent_unsafe_path");
+  } else {
+    const identities = windowsAclIdentities(target);
+    if (identities.length !== 1 || !isCurrentWindowsIdentity(identities[0] ?? "")) {
+      throw new AgentError("agent_unsafe_path");
+    }
+  }
+}
+export async function protect(target: string): Promise<void> {
+  if (process.platform === "win32") {
+    restrictWindowsAcl(target, false);
+  } else fs.chmodSync(target, 0o600);
+}
+export async function writeExclusive(target: string, image: FileImage, privateOnly = false): Promise<void> {
+  const fd = fs.openSync(target, "wx", 0o600);
+  try {
+    fs.writeFileSync(fd, Buffer.from(image.bytes, "base64"));
+    fs.fsyncSync(fd);
+  } finally { fs.closeSync(fd); }
+  if (privateOnly) await protect(target);
+  else await applyAccess(target, image);
+  syncDirectory(path.dirname(target));
+}
+export async function applyAccess(target: string, image: FileImage): Promise<void> {
+  if (process.platform === "win32") {
+    if (image.acl !== null) {
+      await windows(target, "$a=Get-Acl -LiteralPath $p; $a.SetSecurityDescriptorSddlForm([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($env:GHCG_AGENT_ACL))); Set-Acl -LiteralPath $p -AclObject $a", image.acl);
+    } else await protect(target);
+  } else fs.chmodSync(target, image.mode);
+}
+export function syncDirectory(directory: string): void {
+  // Node cannot open directories for FlushFileBuffers on Windows. File fsync and
+  // SQLite FULL synchronization cover process crashes, not hardware power loss.
+  if (process.platform === "win32") return;
+  const fd = fs.openSync(directory, "r");
+  try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+}
+async function windowsAcl(target: string): Promise<string> {
+  // Client configuration commonly inherits an Administrators owner on Windows.
+  // Ownership is therefore not a useful same-user boundary there; reject
+  // reparse points and preserve the complete descriptor instead. Recovery
+  // files remain current-user-only through assertPrivate/restrictWindowsAcl.
+  return (await windows(target, "$a=Get-Acl -LiteralPath $p; if(((Get-Item -LiteralPath $p -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw 'unsafe'}; $a.Sddl")).trim();
+}
+
+// Windows ACL mutation uses icacls instead of PowerShell Set-Acl: reapplying a
+// protected ACL through SetAccessRuleProtection demands SeSecurityPrivilege and
+// fails on already-locked files, while icacls /inheritance:r + /grant:r is
+// idempotent for the recovery files we revisit across apply/restore operations.
+const windowsIdentity = { value: null as { readonly name: string; readonly sid: string } | null };
+
+function windowsCommandPath(command: string): string {
+  return path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", `${command}.exe`);
+}
+
+function currentWindowsIdentity(): { readonly name: string; readonly sid: string } {
+  if (windowsIdentity.value !== null) return windowsIdentity.value;
+  try {
+    const csv = execFileSync(windowsCommandPath("whoami"), ["/user", "/fo", "csv", "/nh"], {
+      encoding: "utf8", windowsHide: true, timeout: 10000,
+    }).trim();
+    const match = /^"([^"]+)","([^"]+)"$/u.exec(csv);
+    if (match === null || match[1] === undefined || match[2] === undefined) throw new Error("whoami");
+    windowsIdentity.value = { name: match[1].toLowerCase(), sid: match[2].toLowerCase() };
+    return windowsIdentity.value;
+  } catch (error: unknown) {
+    const failure = new AgentError("agent_unsafe_path");
+    failure.cause = error;
+    throw failure;
+  }
+}
+
+function isCurrentWindowsIdentity(identity: string): boolean {
+  const normalized = identity.toLowerCase();
+  const current = currentWindowsIdentity();
+  return normalized === current.name || normalized === current.sid;
+}
+
+function icacls(target: string, args: readonly string[]): string {
+  try {
+    return execFileSync(windowsCommandPath("icacls"), [target, ...args], {
+      encoding: "utf8", windowsHide: true, timeout: 10000, maxBuffer: 65536,
+    });
+  } catch (error: unknown) {
+    const failure = new AgentError("agent_unsafe_path");
+    failure.cause = error;
+    throw failure;
+  }
+}
+
+function windowsAclIdentities(target: string): string[] {
+  const output = icacls(target, []);
+  const identities: string[] = [];
+  for (const rawLine of output.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("Successfully processed") || line.startsWith("Failed processing")) continue;
+    const entry = rawLine.startsWith(target) ? rawLine.slice(target.length).trim() : line;
+    const separator = entry.indexOf(":(");
+    if (separator > 0) identities.push(entry.slice(0, separator));
+  }
+  return identities;
+}
+
+function restrictWindowsAcl(target: string, directory: boolean): void {
+  const grant = directory ? `*${currentWindowsIdentity().sid}:(OI)(CI)(F)` : `*${currentWindowsIdentity().sid}:(F)`;
+  icacls(target, ["/inheritance:r", "/grant:r", grant]);
+  for (const identity of windowsAclIdentities(target)) {
+    if (!isCurrentWindowsIdentity(identity)) icacls(target, ["/remove:g", identity]);
+  }
+}
+
+async function windows(target: string, script: string, acl?: string): Promise<string> {
+  try {
+    const executable = path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+    const securityModule = "$env:windir\\system32\\WindowsPowerShell\\v1.0\\Modules"
+      + "\\Microsoft.PowerShell.Security\\Microsoft.PowerShell.Security.psd1";
+    const command = `$ErrorActionPreference='Stop'; Import-Module "${securityModule}"; $p=$env:GHCG_AGENT_PATH; ${script}`;
+    const { stdout } = await promisify(execFile)(executable, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+      encoding: "utf8", windowsHide: true, timeout: 10000, maxBuffer: 16384,
+      env: { ...process.env, GHCG_AGENT_PATH: target, GHCG_AGENT_ACL: acl === undefined ? "" : Buffer.from(acl).toString("base64") },
+    });
+    return stdout;
+  } catch (error: unknown) {
+    const failure = new AgentError("agent_unsafe_path");
+    failure.cause = error;
+    throw failure;
+  }
+}

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -1,0 +1,335 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { randomUUID } from "node:crypto";
+import { AgentError, validateMappings, type AgentId, type AgentStatus, type AgentsManager, type AgentApplyRequest, type AgentRestoreRequest, type AgentModel } from "./types.js";
+import { AgentStore, copyMappings, newImage, type AgentState, type StepState } from "./store.js";
+import { assertNoLinks, assertOwned, assertPrivate, canonical, digest, exists, privateDirectory, protect, readImage, sameDisplacedContent, sameImage, syncDirectory, writeExclusive, type FileImage } from "./files.js";
+import { projectAgent } from "./transform.js";
+
+export interface AgentManagerOptions {
+  readonly home?: string;
+  readonly env?: Readonly<NodeJS.ProcessEnv>;
+  readonly now?: () => Date;
+  /** Deterministic failure/race injection at durable transaction boundaries. */
+  readonly checkpoint?: (point: "intent" | "staged" | "displaced" | "linked" | "published" | "complete", agent: AgentId, index: number) => void;
+}
+
+export class FileAgentsManager implements AgentsManager {
+  private readonly home: string;
+  private readonly root: string;
+  private readonly paths: Record<AgentId, readonly string[]>;
+  private readonly busy = new Set<AgentId>();
+  private closed = false;
+
+  constructor(private readonly options: AgentManagerOptions = {}) {
+    // Resolve the existing home anchor once. macOS exposes its temporary home
+    // paths through the system /var -> /private/var alias; canonicalizing that
+    // trusted anchor avoids rejecting the OS alias while links below it remain
+    // forbidden. A durable baseline pins its own target paths.
+    this.home = fs.realpathSync.native(path.resolve(options.home ?? os.homedir()));
+    this.root = path.join(this.home, ".ghc-gateway-agents");
+    const env = options.env ?? {};
+    const claude = path.resolve(env.CLAUDE_CONFIG_DIR ?? path.join(this.home, ".claude"));
+    const codex = path.resolve(env.CODEX_HOME ?? path.join(this.home, ".codex"));
+    this.paths = {
+      claude: [path.join(claude, "settings.json")],
+      codex: [path.join(codex, "ghcg-models.json"), path.join(codex, "config.toml")],
+    };
+  }
+
+  async inspect(origin: string): Promise<readonly AgentStatus[]> {
+    return await Promise.all((["claude", "codex"] as const).map((agent) => this.status(agent, origin)));
+  }
+
+  async apply(request: AgentApplyRequest, origin: string, models: readonly AgentModel[], assertCurrent: () => void, signal: AbortSignal): Promise<AgentStatus> {
+    return await this.exclusive(request.agent, async () => {
+      signal.throwIfAborted();
+      validateMappings(request.agent, request.mappings);
+      const store = new AgentStore(this.root, request.agent);
+      // Parse and validate BEFORE making a recovery directory or lock file.
+      const initial = await store.read();
+      if (initial.pending !== null) throw new AgentError("agent_recovery_required");
+      const paths = this.targetPaths(request.agent, initial);
+      const before = await this.images(paths);
+      this.requireRevision(request.expectedRevision, initial, before, paths, origin);
+      this.requireExpected(initial, before);
+      const configIndex = request.agent === "claude" ? 0 : 1;
+      const config = initial.targets.length === 0 ? before[configIndex]! : initial.targets[configIndex]!.original;
+      const projection = projectAgent(request.agent, config === null ? null : Buffer.from(config.bytes, "base64"), request.mappings, origin, paths[0]!, models);
+      signal.throwIfAborted();
+      assertCurrent();
+      return await store.locked(async (save) => {
+        const state = await store.read();
+        const current = await this.images(paths);
+        this.requireRevision(request.expectedRevision, state, current, paths, origin);
+        this.requireExpected(state, current);
+        assertCurrent();
+        signal.throwIfAborted();
+        if (state.targets.length === 0) {
+          state.targets = paths.map((target, index) => ({ path: target, original: current[index]!, expected: current[index]! }));
+        }
+        const after = request.agent === "claude"
+          ? [newImage(projection.config, state.targets[0]!.original)]
+          : [newImage(projection.catalog!, state.targets[0]!.original), newImage(projection.config, state.targets[1]!.original)];
+        state.pending = { kind: "apply", steps: this.plan(request.agent, state, current, after), garbage: [] };
+        state.mappings = copyMappings(request.mappings);
+        // From this durable intent onward cancellation must not interrupt commit.
+        await save(state);
+        this.hit("intent", request.agent, -1);
+        await this.execute(request.agent, state, save);
+        state.lastAppliedAt = (this.options.now ?? (() => new Date()))().toISOString();
+        await this.finish(request.agent, state, save);
+        return await this.status(request.agent, origin);
+      });
+    });
+  }
+
+  async restore(request: AgentRestoreRequest, origin: string, signal: AbortSignal): Promise<AgentStatus> {
+    return await this.exclusive(request.agent, async () => {
+      signal.throwIfAborted();
+      const store = new AgentStore(this.root, request.agent);
+      const initial = await store.read();
+      if (initial.targets.length === 0) throw new AgentError("validation_failed");
+      const paths = this.targetPaths(request.agent, initial);
+      const current = await this.images(paths, initial);
+      this.requireRevision(request.expectedRevision, initial, current, paths, origin);
+      await this.requireRecoverable(initial, current);
+      signal.throwIfAborted();
+      return await store.locked(async (save) => {
+        const state = await store.read();
+        const before = await this.images(paths, state);
+        this.requireRevision(request.expectedRevision, state, before, paths, origin);
+        await this.requireRecoverable(state, before);
+        signal.throwIfAborted();
+        if (state.pending?.kind !== "restore") {
+          const garbage = state.pending?.steps.map((step) => step.scratch) ?? [];
+          await this.releasePublishedStageLinks(state);
+          state.pending = {
+            kind: "restore", garbage,
+            steps: this.plan(request.agent, state, before, state.targets.map((target) => target.original)),
+          };
+          await save(state);
+          this.hit("intent", request.agent, -1);
+        }
+        await this.execute(request.agent, state, save);
+        await this.finish(request.agent, state, save);
+        return await this.status(request.agent, origin);
+      });
+    });
+  }
+
+  close(): void {
+    // Mutations are synchronous, bounded by two 1 MiB files and bounded OS calls.
+    // No background queue or automatic shutdown restore exists.
+    this.closed = true;
+  }
+
+  private async exclusive<T>(agent: AgentId, work: () => Promise<T>): Promise<T> {
+    if (this.closed || this.busy.has(agent)) throw new AgentError("agent_busy");
+    this.busy.add(agent);
+    try { return await work(); } catch (error: unknown) {
+      if (error instanceof AgentError || (error instanceof DOMException && error.name === "AbortError")) throw error;
+      throw new AgentError("agent_recovery_required");
+    } finally { this.busy.delete(agent); }
+  }
+
+  private async status(agent: AgentId, origin: string): Promise<AgentStatus> {
+    let state: AgentState | null = null;
+    let paths = this.paths[agent];
+    let revision = "0".repeat(64);
+    let kind: AgentStatus["state"] = "not_managed";
+    let canRestore = false;
+    try {
+      state = await new AgentStore(this.root, agent).read();
+      paths = this.targetPaths(agent, state);
+      const images = await this.images(paths, state);
+      revision = this.revision(state, images, paths, origin);
+      kind = state.targets.length === 0 ? "not_managed" : state.pending !== null ? "recovery_required" : "installed";
+      try { await this.requireRecoverable(state, images); canRestore = state.targets.length > 0; }
+      catch { kind = state.pending !== null ? "recovery_required" : "conflict"; }
+    } catch (error: unknown) {
+      kind = error instanceof AgentError && error.code === "agent_unsafe_path" ? "unsafe_path" : "recovery_required";
+    }
+    return {
+      id: agent, state: kind, revision, paths, endpoint: agent === "claude" ? origin : `${origin}/v1`,
+      backupAvailable: (state?.targets.length ?? 0) > 0, lastAppliedAt: state?.lastAppliedAt ?? null,
+      mappings: state?.mappings ?? [], canRestore,
+    };
+  }
+
+  private targetPaths(agent: AgentId, state: AgentState): readonly string[] {
+    return state.targets.length === 0 ? this.paths[agent].map(canonical) : state.targets.map((target) => canonical(target.path));
+  }
+  private async images(paths: readonly string[], state?: AgentState): Promise<(FileImage | null)[]> {
+    // Client files usually share a parent directory; verify each distinct one once.
+    const parents = new Set(paths.map((target) => {
+      let parent = path.dirname(target);
+      while (!exists(parent)) parent = path.dirname(parent);
+      return parent;
+    }));
+    for (const parent of parents) await assertOwned(parent, true);
+    return await Promise.all(paths.map(async (target, index) => {
+      const stage = state?.pending?.steps.find((step) => step.target === index);
+      return await readImage(target, stage === undefined ? undefined : path.join(stage.scratch, "next"));
+    }));
+  }
+  private revision(state: AgentState, images: readonly (FileImage | null)[], paths: readonly string[], origin: string): string {
+    return digest({ state, images, paths, origin });
+  }
+  private requireRevision(expected: string, state: AgentState, images: readonly (FileImage | null)[], paths: readonly string[], origin: string): void {
+    if (expected !== this.revision(state, images, paths, origin)) throw new AgentError("revision_conflict");
+  }
+  private requireExpected(state: AgentState, images: readonly (FileImage | null)[]): void {
+    if (state.targets.some((target, index) => !sameImage(target.expected, images[index]!))) throw new AgentError("agent_conflict");
+  }
+  private async requireRecoverable(state: AgentState, images: readonly (FileImage | null)[]): Promise<void> {
+    if (state.pending === null) { this.requireExpected(state, images); return; }
+    for (const step of state.pending.steps) await this.classify(step, images[step.target]!);
+    for (const [index, target] of state.targets.entries()) {
+      if (!state.pending.steps.some((step) => step.target === index) && !sameImage(target.expected, images[index]!)) throw new AgentError("agent_conflict");
+    }
+  }
+  private async classify(step: StepState, image: FileImage | null): Promise<"before" | "after" | "gap"> {
+    const displaced = path.join(step.scratch, "previous");
+    if (exists(displaced)) {
+      await assertPrivate(step.scratch, true);
+      const saved = await readImage(displaced);
+      if (saved?.bytes !== step.before?.bytes) throw new AgentError("agent_recovery_required");
+    }
+    if (sameImage(image, step.after) && (step.phase !== "planned" || !sameImage(step.before, step.after))) return "after";
+    if (sameImage(image, step.before)) return "before";
+    if (image === null && step.before !== null && exists(displaced)) return "gap";
+    throw new AgentError("agent_recovery_required");
+  }
+
+  private plan(agent: AgentId, state: AgentState, before: readonly (FileImage | null)[], after: readonly (FileImage | null)[]): StepState[] {
+    return state.targets.map((target, index) => ({
+      target: index, before: before[index]!, after: after[index]!, phase: "planned",
+      scratch: path.join(path.dirname(target.path), `.ghcg-agents-${agent}-${randomUUID()}`),
+    }));
+  }
+
+  private async execute(agent: AgentId, state: AgentState, save: (state: AgentState) => Promise<void>): Promise<void> {
+    const pending = state.pending!;
+    // Catalog first when applying; configuration reference first when restoring.
+    const steps = pending.kind === "restore" ? [...pending.steps].reverse() : pending.steps;
+    for (const step of steps) {
+      const target = state.targets[step.target]!.path;
+      assertNoLinks(target);
+      const stage = path.join(step.scratch, "next");
+      const displaced = path.join(step.scratch, "previous");
+      let position = await this.classify(step, await readImage(target, stage));
+      if (position === "after") { step.phase = "published"; await save(state); continue; }
+      await this.ensureClientParent(path.dirname(target));
+      await privateDirectory(step.scratch);
+      if (step.after !== null && !exists(stage)) {
+        await writeExclusive(stage, step.after);
+        step.after = (await readImage(stage))!;
+        await save(state);
+      }
+      this.hit("staged", agent, step.target);
+      if (position === "before" && step.before !== null) {
+        if (exists(displaced)) throw new AgentError("agent_recovery_required");
+        // Staging and journal writes may take time. Revalidate the full live
+        // image immediately before moving it, then prove rename displaced the
+        // same filesystem object. This catches pathname replacements as well as
+        // content/access changes without trusting a stale pre-staging read.
+        if (!sameImage(await readImage(target, stage), step.before)) throw new AgentError("agent_conflict");
+        const beforeMove = fs.lstatSync(target);
+        fs.renameSync(target, displaced);
+        const afterMove = fs.lstatSync(displaced);
+        syncDirectory(path.dirname(target));
+        syncDirectory(step.scratch);
+        const actual = await readImage(displaced);
+        const matches = beforeMove.dev === afterMove.dev && beforeMove.ino === afterMove.ino
+          && sameDisplacedContent(actual, step.before);
+        await protect(displaced);
+        if (!matches) throw new AgentError("agent_recovery_required");
+        step.phase = "displaced";
+        await save(state);
+        this.hit("displaced", agent, step.target);
+        position = "gap";
+      }
+      if (step.after !== null) {
+        const staged = await readImage(stage);
+        if (!sameImage(staged, step.after)) throw new AgentError("agent_recovery_required");
+        // link is a no-clobber publication on NTFS/APFS/ext4; unsupported filesystems
+        // safely fail with both baseline and displaced bytes retained.
+        fs.linkSync(stage, target);
+        this.hit("linked", agent, step.target);
+        fs.unlinkSync(stage);
+      } else if (position === "before" && step.before === null && exists(target)) {
+        throw new AgentError("agent_recovery_required");
+      }
+      syncDirectory(path.dirname(target));
+      step.phase = "published";
+      await save(state);
+      this.hit("published", agent, step.target);
+    }
+  }
+
+  private async finish(agent: AgentId, state: AgentState, save: (state: AgentState) => Promise<void>): Promise<void> {
+    const pending = state.pending!;
+    for (const step of pending.steps) {
+      const target = state.targets[step.target]!;
+      if (!sameImage(await readImage(target.path, path.join(step.scratch, "next")), step.after)) throw new AgentError("agent_recovery_required");
+      target.expected = step.after;
+    }
+    // Keep the durable baseline until all file publications have been verified.
+    // Cleanup happens while the intent is still present, and can be retried.
+    for (const step of pending.steps) await this.cleanup(step.scratch, state.targets[step.target]?.path);
+    for (const scratch of pending.garbage) await this.cleanup(scratch);
+    if (pending.kind === "restore") {
+      state.targets = [];
+      state.mappings = [];
+      state.lastAppliedAt = null;
+    }
+    state.pending = null;
+    state.revision += 1;
+    await save(state);
+    this.hit("complete", agent, -1);
+  }
+  private async releasePublishedStageLinks(state: AgentState): Promise<void> {
+    for (const step of state.pending?.steps ?? []) {
+      const target = state.targets[step.target]?.path;
+      const stage = path.join(step.scratch, "next");
+      if (target === undefined || !exists(target) || !exists(stage)) continue;
+      const targetStat = fs.lstatSync(target);
+      const stageStat = fs.lstatSync(stage);
+      if (targetStat.dev !== stageStat.dev || targetStat.ino !== stageStat.ino) continue;
+      if (!sameImage(await readImage(target, stage), step.after)) throw new AgentError("agent_recovery_required");
+      await assertOwned(stage, false, target);
+      fs.unlinkSync(stage);
+      syncDirectory(step.scratch);
+    }
+  }
+
+  private async cleanup(scratch: string, liveTarget?: string): Promise<void> {
+    if (!exists(scratch)) return;
+    await assertPrivate(scratch, true);
+    if (fs.readdirSync(scratch).some((entry) => entry !== "previous" && entry !== "next")) throw new AgentError("agent_recovery_required");
+    // No recursive deletion of an unvalidated directory tree.
+    for (const name of ["previous", "next"]) {
+      const target = path.join(scratch, name);
+      if (exists(target)) {
+        await assertOwned(target, false, name === "next" ? liveTarget : undefined);
+        fs.unlinkSync(target);
+      }
+    }
+    fs.rmdirSync(scratch);
+    syncDirectory(path.dirname(scratch));
+  }
+  private async ensureClientParent(directory: string): Promise<void> {
+    assertNoLinks(directory);
+    if (exists(directory)) { await assertOwned(directory, true); return; }
+    await this.ensureClientParent(path.dirname(directory));
+    fs.mkdirSync(directory, { mode: 0o700 });
+    // Never chmod or change ACLs of an existing client directory.
+    await assertOwned(directory, true);
+    syncDirectory(path.dirname(directory));
+  }
+  private hit(point: Parameters<NonNullable<AgentManagerOptions["checkpoint"]>>[0], agent: AgentId, index: number): void {
+    this.options.checkpoint?.(point, agent, index);
+  }
+}

--- a/src/agents/store.ts
+++ b/src/agents/store.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { Type, type Static } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+import { AgentError, type AgentId, type AgentMapping } from "./types.js";
+import { assertNoLinks, assertPrivate, exists, privateDirectory, protect, type FileImage } from "./files.js";
+
+const Image = Type.Union([Type.Null(), Type.Object({
+  bytes: Type.String({ maxLength: 1_398_104, pattern: "^[A-Za-z0-9+/]*={0,2}$" }),
+  mode: Type.Integer({ minimum: 0, maximum: 511 }), acl: Type.Union([Type.Null(), Type.String({ maxLength: 16384 })]),
+}, { additionalProperties: false })]);
+const Mapping = Type.Object({ displayName: Type.String({ maxLength: 80 }), modelId: Type.String({ maxLength: 128 }) }, { additionalProperties: false });
+const Target = Type.Object({ path: Type.String({ maxLength: 4096 }), original: Image, expected: Image }, { additionalProperties: false });
+const Step = Type.Object({
+  target: Type.Integer({ minimum: 0, maximum: 1 }), before: Image, after: Image,
+  scratch: Type.String({ maxLength: 4096 }),
+  phase: Type.Union([Type.Literal("planned"), Type.Literal("displaced"), Type.Literal("published")]),
+}, { additionalProperties: false });
+const StateSchema = Type.Object({
+  version: Type.Literal(1), revision: Type.Integer({ minimum: 0 }),
+  targets: Type.Array(Target, { maxItems: 2 }), mappings: Type.Array(Mapping, { maxItems: 16 }),
+  lastAppliedAt: Type.Union([Type.Null(), Type.String({ maxLength: 40 })]),
+  pending: Type.Union([Type.Null(), Type.Object({
+    kind: Type.Union([Type.Literal("apply"), Type.Literal("restore")]),
+    steps: Type.Array(Step, { minItems: 1, maxItems: 2 }),
+    garbage: Type.Array(Type.String({ maxLength: 4096 }), { maxItems: 2 }),
+  }, { additionalProperties: false })]),
+}, { additionalProperties: false });
+export type AgentState = Static<typeof StateSchema>;
+export type StepState = NonNullable<AgentState["pending"]>["steps"][number];
+export function emptyState(): AgentState {
+  return { version: 1, revision: 0, targets: [], mappings: [], lastAppliedAt: null, pending: null };
+}
+
+// A separate SQLite exclusive transaction is an OS-backed cross-process mutex.
+// It is released by the OS after a crash: no PID files, time-based lock stealing,
+// or competing stale-lock unlink races. Journal writes use a different database.
+export class AgentStore {
+  constructor(private readonly root: string, private readonly agent: AgentId) {}
+  private get directory(): string { return path.join(this.root, this.agent); }
+  private get statePath(): string { return path.join(this.directory, "state.db"); }
+
+  async read(): Promise<AgentState> {
+    assertNoLinks(this.root);
+    if (!exists(this.statePath)) return emptyState();
+    await this.checkDirectory();
+    await assertPrivate(this.statePath, false);
+    const db = new DatabaseSync(this.statePath, { readOnly: true, timeout: 0 });
+    try {
+      const row = db.prepare("SELECT document FROM state WHERE id=1").get();
+      if (row === undefined) return emptyState();
+      if (typeof row.document !== "string" || row.document.length > 16 * 1024 * 1024) throw new AgentError("agent_recovery_required");
+      const state: unknown = JSON.parse(row.document);
+      if (!Value.Check(StateSchema, state)) throw new AgentError("agent_recovery_required");
+      this.validatePaths(state);
+      return state;
+    } catch (error: unknown) {
+      if (error instanceof AgentError) throw error;
+      throw new AgentError("agent_recovery_required");
+    } finally { db.close(); }
+  }
+
+  async locked<T>(work: (save: (state: AgentState) => Promise<void>) => Promise<T>): Promise<T> {
+    await privateDirectory(this.root);
+    await privateDirectory(this.directory);
+    await this.checkDirectory();
+    const lockPath = path.join(this.directory, "lock.db");
+    if (exists(lockPath)) await assertPrivate(lockPath, false);
+    if (!exists(lockPath)) {
+      const fd = fs.openSync(lockPath, "wx", 0o600);
+      fs.closeSync(fd);
+      await protect(lockPath);
+    }
+    const lock = new DatabaseSync(lockPath, { timeout: 0 });
+    try {
+      try { lock.exec("BEGIN EXCLUSIVE"); } catch { throw new AgentError("agent_busy"); }
+      return await work((state) => this.save(state));
+    } finally { lock.close(); }
+  }
+
+  private async save(state: AgentState): Promise<void> {
+    if (!Value.Check(StateSchema, state)) throw new AgentError("agent_recovery_required");
+    this.validatePaths(state);
+    await this.checkDirectory();
+    if (exists(this.statePath)) await assertPrivate(this.statePath, false);
+    if (!exists(this.statePath)) {
+      const fd = fs.openSync(this.statePath, "wx", 0o600);
+      fs.closeSync(fd);
+      await protect(this.statePath);
+    }
+    const db = new DatabaseSync(this.statePath, { timeout: 0 });
+    try {
+      db.exec("PRAGMA journal_mode=DELETE; PRAGMA synchronous=FULL; PRAGMA max_page_count=8192; CREATE TABLE IF NOT EXISTS state(id INTEGER PRIMARY KEY CHECK(id=1), document TEXT NOT NULL)");
+      db.prepare("INSERT INTO state VALUES(1,?) ON CONFLICT(id) DO UPDATE SET document=excluded.document").run(JSON.stringify(state));
+    } finally { db.close(); }
+  }
+  private async checkDirectory(): Promise<void> {
+    await assertPrivate(this.root, true);
+    await assertPrivate(this.directory, true);
+    for (const suffix of ["-journal", "-wal", "-shm"]) {
+      const sidecar = this.statePath + suffix;
+      if (exists(sidecar)) {
+        assertNoLinks(sidecar);
+        if (!fs.lstatSync(sidecar).isFile()) throw new AgentError("agent_unsafe_path");
+      }
+    }
+  }
+  private validatePaths(state: AgentState): void {
+    if (state.targets.length !== 0 && state.targets.length !== (this.agent === "claude" ? 1 : 2)) throw new AgentError("agent_recovery_required");
+    for (const target of state.targets) {
+      if (!path.isAbsolute(target.path)) throw new AgentError("agent_recovery_required");
+    }
+    const steps = state.pending?.steps ?? [];
+    if (new Set(steps.map((step) => step.target)).size !== steps.length) throw new AgentError("agent_recovery_required");
+    for (const step of steps) {
+      const target = state.targets[step.target];
+      if (!target || path.dirname(step.scratch) !== path.dirname(target.path)
+        || !new RegExp(`^\\.ghcg-agents-${this.agent}-[0-9a-f-]{36}$`, "u").test(path.basename(step.scratch))) throw new AgentError("agent_recovery_required");
+    }
+    for (const garbage of state.pending?.garbage ?? []) {
+      if (!state.targets.some((target) => path.dirname(target.path) === path.dirname(garbage))
+        || !new RegExp(`^\\.ghcg-agents-${this.agent}-[0-9a-f-]{36}$`, "u").test(path.basename(garbage))) throw new AgentError("agent_recovery_required");
+    }
+  }
+}
+export function newImage(bytes: Buffer, original: FileImage | null): FileImage {
+  return { bytes: bytes.toString("base64"), mode: original?.mode ?? 0o600, acl: original?.acl ?? null };
+}
+export function copyMappings(mappings: readonly AgentMapping[]): AgentMapping[] {
+  return mappings.map((row) => ({ displayName: row.displayName, modelId: row.modelId }));
+}

--- a/src/agents/transform.ts
+++ b/src/agents/transform.ts
@@ -1,0 +1,124 @@
+import { parse, stringify, type TomlTable } from "smol-toml";
+import { AgentError, validateMappings, type AgentId, type AgentMapping, type AgentModel } from "./types.js";
+
+export interface AgentProjection {
+  readonly config: Buffer;
+  readonly catalog?: Buffer;
+}
+
+// These are client labels, never aliases in Gateway model resolution.
+export function projectAgent(
+  agent: AgentId,
+  original: Buffer | null,
+  mappings: readonly AgentMapping[],
+  origin: string,
+  catalogPath: string,
+  models: readonly AgentModel[],
+): AgentProjection {
+  validateMappings(agent, mappings);
+  if (!/^http:\/\/127\.0\.0\.1:[1-9]\d{0,4}$/u.test(origin) || Number(new URL(origin).port) > 65535) {
+    throw new AgentError("validation_failed");
+  }
+  if (mappings.some((mapping) => !models.some((model) => model.modelId === mapping.modelId))) {
+    throw new AgentError("agent_models_unavailable");
+  }
+  try {
+    const source = original?.toString("utf8").replace(/^\uFEFF/u, "") ?? "";
+    return agent === "claude"
+      ? { config: projectClaude(source, mappings, origin) }
+      : projectCodex(source, mappings, origin, catalogPath, models);
+  } catch (error: unknown) {
+    if (error instanceof AgentError) throw error;
+    // Parser diagnostics can contain configuration secrets.
+    throw new AgentError("agent_invalid_config");
+  }
+}
+
+function object(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new AgentError("agent_invalid_config");
+  return value as Record<string, unknown>;
+}
+
+function projectClaude(source: string, mappings: readonly AgentMapping[], origin: string): Buffer {
+  const config = source === "" ? {} : object(JSON.parse(source));
+  const env = config.env === undefined ? {} : object(config.env);
+  if (Object.values(env).some((value) => typeof value !== "string")) throw new AgentError("agent_invalid_config");
+  // Replace only the keys that route/authenticate Claude Code or pin models.
+  // Stale credentials or a Bedrock/Vertex/Foundry override would bypass the
+  // Gateway; unrelated keys (for example ANTHROPIC_CUSTOM_HEADERS) and the
+  // original file bytes return unchanged on Restore.
+  for (const key of [
+    "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL", "ANTHROPIC_REASONING_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL", "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL", "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL", "ANTHROPIC_DEFAULT_FABLE_MODEL_NAME",
+    "CLAUDE_CODE_SUBAGENT_MODEL", "CLAUDE_CODE_API_KEY_HELPER_TTL_MS",
+    "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_FOUNDRY",
+  ]) delete env[key];
+  delete config.apiKeyHelper;
+  delete config.awsAuthRefresh;
+  delete config.awsCredentialExport;
+  delete config.forceLoginMethod;
+  delete config.forceLoginOrgUUID;
+  // Settings-level model takes precedence over startup defaults in some client releases.
+  config.model = mappings[0]!.modelId;
+  env.ANTHROPIC_BASE_URL = origin;
+  env.ANTHROPIC_AUTH_TOKEN = "ghcg-local";
+  env.ANTHROPIC_MODEL = mappings[0]!.modelId;
+  env.ANTHROPIC_SMALL_FAST_MODEL = mappings[2]!.modelId;
+  for (const [index, role] of ["SONNET", "OPUS", "HAIKU"].entries()) {
+    env[`ANTHROPIC_DEFAULT_${role}_MODEL`] = mappings[index]!.modelId;
+    env[`ANTHROPIC_DEFAULT_${role}_MODEL_NAME`] = mappings[index]!.displayName;
+  }
+  if (mappings[3]) env.CLAUDE_CODE_SUBAGENT_MODEL = mappings[3].modelId;
+  config.env = env;
+  return Buffer.from(`${JSON.stringify(config, null, 2)}\n`);
+}
+
+function projectCodex(
+  source: string, mappings: readonly AgentMapping[], origin: string, catalogPath: string, models: readonly AgentModel[],
+): AgentProjection {
+  const config = source === "" ? {} as TomlTable : parse(source);
+  // Profiles and named subagents can override the provider/catalog. Refuse rather than
+  // silently configure only the root while another visible selection bypasses Gateway.
+  if (config.profile !== undefined || config.profiles !== undefined || config.agents !== undefined) {
+    throw new AgentError("agent_invalid_config");
+  }
+  const providers = config.model_providers === undefined ? {} : object(config.model_providers);
+  const reserved = "ghc_gateway";
+  if (providers[reserved] !== undefined) {
+    // Reapply is projected from the FIRST baseline, so a collision is always external.
+    throw new AgentError("agent_invalid_config");
+  }
+  providers[reserved] = {
+    name: "GHC Gateway", base_url: `${origin}/v1`, wire_api: "responses",
+    experimental_bearer_token: "ghcg-local", requires_openai_auth: false,
+  };
+  config.model_providers = providers as TomlTable;
+  config.model_provider = reserved;
+  config.model = mappings[0]!.modelId;
+  config.model_catalog_json = catalogPath;
+  // These global overrides describe the previous provider's model, not this
+  // catalog; leaving them would send unsupported reasoning/context directives.
+  for (const key of ["model_reasoning_effort", "model_reasoning_summary", "model_verbosity", "model_context_window",
+    "model_auto_compact_token_limit", "model_supports_reasoning_summaries", "review_model", "service_tier"]) delete config[key];
+  const catalog = { models: mappings.map((mapping, index) => {
+    const limit = models.find((model) => model.modelId === mapping.modelId)!.maxInputTokens;
+    return {
+      slug: mapping.modelId, display_name: mapping.displayName, description: mapping.displayName,
+      base_instructions: "You are Codex, a coding agent. Help the user with their coding tasks.",
+      supported_reasoning_levels: [], shell_type: "shell_command", visibility: "list", supported_in_api: true,
+      priority: index, support_verbosity: false, supports_reasoning_summaries: false,
+      supports_reasoning_summary_parameter: false, supports_parallel_tool_calls: false,
+      supports_image_detail_original: false, supports_search_tool: false,
+      truncation_policy: { mode: "bytes", limit: 10000 },
+      experimental_supported_tools: [], input_modalities: ["text"],
+      ...(limit === null ? {} : { context_window: limit, max_context_window: limit }),
+    };
+  }) };
+  const result = stringify(config);
+  parse(result);
+  return { config: Buffer.from(result), catalog: Buffer.from(`${JSON.stringify(catalog, null, 2)}\n`) };
+}

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,0 +1,59 @@
+export type AgentId = "claude" | "codex";
+export interface AgentMapping {
+  readonly displayName: string;
+  readonly modelId: string;
+}
+export type AgentErrorCode = "agent_conflict" | "agent_recovery_required" | "agent_unsafe_path"
+  | "agent_invalid_config" | "agent_models_unavailable" | "agent_busy" | "revision_conflict" | "validation_failed";
+export class AgentError extends Error {
+  constructor(readonly code: AgentErrorCode) {
+    super(code.replaceAll("_", " "));
+    this.name = "AgentError";
+  }
+}
+export interface AgentStatus {
+  readonly id: AgentId;
+  readonly state: "not_managed" | "installed" | "conflict" | "recovery_required" | "unsafe_path";
+  readonly revision: string;
+  readonly paths: readonly string[];
+  readonly endpoint: string;
+  readonly backupAvailable: boolean;
+  readonly lastAppliedAt: string | null;
+  readonly mappings: readonly AgentMapping[];
+  readonly canRestore: boolean;
+}
+export interface AgentsView {
+  readonly items: readonly AgentStatus[];
+  readonly catalogRevision: string | null;
+  readonly modelsAvailable: boolean;
+}
+export interface AgentApplyRequest {
+  readonly agent: AgentId;
+  readonly expectedRevision: string;
+  readonly catalogRevision: string;
+  readonly mappings: readonly AgentMapping[];
+}
+export interface AgentRestoreRequest {
+  readonly agent: AgentId;
+  readonly expectedRevision: string;
+}
+export interface AgentModel {
+  readonly modelId: string;
+  readonly maxInputTokens: number | null;
+}
+export interface AgentsManager {
+  inspect(origin: string): Promise<readonly AgentStatus[]>;
+  apply(request: AgentApplyRequest, origin: string, models: readonly AgentModel[], assertCurrent: () => void, signal: AbortSignal): Promise<AgentStatus>;
+  restore(request: AgentRestoreRequest, origin: string, signal: AbortSignal): Promise<AgentStatus>;
+  close(): void;
+}
+export const MAX_MAPPINGS = 16;
+export function validateMappings(agent: AgentId, mappings: readonly AgentMapping[]): void {
+  if ((agent === "claude" && mappings.length !== 3 && mappings.length !== 4)
+    || mappings.length < 1 || mappings.length > MAX_MAPPINGS
+    || mappings.some((row) => !/^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/u.test(row.modelId)
+      || row.displayName.trim().length === 0 || row.displayName.length > 80 || /[\p{C}]/u.test(row.displayName))
+    || (agent === "codex" && new Set(mappings.map((row) => row.modelId)).size !== mappings.length)) {
+    throw new AgentError("validation_failed");
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { FileAgentsManager } from "./agents/manager.js";
 import { fileURLToPath } from "node:url";
 import { createAdminStaticModule } from "./admin/static.js";
 import { createAdminModule } from "./admin/routes.js";
@@ -323,6 +324,7 @@ export async function composeProductionDaemonGateway(
     };
     const uptimeMs = options.uptimeMs ?? (() => Math.max(0, Math.floor(process.uptime() * 1000)));
     const admin = createAdminModule({
+      agents: new FileAgentsManager({ env: composition.env }),
       accounts: application.directory,
       deviceFlows,
       registry,

--- a/tests/contract/admin_agents.test.ts
+++ b/tests/contract/admin_agents.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+import { createAdminModule } from "../../src/admin/routes.js";
+import type { AdminModule } from "../../src/gateway/create_gateway.js";
+import { createGateway, type Gateway } from "../../src/gateway/create_gateway.js";
+import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
+import { parseStartupConfig } from "../../src/config/startup_config.js";
+import {
+  AgentError,
+  type AgentStatus,
+  type AgentsManager,
+} from "../../src/agents/types.js";
+import { adminDependencies, login, type TestAdminDependencies } from "./admin_test_harness.js";
+
+const ORIGIN = "http://127.0.0.1:31400";
+
+function agentStatus(agent: "claude" | "codex", revision: string, state: AgentStatus["state"] = "not_managed"): AgentStatus {
+  return {
+    id: agent,
+    state,
+    revision,
+    paths: agent === "claude" ? ["C:/home/.claude/settings.json"] : ["C:/home/.codex/ghcg-models.json", "C:/home/.codex/config.toml"],
+    endpoint: agent === "claude" ? ORIGIN : `${ORIGIN}/v1`,
+    backupAvailable: state !== "not_managed",
+    lastAppliedAt: state === "installed" ? "2027-01-15T08:00:00.000Z" : null,
+    mappings: [],
+    canRestore: state === "installed",
+  };
+}
+
+interface AgentStub {
+  readonly manager: AgentsManager;
+  readonly calls: string[];
+  failApply: string | null;
+}
+
+function agentStub(): AgentStub {
+  const calls: string[] = [];
+  const revisions = { claude: "a".repeat(64), codex: "b".repeat(64) };
+  const stub: AgentStub = {
+    calls,
+    failApply: null,
+    manager: {
+      async inspect(origin) {
+        calls.push(`inspect:${origin}`);
+        return [agentStatus("claude", revisions.claude), agentStatus("codex", revisions.codex)];
+      },
+      async apply(request, origin, models, assertCurrent, signal) {
+        signal.throwIfAborted();
+        calls.push(`apply:${request.agent}:${models.map((model) => model.modelId).join(",")}`);
+        if (stub.failApply !== null) throw new AgentError(stub.failApply as never);
+        assertCurrent();
+        if (request.expectedRevision !== revisions[request.agent]) throw new AgentError("revision_conflict");
+        return { ...agentStatus(request.agent, "c".repeat(64), "installed"), mappings: request.mappings };
+      },
+      async restore(request, _origin, signal) {
+        signal.throwIfAborted();
+        calls.push(`restore:${request.agent}`);
+        if (request.expectedRevision !== revisions[request.agent]) throw new AgentError("revision_conflict");
+        return agentStatus(request.agent, "d".repeat(64));
+      },
+      close() {},
+    },
+  };
+  return stub;
+}
+
+async function createHarness(stub: AgentStub | null): Promise<{
+  readonly gateway: Gateway;
+  readonly admin: AdminModule;
+  readonly dependencies: TestAdminDependencies;
+  readonly close: () => Promise<void>;
+}> {
+  const dependencies = adminDependencies();
+  let token = 0;
+  const admin = createAdminModule({
+    ...dependencies,
+    ...(stub === null ? {} : { agents: stub.manager }),
+    createToken: () => `agent-token-${++token}`,
+  });
+  const gateway = await createGateway({
+    startup: parseStartupConfig([], {}, { homedir: "Q:/tmp/admin-agents" }),
+    runtime: defaultRuntimeConfigSnapshot(),
+  }, [], { admin, createRequestId: () => "req_admin_agents" });
+  return { gateway, admin, dependencies, close: async () => gateway.close() };
+}
+
+const claudeMappings = [
+  { displayName: "Sonnet", modelId: "gpt-test" },
+  { displayName: "Opus", modelId: "gpt-test" },
+  { displayName: "Haiku", modelId: "gpt-test" },
+];
+
+describe("Admin agents API", () => {
+  it("serves agent status with the trusted listener origin and model catalog revision", async () => {
+    const stub = agentStub();
+    const harness = await createHarness(stub);
+    try {
+      const session = await login(harness.gateway, harness.admin);
+      const response = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents`, {
+        headers: { cookie: session.cookie },
+      }));
+      expect(response.status).toBe(200);
+      const body = await response.json() as { data: { items: AgentStatus[]; catalogRevision: string | null; modelsAvailable: boolean } };
+      expect(body.data.modelsAvailable).toBe(true);
+      expect(body.data.catalogRevision).toMatch(/^[a-f0-9]{64}$/u);
+      expect(body.data.items.map((item) => item.id)).toEqual(["claude", "codex"]);
+      expect(body.data.items[0]).toMatchObject({ state: "not_managed", endpoint: ORIGIN, backupAvailable: false });
+      expect(body.data.items[1]).toMatchObject({ endpoint: `${ORIGIN}/v1` });
+      expect(stub.calls).toEqual([`inspect:${ORIGIN}`]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("enforces session, Origin, CSRF and strict request schemas on mutations", async () => {
+    const stub = agentStub();
+    const harness = await createHarness(stub);
+    try {
+      const session = await login(harness.gateway, harness.admin);
+      const view = await (await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents`, {
+        headers: { cookie: session.cookie },
+      }))).json() as { data: { catalogRevision: string } };
+      const base = { agent: "claude", expectedRevision: "a".repeat(64), catalogRevision: view.data.catalogRevision, mappings: claudeMappings };
+
+      const noSession = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {
+        method: "POST", headers: { "content-type": "application/json", origin: ORIGIN }, body: JSON.stringify(base),
+      }));
+      expect(noSession.status).toBe(401);
+
+      const noCsrf = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {
+        method: "POST", headers: { "content-type": "application/json", origin: ORIGIN, cookie: session.cookie }, body: JSON.stringify(base),
+      }));
+      expect(noCsrf.status).toBe(403);
+
+      const wrongOrigin = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {
+        method: "POST", headers: { "content-type": "application/json", origin: "http://evil.example", cookie: session.cookie, "x-ghcg-csrf": session.csrf },
+        body: JSON.stringify(base),
+      }));
+      expect(wrongOrigin.status).toBe(403);
+
+      const extraField = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {
+        method: "POST", headers: { "content-type": "application/json", origin: ORIGIN, cookie: session.cookie, "x-ghcg-csrf": session.csrf },
+        body: JSON.stringify({ ...base, configDir: "C:/evil" }),
+      }));
+      expect(extraField.status).toBe(400);
+      expect(await extraField.json()).toMatchObject({ error: { code: "validation_failed" } });
+
+      const badModel = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {
+        method: "POST", headers: { "content-type": "application/json", origin: ORIGIN, cookie: session.cookie, "x-ghcg-csrf": session.csrf },
+        body: JSON.stringify({ ...base, mappings: [{ displayName: "X", modelId: "has space" }] }),
+      }));
+      expect(badModel.status).toBe(400);
+      expect(stub.calls.filter((call) => call.startsWith("apply:"))).toEqual([]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("rejects stale catalog and agent revisions with 409 before touching configuration", async () => {
+    const stub = agentStub();
+    const harness = await createHarness(stub);
+    try {
+      const session = await login(harness.gateway, harness.admin);
+      const view = await (await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents`, {
+        headers: { cookie: session.cookie },
+      }))).json() as { data: { catalogRevision: string } };
+      const send = (body: unknown) => harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {
+        method: "POST", headers: { "content-type": "application/json", origin: ORIGIN, cookie: session.cookie, "x-ghcg-csrf": session.csrf },
+        body: JSON.stringify(body),
+      }));
+      const staleCatalog = await send({ agent: "claude", expectedRevision: "a".repeat(64), catalogRevision: "0".repeat(64), mappings: claudeMappings });
+      expect(staleCatalog.status).toBe(409);
+      const staleAgent = await send({ agent: "claude", expectedRevision: "9".repeat(64), catalogRevision: view.data.catalogRevision, mappings: claudeMappings });
+      expect(staleAgent.status).toBe(409);
+      expect(stub.calls.filter((call) => call.startsWith("apply:")).length).toBe(1);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("applies and restores through the manager and maps agent errors to sanitized statuses", async () => {
+    const stub = agentStub();
+    const harness = await createHarness(stub);
+    try {
+      const session = await login(harness.gateway, harness.admin);
+      const headers = { "content-type": "application/json", origin: ORIGIN, cookie: session.cookie, "x-ghcg-csrf": session.csrf };
+      const view = await (await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents`, {
+        headers: { cookie: session.cookie },
+      }))).json() as { data: { catalogRevision: string } };
+
+      const applied = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {
+        method: "POST", headers, body: JSON.stringify({
+          agent: "claude", expectedRevision: "a".repeat(64), catalogRevision: view.data.catalogRevision, mappings: claudeMappings,
+        }),
+      }));
+      expect(applied.status).toBe(200);
+      expect(await applied.json()).toMatchObject({ data: { id: "claude", state: "installed", canRestore: true } });
+      expect(stub.calls).toContain("apply:claude:gpt-test");
+
+      stub.failApply = "agent_conflict";
+      const conflict = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {
+        method: "POST", headers, body: JSON.stringify({
+          agent: "claude", expectedRevision: "a".repeat(64), catalogRevision: view.data.catalogRevision, mappings: claudeMappings,
+        }),
+      }));
+      expect(conflict.status).toBe(409);
+      const conflictBody = await conflict.text();
+      expect(JSON.parse(conflictBody)).toMatchObject({ error: { code: "agent_conflict" } });
+      expect(conflictBody).not.toContain("secret");
+      stub.failApply = null;
+
+      const restored = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/restore`, {
+        method: "POST", headers, body: JSON.stringify({ agent: "codex", expectedRevision: "b".repeat(64) }),
+      }));
+      expect(restored.status).toBe(200);
+      expect(await restored.json()).toMatchObject({ data: { id: "codex", state: "not_managed" } });
+      expect(stub.calls).toContain("restore:codex");
+
+      const staleRestore = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/restore`, {
+        method: "POST", headers, body: JSON.stringify({ agent: "codex", expectedRevision: "0".repeat(64) }),
+      }));
+      expect(staleRestore.status).toBe(409);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("restore works when the Copilot account is unavailable but apply does not", async () => {
+    const stub = agentStub();
+    const harness = await createHarness(stub);
+    try {
+      const session = await login(harness.gateway, harness.admin);
+      harness.dependencies.accounts.list = () => [];
+      harness.dependencies.accounts.defaultState = () => ({ defaultRevision: 2, defaultAccountId: null });
+      const headers = { "content-type": "application/json", origin: ORIGIN, cookie: session.cookie, "x-ghcg-csrf": session.csrf };
+
+      const view = await (await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents`, {
+        headers: { cookie: session.cookie },
+      }))).json() as { data: { modelsAvailable: boolean; catalogRevision: string | null } };
+      expect(view.data).toMatchObject({ modelsAvailable: false, catalogRevision: null });
+
+      const applied = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {
+        method: "POST", headers, body: JSON.stringify({
+          agent: "claude", expectedRevision: "a".repeat(64), catalogRevision: "0".repeat(64), mappings: claudeMappings,
+        }),
+      }));
+      expect(applied.status).toBe(400);
+      expect(await applied.json()).toMatchObject({ error: { code: "agent_models_unavailable" } });
+
+      const restored = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/restore`, {
+        method: "POST", headers, body: JSON.stringify({ agent: "claude", expectedRevision: "a".repeat(64) }),
+      }));
+      expect(restored.status).toBe(200);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("returns not_found when the agents manager is not configured", async () => {
+    const harness = await createHarness(null);
+    try {
+      const session = await login(harness.gateway, harness.admin);
+      const response = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents`, {
+        headers: { cookie: session.cookie },
+      }));
+      expect(response.status).toBe(404);
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/tests/contract/admin_test_harness.ts
+++ b/tests/contract/admin_test_harness.ts
@@ -154,6 +154,8 @@ export function adminDependencies(now = { value: 1_800_000_000_000 }): TestAdmin
         return capabilitySnapshot(bound);
       },
       invalidate: (accountId) => calls.push(`invalidate:${accountId}`),
+      isCurrent: (snapshot) => snapshot.catalogGeneration === 7
+        && snapshot.credentialGeneration === 4,
     },
     preferences: {
       get: () => preference,

--- a/tests/e2e/admin_agents.spec.ts
+++ b/tests/e2e/admin_agents.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installAdminFixture } from "./fixtures/admin_fixture.js";
+
+async function openAgents(page: Page) {
+  const fixture = await installAdminFixture(page);
+  await page.goto("/admin/#bootstrap_token=one-time-secret");
+  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
+  await page.getByRole("button", { name: "Agents" }).click();
+  await expect(page.getByRole("heading", { name: "Agents" })).toBeFocused();
+  return fixture;
+}
+
+test("agents view sits between Models and Configuration with two consistent cards", async ({ page }) => {
+  await openAgents(page);
+  const labels = await page.locator(".nav-item").allTextContents();
+  expect(labels.map((label) => label.replace(/\[\d+\]/u, "").trim()))
+    .toEqual(["Overview", "Accounts", "Models", "Agents", "Configuration", "Events"]);
+
+  for (const title of ["Claude Code", "Codex"]) {
+    const card = page.locator(".agent-card", { has: page.getByRole("heading", { name: title }) });
+    await expect(card).toBeVisible();
+    await expect(card.getByText("Model mapping")).toBeVisible();
+    await expect(card.getByRole("button", { name: "Apply changes" })).toBeVisible();
+    await expect(card.getByRole("button", { name: "Restore" })).toBeVisible();
+    await expect(card.locator("select")).toHaveCount(0);
+    await expect(card.locator("input[type='radio']")).toHaveCount(0);
+    await expect(card.getByText(/first row is the startup model/)).toBeVisible();
+  }
+  // Claude maps its three native roles; Codex rows are addable/removable.
+  const claude = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Claude Code" }) });
+  await expect(claude.locator(".agent-mapping-row")).toHaveCount(3);
+  const codex = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Codex" }) });
+  await codex.getByRole("button", { name: "Add model" }).click();
+  await expect(codex.locator(".agent-mapping-row")).toHaveCount(2);
+  await codex.getByRole("button", { name: "Remove model 2" }).click();
+  await expect(codex.locator(".agent-mapping-row")).toHaveCount(1);
+});
+
+test("mapping edits gate Apply changes and apply posts exact text mappings", async ({ page }) => {
+  const fixture = await openAgents(page);
+  const codex = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Codex" }) });
+  const apply = codex.getByRole("button", { name: "Apply changes" });
+  await expect(apply).toBeDisabled();
+  await expect(codex.getByText("No unapplied changes")).toBeVisible();
+
+  await codex.getByLabel("Display name").fill("Fast");
+  await codex.getByLabel("Copilot model ID").fill("gpt-alpha");
+  await expect(codex.getByText("Unapplied changes")).toBeVisible();
+  await expect(apply).toBeEnabled();
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await apply.click();
+  await expect(codex.getByText(/Configuration installed\. Restart the client/)).toBeVisible();
+  await expect(codex.getByText("No unapplied changes")).toBeVisible();
+
+  const request = fixture.requests.find((item) => item.url().endsWith("/agents/apply"));
+  expect(request?.method()).toBe("POST");
+  expect(request?.postDataJSON()).toMatchObject({
+    agent: "codex",
+    catalogRevision: "c".repeat(64),
+    mappings: [{ displayName: "Fast", modelId: "gpt-alpha" }],
+  });
+});
+
+test("restore confirms and returns the card to Not managed", async ({ page }) => {
+  const fixture = await openAgents(page);
+  const claude = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Claude Code" }) });
+  for (const [index, model] of ["gpt-alpha", "gpt-alpha", "claude-beta"].entries()) {
+    await claude.getByLabel("Copilot model ID").nth(index).fill(model);
+  }
+  page.once("dialog", (dialog) => dialog.accept());
+  await claude.getByRole("button", { name: "Apply changes" }).click();
+  await expect(claude.locator(".badge")).toHaveText("Configuration installed");
+  await expect(claude.getByRole("button", { name: "Restore" })).toBeEnabled();
+
+  let confirmed = false;
+  page.once("dialog", (dialog) => {
+    confirmed = true;
+    expect(dialog.message()).toContain("restores the configuration saved before the first apply");
+    void dialog.accept();
+  });
+  await claude.getByRole("button", { name: "Restore" }).click();
+  expect(confirmed).toBe(true);
+  await expect(claude.locator(".badge")).toHaveText("Not managed");
+  expect(fixture.requests.some((item) => item.url().endsWith("/agents/restore"))).toBe(true);
+});
+
+test("conflict and unavailable states block apply without destructive actions", async ({ page }) => {
+  const fixture = await installAdminFixture(page);
+  fixture.state.agents.codex = { ...fixture.state.agents.codex, state: "conflict" };
+  fixture.state.agents.claude = { ...fixture.state.agents.claude, state: "recovery_required" };
+  fixture.state.agentsApplyConflict = false;
+  await page.goto("/admin/#bootstrap_token=one-time-secret");
+  await page.getByRole("button", { name: "Agents" }).click();
+  await expect(page.getByRole("heading", { name: "Agents" })).toBeFocused();
+
+  const codex = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Codex" }) });
+  await expect(codex.locator(".badge")).toHaveText("External changes detected");
+  await expect(codex.getByText(/Outside edits are never overwritten/)).toBeVisible();
+  await codex.getByLabel("Display name").fill("Fast");
+  await codex.getByLabel("Copilot model ID").fill("gpt-alpha");
+  await expect(codex.getByRole("button", { name: "Apply changes" })).toBeDisabled();
+
+  const claude = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Claude Code" }) });
+  await expect(claude.locator(".badge")).toHaveText("Recovery required");
+  await expect(claude.getByRole("button", { name: "Restore" })).toBeDisabled();
+});
+
+test("agents cards stay responsive without horizontal scrolling", async ({ page }) => {
+  await openAgents(page);
+  for (const width of [1440, 900, 390, 320]) {
+    await page.setViewportSize({ width, height: 900 });
+    await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
+  }
+});
+
+test("agents mapping rows are keyboard operable with unique labels", async ({ page }) => {
+  await openAgents(page);
+  await expect(page.locator(".agent-card")).toHaveCount(2);
+  const evidence = await page.evaluate(() => {
+    const controls = [...document.querySelectorAll<HTMLElement>(".agent-card input, .agent-card button")];
+    const name = (element: HTMLElement): string => {
+      const explicit = element.getAttribute("aria-label");
+      if (explicit !== null && explicit !== "") return explicit;
+      const wrapped = element.closest("label")?.textContent?.trim();
+      if (wrapped !== undefined && wrapped !== "") return wrapped;
+      return element.textContent?.trim() ?? "";
+    };
+    return {
+      controls: controls.length,
+      unnamed: controls.filter((element) => name(element) === "").length,
+      dialogs: document.querySelectorAll(".agent-card").length,
+    };
+  });
+  expect(evidence.dialogs).toBe(2);
+  expect(evidence.controls).toBeGreaterThan(10);
+  expect(evidence.unnamed).toBe(0);
+});

--- a/tests/e2e/admin_shell_polish.spec.ts
+++ b/tests/e2e/admin_shell_polish.spec.ts
@@ -26,7 +26,7 @@ for (const width of [1440, 390]) {
       const menu = page.getByRole("button", { name: "Open navigation" });
       if (await menu.isVisible()) await menu.click();
       const navigation = page.getByRole("navigation");
-      await expect(navigation.getByRole("button")).toHaveCount(5);
+      await expect(navigation.getByRole("button")).toHaveCount(6);
       await expect(navigation.getByRole("button", { name: "Responses History" })).toHaveCount(0);
       await navigation.getByRole("button", { name: "Events", exact: true }).click();
       await expect(page.getByRole("heading", { name: "Events", exact: true })).toBeFocused();

--- a/tests/e2e/fixtures/admin_fixture.ts
+++ b/tests/e2e/fixtures/admin_fixture.ts
@@ -10,6 +10,7 @@ import type {
   AdminRuntimeConfig,
   AdminStatus,
 } from "../../../web/src/types.js";
+import type { AgentStatus, AgentsView } from "../../../src/agents/types.js";
 
 const NOW = "2026-09-03T12:00:00.000Z";
 export const ADMIN_FIXTURE_NOW_MS = Date.parse(NOW);
@@ -52,6 +53,9 @@ export interface AdminFixture {
     deviceNowMs: number;
     accountsDelayMs: number;
     modelDelayByAccount: Record<string, number>;
+    agents: Record<"claude" | "codex", AgentStatus>;
+    agentsCatalogRevision: string | null;
+    agentsApplyConflict: boolean;
     cancelCompletesDeviceFlow: boolean;
     streamBodies: string[];
     streamDelaysMs: number[];
@@ -136,6 +140,9 @@ export async function installAdminFixture(page: Page): Promise<AdminFixture> {
       deviceNowMs: ADMIN_FIXTURE_NOW_MS,
       accountsDelayMs: 0,
       modelDelayByAccount: {},
+      agents: { claude: agentStatus("claude", 1), codex: agentStatus("codex", 7) },
+      agentsCatalogRevision: "c".repeat(64),
+      agentsApplyConflict: false,
       cancelCompletesDeviceFlow: false,
       streamBodies: [sse("performance", { kind: "performance", status: status("healthy") })],
       streamDelaysMs: [],
@@ -179,6 +186,27 @@ export async function installAdminFixture(page: Page): Promise<AdminFixture> {
     });
   });
   return fixture;
+}
+
+function nextAgentRevision(revision: string): string {
+  const next = ((Number.parseInt(revision[0] ?? "a", 16) + 1) % 16).toString(16);
+  return next.repeat(64);
+}
+
+function agentStatus(agent: "claude" | "codex", seed: number): AgentStatus {
+  return {
+    id: agent,
+    state: "not_managed",
+    revision: seed.toString(16).repeat(64),
+    paths: agent === "claude"
+      ? ["C:/Users/octo/.claude/settings.json"]
+      : ["C:/Users/octo/.codex/ghcg-models.json", "C:/Users/octo/.codex/config.toml"],
+    endpoint: agent === "claude" ? "http://127.0.0.1:31400" : "http://127.0.0.1:31400/v1",
+    backupAvailable: false,
+    lastAppliedAt: null,
+    mappings: [],
+    canRestore: false,
+  };
 }
 
 function modelItem(input: {
@@ -279,6 +307,47 @@ async function handle(
         latencyMaxMs: 120,
       },
     });
+  }
+  if (path === "/agents") {
+    const view: AgentsView = {
+      items: [structuredClone(fixture.state.agents.claude), structuredClone(fixture.state.agents.codex)],
+      catalogRevision: fixture.state.agentsCatalogRevision,
+      modelsAvailable: fixture.state.agentsCatalogRevision !== null,
+    };
+    return json(route, 200, view);
+  }
+  if (path === "/agents/apply" && request.method() === "POST") {
+    const body = request.postDataJSON() as { agent: "claude" | "codex"; expectedRevision: string; mappings: { displayName: string; modelId: string }[] };
+    if (fixture.state.agentsApplyConflict) return failure(route, 409, "agent_conflict");
+    const current = fixture.state.agents[body.agent];
+    if (body.expectedRevision !== current.revision) return failure(route, 409, "revision_conflict");
+    const next: AgentStatus = {
+      ...current,
+      state: "installed",
+      revision: nextAgentRevision(current.revision),
+      backupAvailable: true,
+      lastAppliedAt: NOW,
+      mappings: body.mappings,
+      canRestore: true,
+    };
+    fixture.state.agents[body.agent] = next;
+    return json(route, 200, next);
+  }
+  if (path === "/agents/restore" && request.method() === "POST") {
+    const body = request.postDataJSON() as { agent: "claude" | "codex"; expectedRevision: string };
+    const current = fixture.state.agents[body.agent];
+    if (body.expectedRevision !== current.revision) return failure(route, 409, "revision_conflict");
+    const next: AgentStatus = {
+      ...current,
+      state: "not_managed",
+      revision: nextAgentRevision(current.revision),
+      backupAvailable: false,
+      lastAppliedAt: null,
+      mappings: [],
+      canRestore: false,
+    };
+    fixture.state.agents[body.agent] = next;
+    return json(route, 200, next);
   }
   if (path === "/accounts") {
     const accounts = structuredClone(fixture.state.accounts);

--- a/tests/integration/agents_files.test.ts
+++ b/tests/integration/agents_files.test.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileAgentsManager, type AgentManagerOptions } from "../../src/agents/manager.js";
+import type { AgentId, AgentMapping } from "../../src/agents/types.js";
+
+const homes: string[] = [];
+const origin = "http://127.0.0.1:32567";
+const models = ["model-a", "model-b", "model-c"].map((modelId) => ({ modelId, maxInputTokens: 32000 }));
+const mappings = models.map((model) => ({ displayName: `Label ${model.modelId}`, modelId: model.modelId }));
+function harness(options: Omit<AgentManagerOptions, "home"> = {}) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "ghcg-agents-"));
+  homes.push(home);
+  const manager = new FileAgentsManager({ home, now: () => new Date("2026-01-02T03:04:05Z"), ...options });
+  const status = async (agent: AgentId) => (await manager.inspect(origin)).find((item) => item.id === agent)!;
+  return { home, manager, status };
+}
+async function apply(manager: FileAgentsManager, agent: AgentId, rows: readonly AgentMapping[] = mappings) {
+  const status = (await manager.inspect(origin)).find((item) => item.id === agent)!;
+  return await manager.apply({ agent, expectedRevision: status.revision, catalogRevision: "a".repeat(64), mappings: rows }, origin, models, () => undefined, new AbortController().signal);
+}
+async function restore(manager: FileAgentsManager, agent: AgentId) {
+  const status = (await manager.inspect(origin)).find((item) => item.id === agent)!;
+  return await manager.restore({ agent, expectedRevision: status.revision }, origin, new AbortController().signal);
+}
+function seed(home: string, target: string, bytes: Buffer | string): string {
+  const file = path.join(home, target);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, bytes, { mode: 0o600 });
+  return file;
+}
+afterEach(() => { for (const home of homes.splice(0)) fs.rmSync(home, { recursive: true, force: true }); });
+
+describe("private reversible agent configuration", () => {
+  it("reads without creating any directories and rejects invalid parsing before writes", async () => {
+    const h = harness();
+    expect((await h.status("codex")).state).toBe("not_managed");
+    expect(fs.readdirSync(h.home)).toEqual([]);
+    seed(h.home, ".codex/config.toml", "token=\"secret\n");
+    await expect(apply(h.manager, "codex")).rejects.toThrow("agent invalid config");
+    expect(fs.readdirSync(h.home)).toEqual([".codex"]);
+  }, 180_000);
+
+  it("round-trips exact original Claude bytes through A -> B -> C -> Restore A", async () => {
+    const h = harness();
+    const original = Buffer.from("\ufeff{\r\n  \"hooks\": {\"Stop\": []}, \"env\": {\"OTHER\":\"untouched\"}\r\n}\r\n");
+    const file = seed(h.home, ".claude/settings.json", original);
+    seed(h.home, ".claude/.credentials.json", "login-secret");
+    expect((await apply(h.manager, "claude")).state).toBe("installed");
+    const first = await h.status("claude");
+    expect(first.lastAppliedAt).toBe("2026-01-02T03:04:05.000Z");
+    expect((await apply(h.manager, "claude", [...mappings].reverse())).state).toBe("installed");
+    await expect(h.manager.restore({ agent: "claude", expectedRevision: first.revision }, origin, new AbortController().signal)).rejects.toThrow("revision conflict");
+    expect((await restore(h.manager, "claude")).state).toBe("not_managed");
+    expect(fs.readFileSync(file)).toEqual(original);
+    expect(fs.readFileSync(path.join(h.home, ".claude/.credentials.json"), "utf8")).toBe("login-secret");
+  }, 300_000);
+
+  it("restores absent Codex config/catalog and retains auth.json; first baseline survives reapply/restart", async () => {
+    const h = harness();
+    const auth = seed(h.home, ".codex/auth.json", "login-secret");
+    expect((await apply(h.manager, "codex")).state).toBe("installed");
+    const restarted = new FileAgentsManager({ home: h.home });
+    expect((await apply(restarted, "codex", [...mappings].reverse())).state).toBe("installed");
+    const value = JSON.parse(fs.readFileSync(path.join(h.home, ".codex/ghcg-models.json"), "utf8"));
+    expect(value.models.map((row: { slug: string }) => row.slug)).toEqual([...models].reverse().map((row) => row.modelId));
+    expect((await restore(restarted, "codex")).state).toBe("not_managed");
+    expect(fs.readdirSync(path.join(h.home, ".codex"))).toEqual(["auth.json"]);
+    expect(fs.readFileSync(auth, "utf8")).toBe("login-secret");
+  }, 300_000);
+
+  it("reports outside edits as conflict and never overwrites them", async () => {
+    const h = harness();
+    const original = seed(h.home, ".claude/settings.json", JSON.stringify({ env: { OTHER: "keep" } }));
+    await apply(h.manager, "claude");
+    const external = Buffer.from(JSON.stringify({ env: { OTHER: "external-edit" } }));
+    fs.writeFileSync(original, external);
+    expect((await h.status("claude")).state).toBe("conflict");
+    await expect(apply(h.manager, "claude")).rejects.toThrow("agent conflict");
+    await expect(restore(h.manager, "claude")).rejects.toThrow("agent conflict");
+    expect(fs.readFileSync(original)).toEqual(external);
+  }, 180_000);
+
+  it("revalidates the live file after staging and before rename", async () => {
+    const home = homeWithCrash();
+    const original = seed(home, ".claude/settings.json", JSON.stringify({ env: { OTHER: "keep" } }));
+    const external = Buffer.from(JSON.stringify({ env: { OTHER: "raced" } }));
+    const manager = new FileAgentsManager({
+      home,
+      checkpoint: (point, agent, index) => {
+        if (point === "staged" && agent === "claude" && index === 0) fs.writeFileSync(original, external);
+      },
+    });
+    await expect(apply(manager, "claude")).rejects.toThrow("agent conflict");
+    expect(fs.readFileSync(original)).toEqual(external);
+  }, 180_000);
+
+  it("serializes concurrent applies from two Gateway instances sharing a home", async () => {
+    const h = harness();
+    const second = new FileAgentsManager({ home: h.home });
+    const reversed = [...mappings].reverse();
+    const firstStatus = await h.status("claude");
+    const [one, two] = await Promise.allSettled([
+      h.manager.apply({ agent: "claude", expectedRevision: firstStatus.revision, catalogRevision: "a".repeat(64), mappings }, origin, models, () => undefined, new AbortController().signal),
+      second.apply({ agent: "claude", expectedRevision: firstStatus.revision, catalogRevision: "a".repeat(64), mappings: reversed }, origin, models, () => undefined, new AbortController().signal),
+    ]);
+    const outcomes = [one, two];
+    expect(outcomes.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = outcomes.find((result) => result.status === "rejected");
+    expect(rejected?.status).toBe("rejected");
+    expect((rejected as PromiseRejectedResult).reason).toMatchObject({ name: "AgentError" });
+    const live = JSON.parse(fs.readFileSync(path.join(h.home, ".claude/settings.json"), "utf8"));
+    const winner = one.status === "fulfilled" ? mappings : reversed;
+    expect(live.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(winner[0]!.modelId);
+    expect((await restore(h.manager, "claude")).state).toBe("not_managed");
+  }, 300_000);
+
+  it.each([
+    ["intent", -1],
+    ["linked", 0],
+    ["published", 0],
+    ["displaced", 1],
+  ] as const)("recovers original Codex bytes after a crash at %s", async (point, index) => {
+    const original = Buffer.from("model = \"old\"\n# comment survives\n");
+    const file = seed(homeWithCrash(), ".codex/config.toml", original);
+    const crashed = new FileAgentsManager({
+      home: homes.at(-1)!,
+      now: () => new Date("2026-01-02T03:04:05Z"),
+      checkpoint: (hitPoint, _agent, hitIndex) => {
+        if (hitPoint === point && hitIndex === index) throw new Error("simulated crash");
+      },
+    });
+    await expect(apply(crashed, "codex")).rejects.toThrow();
+    const restarted = new FileAgentsManager({ home: homes.at(-1)! });
+    expect((await restarted.inspect(origin)).find((item) => item.id === "codex")!.state).toBe("recovery_required");
+    const status = await restarted.inspect(origin);
+    await expect(restarted.apply({ agent: "codex", expectedRevision: status.find((item) => item.id === "codex")!.revision,
+      catalogRevision: "a".repeat(64), mappings }, origin, models, () => undefined, new AbortController().signal)).rejects.toThrow("recovery required");
+    const restored = await restarted.restore({ agent: "codex", expectedRevision: status.find((item) => item.id === "codex")!.revision }, origin, new AbortController().signal);
+    expect(restored.state).toBe("not_managed");
+    expect(fs.readFileSync(file)).toEqual(original);
+    expect(fs.readdirSync(path.join(homes.at(-1)!, ".codex"))).toEqual(["config.toml"]);
+  }, 300_000);
+
+  it("rejects symlinked configuration directories without writing", async () => {
+    const h = harness();
+    const elsewhere = fs.mkdtempSync(path.join(os.tmpdir(), "ghcg-agents-elsewhere-"));
+    homes.push(elsewhere);
+    fs.symlinkSync(elsewhere, path.join(h.home, ".claude"), process.platform === "win32" ? "junction" : "dir");
+    await expect(apply(h.manager, "claude")).rejects.toThrow("agent unsafe path");
+    expect(fs.readdirSync(elsewhere)).toEqual([]);
+  }, 180_000);
+
+  it.skipIf(process.platform === "win32")("accepts a canonicalized home alias but still rejects links below it", async () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), "ghcg-agents-alias-"));
+    homes.push(parent);
+    const realHome = path.join(parent, "real-home");
+    const aliasHome = path.join(parent, "alias-home");
+    const elsewhere = path.join(parent, "elsewhere");
+    fs.mkdirSync(realHome, { mode: 0o700 });
+    fs.mkdirSync(elsewhere, { mode: 0o700 });
+    fs.symlinkSync(realHome, aliasHome, "dir");
+    const manager = new FileAgentsManager({ home: aliasHome });
+    expect((await manager.inspect(origin)).find((item) => item.id === "claude")!.state).toBe("not_managed");
+    fs.symlinkSync(elsewhere, path.join(realHome, ".claude"), "dir");
+    await expect(apply(manager, "claude")).rejects.toThrow("agent unsafe path");
+  }, 180_000);
+
+  it.skipIf(process.platform === "win32")("rejects world-readable recovery state", async () => {
+    const h = harness();
+    await apply(h.manager, "claude");
+    fs.chmodSync(path.join(h.home, ".ghc-gateway-agents/claude/state.db"), 0o644);
+    expect((await h.status("claude")).state).toBe("unsafe_path");
+  }, 180_000);
+});
+
+function homeWithCrash(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "ghcg-agents-"));
+  homes.push(home);
+  return home;
+}

--- a/tests/integration/pack.test.ts
+++ b/tests/integration/pack.test.ts
@@ -175,6 +175,7 @@ describe("package evidence", () => {
       "@hono/node-server@2.1.1",
       "@sinclair/typebox@0.34.52",
       "hono@4.13.4",
+      "smol-toml@1.8.0",
       "undici@8.10.0",
     ]);
   });

--- a/tests/unit/agents_model_resolution.test.ts
+++ b/tests/unit/agents_model_resolution.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { capabilitySnapshotFromCatalog } from "../../src/copilot/capability_registry.js";
+import { resolveGitHubEnvironment } from "../../src/accounts/github_environment.js";
+import { resolveModel } from "../../src/protocols/model_catalog/resolver.js";
+import { planProtocolExecution } from "../../src/protocols/conversion/planner.js";
+import { projectAgent } from "../../src/agents/transform.js";
+import { parseLiveModelCapabilities } from "../../src/copilot/model_capabilities.js";
+import { isWireJsonObject, parseWireJson, type WireJsonObject } from "../../src/serialization/wire_json.js";
+
+const origin = "http://127.0.0.1:32567";
+
+function wireBody(value: unknown): WireJsonObject {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  const parsed = parseWireJson(bytes, { maxBytes: bytes.byteLength, maxDepth: 64 });
+  if (!isWireJsonObject(parsed)) throw new Error("expected object");
+  return parsed;
+}
+const account = {
+  accountId: "github.com/42",
+  environment: resolveGitHubEnvironment("github.com"),
+  userId: "42",
+  login: "octocat",
+  displayName: null,
+  credentialGeneration: 4,
+};
+
+function snapshotWith(models: readonly { id: string; protocols: readonly string[] }[]) {
+  return capabilitySnapshotFromCatalog(account, {
+    accountId: account.accountId,
+    generation: 7,
+    credentialGeneration: 4,
+    fetchedAt: "2027-01-15T08:00:00.000Z",
+    models: models.map((model) => ({
+      id: model.id,
+      name: model.id,
+      vendor: "test",
+      modelPickerEnabled: true,
+      capabilities: parseLiveModelCapabilities({
+        supported_endpoints: model.protocols.map((protocol) => `/v1/${protocol === "chat" ? "chat/completions" : protocol}`),
+        max_input_tokens: 128_000,
+      }),
+    })),
+  });
+}
+
+describe("agent configuration compatibility with Gateway model resolution", () => {
+  it("resolves every generated Codex catalog slug explicitly and plans native Responses", () => {
+    const snapshot = snapshotWith([
+      { id: "gpt-test", protocols: ["responses"] },
+      { id: "claude-test", protocols: ["messages", "chat"] },
+    ]);
+    const projection = projectAgent("codex", null, [
+      { displayName: "Coding", modelId: "gpt-test" },
+      { displayName: "Writer", modelId: "claude-test" },
+    ], origin, "ghcg-models.json", [
+      { modelId: "gpt-test", maxInputTokens: 128_000 },
+      { modelId: "claude-test", maxInputTokens: 128_000 },
+    ]);
+    const catalog = JSON.parse(projection.catalog!.toString()) as { models: { slug: string }[] };
+    for (const entry of catalog.models) {
+      const resolved = resolveModel(snapshot, entry.slug, null);
+      expect(resolved).toMatchObject({ upstreamModel: entry.slug, source: "explicit" });
+    }
+    const config = projection.config.toString();
+    expect(config).toContain("model = \"gpt-test\"");
+
+    // Native protocol short-circuit: a Responses-capable model needs no conversion.
+    const resolved = resolveModel(snapshot, "gpt-test", null);
+    if (!("upstreamModel" in resolved)) throw new Error("resolution failed");
+    const plan = planProtocolExecution({
+      source: "responses",
+      stream: false,
+      body: wireBody({}),
+      resolvedModel: "gpt-test",
+      capability: resolved.capability,
+    });
+    expect(plan).toMatchObject({ kind: "native", target: "responses" });
+
+    // A Messages-only model still routes deterministically through conversion.
+    const converted = resolveModel(snapshot, "claude-test", null);
+    if (!("upstreamModel" in converted)) throw new Error("resolution failed");
+    const bridged = planProtocolExecution({
+      source: "responses",
+      stream: false,
+      body: wireBody({ model: "claude-test", input: "hi" }),
+      resolvedModel: "claude-test",
+      capability: converted.capability,
+    });
+    expect(bridged.kind).toBe("converted");
+    expect(bridged.target).toBe("chat");
+  });
+
+  it("resolves Claude role model IDs explicitly through the Messages endpoint", () => {
+    const snapshot = snapshotWith([
+      { id: "sonnet-real", protocols: ["messages"] },
+      { id: "opus-real", protocols: ["chat"] },
+      { id: "haiku-real", protocols: ["messages"] },
+    ]);
+    const projection = projectAgent("claude", null, [
+      { displayName: "Sonnet", modelId: "sonnet-real" },
+      { displayName: "Opus", modelId: "opus-real" },
+      { displayName: "Haiku", modelId: "haiku-real" },
+    ], origin, "unused", [
+      { modelId: "sonnet-real", maxInputTokens: null },
+      { modelId: "opus-real", maxInputTokens: null },
+      { modelId: "haiku-real", maxInputTokens: null },
+    ]);
+    const env = JSON.parse(projection.config.toString()).env as Record<string, string>;
+    for (const key of ["ANTHROPIC_MODEL", "ANTHROPIC_DEFAULT_SONNET_MODEL", "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_DEFAULT_HAIKU_MODEL"]) {
+      const resolved = resolveModel(snapshot, env[key]!, null);
+      expect(resolved).toMatchObject({ upstreamModel: env[key], source: "explicit" });
+    }
+    expect(env.ANTHROPIC_BASE_URL).toBe(origin);
+  });
+});

--- a/tests/unit/agents_transform.test.ts
+++ b/tests/unit/agents_transform.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "smol-toml";
+import { projectAgent } from "../../src/agents/transform.js";
+
+const origin = "http://127.0.0.1:32567";
+const mappings = ["real-sonnet", "real-opus", "real-haiku"].map((modelId, index) => ({ modelId, displayName: `Friendly ${index}` }));
+const models = mappings.map((row, i) => ({ modelId: row.modelId, maxInputTokens: i === 0 ? 32000 : null }));
+
+describe("agent configuration projection", () => {
+  it("projects Claude native roles, clears competing auth/backends and preserves hooks/MCP/unrelated settings", () => {
+    const config = { env: { ANTHROPIC_API_KEY: "secret", CLAUDE_CODE_USE_BEDROCK: "1", KEEP_ME: "yes" },
+      apiKeyHelper: "secret-command", model: "old", hooks: { Stop: [] }, mcpServers: { local: { command: "node" } }, theme: "dark" };
+    const value = JSON.parse(projectAgent("claude", Buffer.from(`\ufeff${JSON.stringify(config)}\r\n`), mappings, origin, "unused", models).config.toString());
+    expect(value).toMatchObject({ model: "real-sonnet", hooks: config.hooks, mcpServers: config.mcpServers, theme: "dark", env: {
+      KEEP_ME: "yes", ANTHROPIC_BASE_URL: origin, ANTHROPIC_AUTH_TOKEN: "ghcg-local", ANTHROPIC_MODEL: "real-sonnet",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "real-sonnet", ANTHROPIC_DEFAULT_SONNET_MODEL_NAME: "Friendly 0",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "real-opus", ANTHROPIC_DEFAULT_HAIKU_MODEL: "real-haiku",
+    } });
+    expect(value.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(value.env.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
+    expect(value.apiKeyHelper).toBeUndefined();
+  });
+  it("generates a multi-model Responses catalog with actual request IDs and conservative metadata", () => {
+    const source = "\ufeff# keep on restore\r\nmodel=\"old\"\r\nmodel_catalog_json=\"/external/catalog.json\"\r\nweb_search=\"live\"\r\n[model_providers.other]\r\nname=\"Other\"\r\n[mcp_servers.local]\r\ncommand=\"node\"\r\n";
+    const result = projectAgent("codex", Buffer.from(source), mappings, origin, "C:\\test\\ghcg-models.json", models);
+    expect(parse(result.config.toString())).toMatchObject({ model: "real-sonnet", model_provider: "ghc_gateway", model_catalog_json: "C:\\test\\ghcg-models.json",
+      model_providers: { other: { name: "Other" }, ghc_gateway: { base_url: `${origin}/v1`, wire_api: "responses", requires_openai_auth: false, experimental_bearer_token: "ghcg-local" } },
+      mcp_servers: { local: { command: "node" } }, web_search: "live" });
+    const catalog = JSON.parse(result.catalog!.toString());
+    expect(catalog.models.map((model: { slug: string }) => model.slug)).toEqual(mappings.map((row) => row.modelId));
+    expect(catalog.models[0]).toMatchObject({ display_name: "Friendly 0", context_window: 32000, shell_type: "shell_command", supported_reasoning_levels: [], supports_reasoning_summary_parameter: false, experimental_supported_tools: [], input_modalities: ["text"] });
+    expect(catalog.models[1].context_window).toBeUndefined();
+    expect(catalog.models[1].default_reasoning_level).toBeUndefined();
+  });
+  it.each(["profile=\"work\"", "[profiles.work]\nmodel=\"other\"", "[agents.worker]\nconfig_file=\"other.toml\"", "[model_providers.ghc_gateway]\nname=\"external\"", "invalid=\"unterminated"])(
+    "refuses unsupported Codex routing/configuration without parser diagnostics: %s",
+    (source) => {
+      expect(() => projectAgent("codex", Buffer.from(source), mappings, origin, "catalog.json", models)).toThrow("agent invalid config");
+    },
+  );
+  it("rejects unknown models, duplicate Codex IDs, invalid labels/IDs, endpoint injection and role count", () => {
+    expect(() => projectAgent("codex", null, mappings, origin, "catalog.json", [])).toThrow("agent models unavailable");
+    expect(() => projectAgent("codex", null, [mappings[0]!, mappings[0]!], origin, "catalog.json", models)).toThrow("validation failed");
+    expect(() => projectAgent("claude", null, mappings.slice(0, 1), origin, "catalog.json", models)).toThrow("validation failed");
+    expect(() => projectAgent("claude", null, mappings, "https://evil.example", "catalog.json", models)).toThrow("validation failed");
+    expect(() => projectAgent("claude", Buffer.from("{\"secret\":\"broken"), mappings, origin, "catalog.json", models)).toThrow("agent invalid config");
+  });
+});

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -7,6 +7,7 @@
     AdminStatus,
     StreamState,
   } from "./types.js";
+  import Agents from "./views/Agents.svelte";
   import Accounts from "./views/Accounts.svelte";
   import Configuration from "./views/Configuration.svelte";
   import Events from "./views/Events.svelte";
@@ -14,7 +15,7 @@
   import Overview from "./views/Overview.svelte";
   import TerminalMark from "./TerminalMark.svelte";
 
-  const views = ["Overview", "Accounts", "Models", "Configuration", "Events"] as const;
+  const views = ["Overview", "Accounts", "Models", "Agents", "Configuration", "Events"] as const;
   type View = typeof views[number];
 
   let view: View = $state("Overview");
@@ -235,6 +236,8 @@
             <Accounts {client} {pageNumber} />
           {:else if view === "Models"}
             <Models {client} {pageNumber} />
+          {:else if view === "Agents"}
+            <Agents {client} {pageNumber} />
           {:else if view === "Configuration"}
             <Configuration {client} {pageNumber} />
           {:else}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,3 +1,4 @@
+import type { AgentsView, AgentStatus, AgentApplyRequest, AgentRestoreRequest } from "../../src/agents/types.js";
 import type {
   AdminAccount,
   AdminAccounts,
@@ -58,6 +59,9 @@ export class AdminClient {
   models(accountId?: string): Promise<AdminModels> {
     return this.request(`/models${accountId === undefined ? "" : `?accountId=${encodeURIComponent(accountId)}`}`);
   }
+  agents(): Promise<AgentsView> { return this.request("/agents"); }
+  applyAgent(value: AgentApplyRequest): Promise<AgentStatus> { return this.mutate("/agents/apply", "POST", value); }
+  restoreAgent(value: AgentRestoreRequest): Promise<AgentStatus> { return this.mutate("/agents/restore", "POST", value); }
   config(): Promise<AdminRuntimeConfig> { return this.request("/config"); }
   history(): Promise<AdminHistorySummary> { return this.request("/history"); }
   events(cursor?: string): Promise<AdminEventPage> {
@@ -144,6 +148,12 @@ export function takeBootstrapToken(): string | null {
 
 export function errorMessage(error: unknown): string {
   if (error instanceof ApiError) {
+    if (error.code === "agent_invalid_config") return "Unsupported or invalid client configuration. Check global configuration syntax and remove conflicting profiles or reserved providers before applying.";
+    if (error.code === "agent_models_unavailable") return "Use exact enabled Copilot model IDs with usable capabilities from Models, then refresh.";
+    if (error.code === "agent_unsafe_path") return "The configuration path or access permissions are unsafe or unsupported. No forced overwrite is available.";
+    if (error.code === "agent_recovery_required") return "Recovery is required. Refresh to inspect; keep recovery files and do not overwrite external changes.";
+    if (error.code === "agent_conflict") return "Client configuration changed outside Gateway. Refresh and reconcile those changes before applying or restoring.";
+    if (error.code === "agent_busy") return "Another agent configuration operation is running. Try again after it finishes.";
     if (error.status === 409) return "This data changed elsewhere. Refresh before trying again.";
     if (error.status === 403) return "The security check rejected this change.";
     if (error.status === 0) return "The gateway is unreachable. Check that it is still running.";

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -453,3 +453,24 @@ tr.current-row > td:last-child, .account-table tr > td:last-child { padding-righ
 @media (prefers-reduced-motion: reduce) {
   * { scroll-behavior: auto !important; transition: none !important; }
 }
+
+.agent-cards { display: grid; gap: 24px; margin-top: 24px; }
+.agent-card { min-width: 0; border: 1px solid var(--border); padding: 24px; border-radius: 8px; }
+.agent-card-head, .agent-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.agent-card-head { justify-content: space-between; }
+.agent-card fieldset { min-width: 0; margin: 20px 0; }
+.agent-mapping-row { display: flex; gap: 12px; align-items: end; margin: 16px 0; flex-wrap: wrap; }
+.agent-mapping-row label { display: grid; gap: 6px; flex: 1 1 200px; min-width: 0; }
+.agent-mapping-row input { width: 100%; min-width: 0; }
+.agent-role { flex: 0 0 64px; align-self: center; }
+.agent-actions p { flex: 1 1 180px; }
+.agent-details { margin-top: 20px; }
+.agent-card summary { cursor: pointer; padding: 8px 0; }
+.agent-details dd { margin: 6px 0 16px; }
+.agent-details code { display: block; overflow-wrap: anywhere; }
+@media (max-width: 600px) {
+  .agent-card { padding: 16px; }
+  .agent-mapping-row { align-items: stretch; }
+  .agent-role { flex-basis: 100%; }
+  .agent-mapping-row label { flex-basis: 100%; }
+}

--- a/web/src/views/AgentCard.svelte
+++ b/web/src/views/AgentCard.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import { errorMessage, type AdminClient } from "../api.js";
+  import type { AgentMapping, AgentStatus } from "../../../src/agents/types.js";
+
+  let { client, status, catalogRevision, onchanged }: {
+    client: AdminClient; status: AgentStatus; catalogRevision: string | null; onchanged: (status: AgentStatus) => void;
+  } = $props();
+  const title = $derived(status.id === "claude" ? "Claude Code" : "Codex");
+  let drafts: AgentMapping[] = $state([]);
+  let baseline = $state("");
+  let loadedRevision = $state("");
+  let busy = $state(false);
+  let failure = $state("");
+  let notice = $state("");
+  const dirty = $derived(JSON.stringify(drafts) !== baseline);
+  const valid = $derived(drafts.length > 0 && drafts.every((row) => row.displayName.trim().length > 0
+    && row.displayName.length <= 80 && !/[\p{C}]/u.test(row.displayName)
+    && /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/u.test(row.modelId))
+    && (status.id !== "codex" || new Set(drafts.map((row) => row.modelId)).size === drafts.length));
+  const applyAllowed = $derived(status.state === "not_managed" || status.state === "installed");
+  const stateLabel = $derived({
+    not_managed: "Not managed", installed: "Configuration installed", conflict: "External changes detected",
+    recovery_required: "Recovery required", unsafe_path: "Unsupported or unsafe path",
+  }[status.state]);
+
+  $effect(() => {
+    if (loadedRevision !== status.revision) {
+      if (loadedRevision === "" || !dirty) resetDrafts();
+      loadedRevision = status.revision;
+    }
+  });
+  function resetDrafts(): void {
+    drafts = status.mappings.length > 0 ? status.mappings.map((row) => ({ ...row }))
+      : (status.id === "claude" ? ["Sonnet", "Opus", "Haiku"] : [""]).map((displayName) => ({ displayName, modelId: "" }));
+    baseline = JSON.stringify(drafts);
+  }
+  function setRow(index: number, key: keyof AgentMapping, value: string): void {
+    drafts = drafts.map((row, i) => i === index ? { ...row, [key]: value } : row);
+    notice = "";
+  }
+  async function mutate(restore: boolean): Promise<void> {
+    if (restore) {
+      if (!window.confirm(`Restore ${title}? This restores the configuration saved before the first apply, undoing all subsequent Gateway configuration changes.`)) return;
+    } else if (!status.backupAvailable && !window.confirm(`Apply ${title} configuration? Gateway will privately back up the original global configuration before making changes. Restart the client after applying.`)) return;
+    busy = true;
+    failure = "";
+    notice = "";
+    try {
+      const next = restore
+        ? await client.restoreAgent({ agent: status.id, expectedRevision: status.revision })
+        : await client.applyAgent({ agent: status.id, expectedRevision: status.revision, catalogRevision: catalogRevision!, mappings: drafts });
+      status = next;
+      resetDrafts();
+      loadedRevision = next.revision;
+      onchanged(next);
+      notice = restore ? "Original configuration restored. Restart the client." : "Configuration installed. Restart the client; inference has not been tested.";
+    } catch (error: unknown) {
+      failure = errorMessage(error);
+    } finally { busy = false; }
+  }
+</script>
+
+<section class="agent-card" aria-label={title} aria-busy={busy}>
+  <header class="agent-card-head">
+    <h2>{title}</h2>
+    <span class="badge">{stateLabel}</span>
+  </header>
+  {#if failure}<p class="notice error" role="alert">{failure}</p>{/if}
+  {#if notice}<p class="notice success" role="status">{notice}</p>{/if}
+  {#if status.state === "conflict" || status.state === "recovery_required"}
+    <p class="notice">Outside edits are never overwritten. Refresh to inspect again. Restore is available only when recovery is unambiguous; otherwise keep recovery files and reconcile the external changes first.</p>
+  {/if}
+  <form onsubmit={(event) => { event.preventDefault(); void mutate(false); }}>
+    <fieldset disabled={busy}>
+      <legend>Model mapping</legend>
+      <p class="muted" id={`${status.id}-mapping-help`}>The first row is the startup model. Display names are labels; Copilot model IDs are sent unchanged.</p>
+      {#each drafts as row, index (index)}
+        {#if index < 3 || status.id === "codex"}
+          <div class="agent-mapping-row">
+            {#if status.id === "claude"}<strong class="agent-role">{["Sonnet", "Opus", "Haiku"][index]}</strong>{/if}
+            <label>Display name
+              <input type="text" value={row.displayName} maxlength="80" required aria-describedby={`${status.id}-mapping-help`}
+                oninput={(event) => setRow(index, "displayName", event.currentTarget.value)} />
+            </label>
+            <label>Copilot model ID
+              <input type="text" value={row.modelId} maxlength="128" required spellcheck="false" autocomplete="off"
+                oninput={(event) => setRow(index, "modelId", event.currentTarget.value)} />
+            </label>
+            {#if status.id === "codex"}
+              <button type="button" aria-label={`Remove model ${index + 1}`} disabled={drafts.length === 1} onclick={() => drafts = drafts.filter((_, i) => i !== index)}>Remove</button>
+            {/if}
+          </div>
+        {/if}
+      {/each}
+      {#if status.id === "codex"}
+        <button type="button" disabled={drafts.length >= 16} onclick={() => drafts = [...drafts, { displayName: "", modelId: "" }]}>Add model</button>
+      {:else}
+        <details>
+          <summary>Additional settings</summary>
+          {#if drafts[3]}
+            <div class="agent-mapping-row">
+              <strong class="agent-role">Subagent</strong>
+              <label>Display name<input type="text" value={drafts[3].displayName} maxlength="80" required oninput={(event) => setRow(3, "displayName", event.currentTarget.value)} /></label>
+              <label>Copilot model ID<input type="text" value={drafts[3].modelId} maxlength="128" required oninput={(event) => setRow(3, "modelId", event.currentTarget.value)} /></label>
+              <button type="button" onclick={() => drafts = drafts.slice(0, 3)}>Remove subagent mapping</button>
+            </div>
+          {:else}
+            <button type="button" onclick={() => drafts = [...drafts, { displayName: "Subagent", modelId: "" }]}>Add subagent mapping</button>
+          {/if}
+        </details>
+      {/if}
+    </fieldset>
+    <div class="agent-actions">
+      <p aria-live="polite">{dirty ? "Unapplied changes" : "No unapplied changes"}</p>
+      <button class="primary" disabled={busy || !dirty || !valid || !applyAllowed || catalogRevision === null}>Apply changes</button>
+      <button type="button" disabled={busy || !status.canRestore} onclick={() => void mutate(true)}>Restore</button>
+    </div>
+  </form>
+  <details class="agent-details">
+    <summary>Configuration details</summary>
+    <dl>
+      <dt>Configuration paths</dt><dd>{#each status.paths as target (target)}<code>{target}</code>{/each}</dd>
+      <dt>Trusted Gateway URL</dt><dd><code>{status.endpoint}</code></dd>
+      <dt>Original backup</dt><dd>{status.backupAvailable ? "Available — retained from the first apply" : "Not created"}</dd>
+      <dt>Last apply</dt><dd>{status.lastAppliedAt === null ? "Never" : new Date(status.lastAppliedAt).toLocaleString()}</dd>
+    </dl>
+  </details>
+</section>

--- a/web/src/views/Agents.svelte
+++ b/web/src/views/Agents.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { errorMessage, type AdminClient } from "../api.js";
+  import type { AgentsView, AgentStatus } from "../../../src/agents/types.js";
+  import AgentCard from "./AgentCard.svelte";
+  let { client, pageNumber }: { client: AdminClient; pageNumber: string } = $props();
+  let data: AgentsView | null = $state(null);
+  let loading = $state(false);
+  let failure = $state("");
+  onMount(() => { void load(); });
+  async function load(): Promise<void> {
+    loading = true;
+    failure = "";
+    try { data = await client.agents(); }
+    catch (error: unknown) { failure = errorMessage(error); }
+    finally { loading = false; }
+  }
+  function changed(status: AgentStatus): void {
+    if (data) data = { ...data, items: data.items.map((item) => item.id === status.id ? status : item) };
+  }
+</script>
+<header class="page-head">
+  <div>
+    <p class="eyebrow">[{pageNumber}] LOCAL ADMINISTRATION</p>
+    <h1 tabindex="-1">Agents</h1>
+    <p>Reversible global configuration for this Gateway process user.</p>
+  </div>
+  <button disabled={loading} onclick={() => void load()}>Refresh</button>
+</header>
+<p class="muted">Refresh only reads configuration. Status means configuration installed, not a tested client or inference connection. Preferred Model and account selection are unchanged.</p>
+<p class="muted">Restart clients after applying or restoring. Command-line, project and managed-policy overrides are outside these global settings; do not use routing overrides with this integration.</p>
+{#if failure}<p class="notice error" role="alert">{failure}</p>{/if}
+{#if data}
+  {#if !data.modelsAvailable}<p class="notice" role="status">Model catalog unavailable. Sign in and configure usable model capabilities in Models before applying. Inspection and Restore do not require a Copilot account.</p>{/if}
+  <div class="agent-cards">
+    {#each data.items as status (status.id)}
+      <AgentCard {client} {status} catalogRevision={data.catalogRevision} onchanged={changed} />
+    {/each}
+  </div>
+{:else if loading}<p class="loading-line" aria-busy="true">Reading agent configuration...</p>{/if}


### PR DESCRIPTION
## Summary

- add an **Agents** Admin view between Models and Configuration
- provide consistent text-only **Model mapping** editors for Claude Code and Codex with **Apply changes** / **Restore** actions
- generate Claude role mappings and a Codex multi-model catalog that route exact Copilot model IDs through the trusted loopback Gateway
- preserve a private first baseline and restore exact original bytes, with external-change detection, serialized multi-instance writes, durable recovery state, and no Codex `auth.json` / Claude credential changes
- reuse existing Admin Session, Origin, CSRF, account and catalog-currentness contracts

## Safety and compatibility

- browser requests cannot supply config paths or Gateway endpoints
- backups and recovery records are bounded and protected
- apply/restore fail closed for unsupported config shapes, unsafe paths, external edits or ambiguous crash state
- no Preferred Model, model resolver, protocol routing or Responses History ownership changes
- rebased with #169; removed Ollama/manual capability override behavior remains removed

## Verification

- `npm run lint`
- `npm run typecheck`
- `npx vitest run --config vitest.config.ts --testTimeout=180000` — 81 files, 1063 passed, 5 skipped
- `CI=1 npx playwright test -c playwright.config.ts` — 97 passed
- `npm run build`
- `npm run smoke:sqlite`
- `npm run fixtures:verify` — 53 entries
- focused package/toolchain tests
- three code-review passes; final Standards and Spec reviews found no blockers/findings

Windows local package-smoke note: package build and offline dependency install passed, but the smoke daemon restart exceeded its existing 30s deadline because this host's Windows ACL commands currently take 28–80s. No timeout was changed; Linux CI is the final standard `npm run pack` evidence.

## Deferred follow-ups

- #170 — share duplicate Windows ACL helpers and hoist the agent catalog usability predicate

Closes #167
