### PR TITLE
Share Windows ACL helpers and agent catalog filtering

### DIFF
--- a/src/accounts/credential_store.ts
+++ b/src/accounts/credential_store.ts
@@ -1,6 +1,7 @@
 import { chmodSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeSync, closeSync } from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { WindowsAcl, windowsCommandPath } from "../security/windows_acl.js";
 
 export type AccountId = string;
 
@@ -161,7 +162,7 @@ export function ensureProtectedDirectory(directory: string): void {
   }
   assertOwnedByCurrentUser(stat);
   if (process.platform === "win32") {
-    restrictWindowsAcl(directory);
+    WINDOWS_ACL.restrict(directory, true);
     assertWindowsAclCurrentUserOnly(directory);
     return;
   }
@@ -193,76 +194,23 @@ function assertOwnedByCurrentUser(stat: { uid: number }): void {
 
 function protectFile(filePath: string): void {
   if (process.platform === "win32") {
-    restrictWindowsAcl(filePath);
+    WINDOWS_ACL.restrict(filePath, false);
     assertWindowsAclCurrentUserOnly(filePath);
     return;
   }
   chmodSync(filePath, 0o600);
 }
 
-function restrictWindowsAcl(target: string): void {
-  const current = currentWindowsIdentity();
-  const grant = isDirectory(target) ? `*${current.sid}:(OI)(CI)(F)` : `*${current.sid}:(F)`;
-  const icacls = windowsCommandPath("icacls");
-  execFileSync(icacls, [target, "/inheritance:r", "/grant:r", grant], { stdio: "ignore", windowsHide: true });
-  for (const identity of windowsAclIdentities(target)) {
-    if (!isCurrentWindowsIdentity(identity, current)) {
-      execFileSync(icacls, [target, "/remove:g", identity], { stdio: "ignore", windowsHide: true });
-    }
-  }
-}
+const WINDOWS_ACL = new WindowsAcl((file, args) => execFileSync(
+  windowsCommandPath(file),
+  [...args],
+  { encoding: "utf8", windowsHide: true },
+));
 
 function assertWindowsAclCurrentUserOnly(target: string): void {
-  const current = currentWindowsIdentity();
-  const identities = windowsAclIdentities(target);
-  if (identities.length !== 1 || !isCurrentWindowsIdentity(identities[0] ?? "", current)) {
+  if (!WINDOWS_ACL.isCurrentUserOnly(target)) {
     throw new Error("credential ACL must be restricted to the current user");
   }
-}
-
-function windowsCommandPath(command: string): string {
-  if (process.platform === "win32") {
-    const systemRoot = process.env.SystemRoot ?? process.env.WINDIR ?? "C:\\Windows";
-    return path.join(systemRoot, "System32", `${command}.exe`);
-  }
-  return command;
-}
-
-function currentWindowsIdentity(): { readonly name: string; readonly sid: string } {
-  const whoami = windowsCommandPath("whoami");
-  const csv = execFileSync(whoami, ["/user", "/fo", "csv", "/nh"], { encoding: "utf8", windowsHide: true }).trim();
-  const match = /^"([^"]+)","([^"]+)"$/u.exec(csv);
-  if (match === null || match[1] === undefined || match[2] === undefined) {
-    throw new Error("unable to resolve current Windows identity");
-  }
-  return { name: match[1].toLowerCase(), sid: match[2].toLowerCase() };
-}
-
-function windowsAclIdentities(target: string): readonly string[] {
-  const icacls = windowsCommandPath("icacls");
-  const output = execFileSync(icacls, [target], { encoding: "utf8", windowsHide: true });
-  const identities: string[] = [];
-  for (const rawLine of output.split(/\r?\n/u)) {
-    const line = rawLine.trim();
-    if (line.length === 0 || line.startsWith("Successfully processed") || line.startsWith("Failed processing")) {
-      continue;
-    }
-    const entry = rawLine.startsWith(target) ? rawLine.slice(target.length).trim() : line;
-    const separator = entry.indexOf(":(");
-    if (separator > 0) {
-      identities.push(entry.slice(0, separator));
-    }
-  }
-  return identities;
-}
-
-function isCurrentWindowsIdentity(identity: string, current: { readonly name: string; readonly sid: string }): boolean {
-  const normalized = identity.toLowerCase();
-  return normalized === current.name || normalized === current.sid;
-}
-
-function isDirectory(target: string): boolean {
-  return lstatSync(target).isDirectory();
 }
 
 function isNotFound(error: unknown): boolean {

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -278,6 +278,9 @@ export interface AdminCapabilityRegistry {
   }>;
   invalidate(accountId: string): void;
   isCurrent(snapshot: Awaited<ReturnType<AdminCapabilityRegistry["get"]>>): boolean;
+  modelsUsableForAgentMapping(
+    snapshot: Awaited<ReturnType<AdminCapabilityRegistry["get"]>>,
+  ): Awaited<ReturnType<AdminCapabilityRegistry["get"]>>["models"];
 }
 
 export interface AdminAccountCaches {
@@ -481,10 +484,7 @@ export class AdminManagementApi {
       const captured = await this.agentCatalog(signal);
       if (captured.revision !== request.catalogRevision) throw new AdminApiError("revision_conflict");
       await this.requireSameCredentialGeneration(captured.account.accountId, captured.account, signal);
-      const models = captured.catalog.models.filter((model) => model.protocols.value !== null
-        && model.protocols.value.length > 0
-        && model.defaultOutputTokens.valid
-        && (!model.protocols.value.every((protocol) => protocol === "chat") || model.profile.chatOutputTokenField.value !== null))
+      const models = this.dependencies.registry.modelsUsableForAgentMapping(captured.catalog)
         .map((model) => ({ modelId: model.modelId, maxInputTokens: model.maxInputTokens.value }));
       return await this.requireAgents().apply(request, origin, models, () => {
         signal.throwIfAborted();

--- a/src/agents/files.ts
+++ b/src/agents/files.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { createHash } from "node:crypto";
+import { WindowsAcl, windowsCommandPath } from "../security/windows_acl.js";
 import { AgentError } from "./types.js";
 
 export const MAX_FILE_BYTES = 1024 * 1024;
@@ -99,7 +100,7 @@ export async function privateDirectory(target: string): Promise<void> {
   if (exists(target)) { await assertPrivate(target, true); return; }
   fs.mkdirSync(target, { mode: 0o700 });
   if (process.platform === "win32") {
-    restrictWindowsAcl(target, true);
+    agentWindowsAcl(() => WINDOWS_ACL.restrict(target, true));
   }
   await assertPrivate(target, true);
 }
@@ -109,16 +110,13 @@ export async function assertPrivate(target: string, directory: boolean): Promise
   if (directory ? !stat.isDirectory() : !stat.isFile()) throw new AgentError("agent_unsafe_path");
   if (process.platform !== "win32") {
     if (stat.uid !== process.getuid?.() || (stat.mode & 0o077) !== 0) throw new AgentError("agent_unsafe_path");
-  } else {
-    const identities = windowsAclIdentities(target);
-    if (identities.length !== 1 || !isCurrentWindowsIdentity(identities[0] ?? "")) {
-      throw new AgentError("agent_unsafe_path");
-    }
+  } else if (!agentWindowsAcl(() => WINDOWS_ACL.isCurrentUserOnly(target))) {
+    throw new AgentError("agent_unsafe_path");
   }
 }
 export async function protect(target: string): Promise<void> {
   if (process.platform === "win32") {
-    restrictWindowsAcl(target, false);
+    agentWindowsAcl(() => WINDOWS_ACL.restrict(target, false));
   } else fs.chmodSync(target, 0o600);
 }
 export async function writeExclusive(target: string, image: FileImage, privateOnly = false): Promise<void> {
@@ -157,65 +155,19 @@ async function windowsAcl(target: string): Promise<string> {
 // protected ACL through SetAccessRuleProtection demands SeSecurityPrivilege and
 // fails on already-locked files, while icacls /inheritance:r + /grant:r is
 // idempotent for the recovery files we revisit across apply/restore operations.
-const windowsIdentity = { value: null as { readonly name: string; readonly sid: string } | null };
+const WINDOWS_ACL = new WindowsAcl((file, args) => execFileSync(
+  windowsCommandPath(file, "win32", { SystemRoot: process.env.SystemRoot ?? "C:\\Windows" }),
+  [...args],
+  { encoding: "utf8", windowsHide: true, timeout: 10000, maxBuffer: 65536 },
+), { cacheIdentity: true });
 
-function windowsCommandPath(command: string): string {
-  return path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", `${command}.exe`);
-}
-
-function currentWindowsIdentity(): { readonly name: string; readonly sid: string } {
-  if (windowsIdentity.value !== null) return windowsIdentity.value;
+function agentWindowsAcl<T>(operation: () => T): T {
   try {
-    const csv = execFileSync(windowsCommandPath("whoami"), ["/user", "/fo", "csv", "/nh"], {
-      encoding: "utf8", windowsHide: true, timeout: 10000,
-    }).trim();
-    const match = /^"([^"]+)","([^"]+)"$/u.exec(csv);
-    if (match === null || match[1] === undefined || match[2] === undefined) throw new Error("whoami");
-    windowsIdentity.value = { name: match[1].toLowerCase(), sid: match[2].toLowerCase() };
-    return windowsIdentity.value;
+    return operation();
   } catch (error: unknown) {
     const failure = new AgentError("agent_unsafe_path");
     failure.cause = error;
     throw failure;
-  }
-}
-
-function isCurrentWindowsIdentity(identity: string): boolean {
-  const normalized = identity.toLowerCase();
-  const current = currentWindowsIdentity();
-  return normalized === current.name || normalized === current.sid;
-}
-
-function icacls(target: string, args: readonly string[]): string {
-  try {
-    return execFileSync(windowsCommandPath("icacls"), [target, ...args], {
-      encoding: "utf8", windowsHide: true, timeout: 10000, maxBuffer: 65536,
-    });
-  } catch (error: unknown) {
-    const failure = new AgentError("agent_unsafe_path");
-    failure.cause = error;
-    throw failure;
-  }
-}
-
-function windowsAclIdentities(target: string): string[] {
-  const output = icacls(target, []);
-  const identities: string[] = [];
-  for (const rawLine of output.split(/\r?\n/u)) {
-    const line = rawLine.trim();
-    if (line.length === 0 || line.startsWith("Successfully processed") || line.startsWith("Failed processing")) continue;
-    const entry = rawLine.startsWith(target) ? rawLine.slice(target.length).trim() : line;
-    const separator = entry.indexOf(":(");
-    if (separator > 0) identities.push(entry.slice(0, separator));
-  }
-  return identities;
-}
-
-function restrictWindowsAcl(target: string, directory: boolean): void {
-  const grant = directory ? `*${currentWindowsIdentity().sid}:(OI)(CI)(F)` : `*${currentWindowsIdentity().sid}:(F)`;
-  icacls(target, ["/inheritance:r", "/grant:r", grant]);
-  for (const identity of windowsAclIdentities(target)) {
-    if (!isCurrentWindowsIdentity(identity)) icacls(target, ["/remove:g", identity]);
   }
 }
 

--- a/src/copilot/capability_registry.ts
+++ b/src/copilot/capability_registry.ts
@@ -97,6 +97,16 @@ export class ModelCapabilityRegistry {
     );
   }
 
+  modelsUsableForAgentMapping(
+    snapshot: Readonly<CapabilityCatalogSnapshot>,
+  ): readonly EffectiveModelCapabilitySnapshot[] {
+    return snapshot.models.filter((model) => model.protocols.value !== null
+      && model.protocols.value.length > 0
+      && model.defaultOutputTokens.valid
+      && (!model.protocols.value.every((protocol) => protocol === "chat")
+        || model.profile.chatOutputTokenField.value !== null));
+  }
+
   async close(): Promise<void> {
     await this.catalog.close();
   }

--- a/src/daemon/identity_file.ts
+++ b/src/daemon/identity_file.ts
@@ -16,6 +16,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
+import { InvalidWindowsIdentityError, WindowsAcl, windowsCommandPath } from "../security/windows_acl.js";
 import { captureProcessStartIdentity } from "./process_identity.js";
 
 export interface DaemonIdentity {
@@ -86,6 +87,7 @@ export class DaemonIdentityFile {
   private readonly lockPath: string;
   private readonly platform: NodeJS.Platform;
   private readonly runCommand: (file: string, args: readonly string[]) => string;
+  private readonly windowsAcl: WindowsAcl;
   private readonly processIdentity: (pid: number) => Promise<string | null>;
 
   constructor(directory: string, options: DaemonIdentityFileOptions = {}) {
@@ -94,6 +96,7 @@ export class DaemonIdentityFile {
     this.lockPath = path.join(this.directory, "daemon.lock");
     this.platform = options.platform ?? process.platform;
     this.runCommand = options.runCommand ?? defaultRunCommand;
+    this.windowsAcl = new WindowsAcl(this.runCommand);
     this.processIdentity = options.processIdentity ?? captureProcessStartIdentity;
   }
 
@@ -388,26 +391,30 @@ export class DaemonIdentityFile {
   }
 
   private restrictWindowsAcl(target: string, directory: boolean): void {
-    const current = currentWindowsIdentity(this.runCommand);
-    const grant = directory ? `*${current.sid}:(OI)(CI)(F)` : `*${current.sid}:(F)`;
-    this.runCommand("icacls", [target, "/setowner", `*${current.sid}`]);
-    this.runCommand("icacls", [target, "/inheritance:r", "/grant:r", grant]);
-    for (const identity of windowsAclIdentities(target, this.runCommand)) {
-      if (!isCurrentWindowsIdentity(identity, current)) {
-        this.runCommand("icacls", [target, "/remove:g", identity]);
-      }
-    }
+    const current = this.currentWindowsIdentity();
+    this.windowsAcl.restrict(target, directory, { setOwner: true, currentIdentity: current });
   }
 
   private assertWindowsAcl(target: string): void {
-    const current = currentWindowsIdentity(this.runCommand);
+    const current = this.currentWindowsIdentity();
     const owner = windowsOwner(target, this.runCommand);
-    if (!isCurrentWindowsIdentity(owner, current)) {
+    if (!this.windowsAcl.isCurrentIdentity(owner, current)) {
       throw new DaemonIdentityFileError("unsafe_owner", "daemon path must be owned by the current user");
     }
-    const identities = windowsAclIdentities(target, this.runCommand);
-    if (identities.length !== 1 || !isCurrentWindowsIdentity(identities[0] ?? "", current)) {
+    const identities = this.windowsAcl.identities(target);
+    if (identities.length !== 1 || !this.windowsAcl.isCurrentIdentity(identities[0] ?? "", current)) {
       throw new DaemonIdentityFileError("unsafe_permissions", "daemon ACL must be restricted to the current user");
+    }
+  }
+
+  private currentWindowsIdentity() {
+    try {
+      return this.windowsAcl.currentIdentity();
+    } catch (error: unknown) {
+      if (error instanceof InvalidWindowsIdentityError) {
+        throw new DaemonIdentityFileError("unsafe_owner", "unable to resolve current Windows identity");
+      }
+      throw error;
     }
   }
 
@@ -575,41 +582,9 @@ function isAlreadyExists(error: unknown): boolean {
 
 function defaultRunCommand(file: string, args: readonly string[]): string {
   const resolved = process.platform === "win32" && (file === "whoami" || file === "icacls")
-    ? path.join(process.env.SystemRoot ?? process.env.WINDIR ?? "C:\\Windows", "System32", `${file}.exe`)
+    ? windowsCommandPath(file)
     : file;
   return execFileSync(resolved, [...args], { encoding: "utf8", windowsHide: true });
-}
-
-function currentWindowsIdentity(runCommand: (file: string, args: readonly string[]) => string): {
-  readonly name: string;
-  readonly sid: string;
-} {
-  const output = runCommand("whoami", ["/user", "/fo", "csv", "/nh"]).trim();
-  const match = /^"([^"]+)","([^"]+)"$/u.exec(output);
-  if (match === null || match[1] === undefined || match[2] === undefined) {
-    throw new DaemonIdentityFileError("unsafe_owner", "unable to resolve current Windows identity");
-  }
-  return { name: match[1].toLowerCase(), sid: match[2].toLowerCase() };
-}
-
-function windowsAclIdentities(
-  target: string,
-  runCommand: (file: string, args: readonly string[]) => string,
-): readonly string[] {
-  const output = runCommand("icacls", [target]);
-  const identities: string[] = [];
-  for (const rawLine of output.split(/\r?\n/u)) {
-    const line = rawLine.trim();
-    if (line.length === 0 || line.startsWith("Successfully processed") || line.startsWith("Failed processing")) {
-      continue;
-    }
-    const entry = rawLine.startsWith(target) ? rawLine.slice(target.length).trim() : line;
-    const separator = entry.indexOf(":(");
-    if (separator > 0) {
-      identities.push(entry.slice(0, separator));
-    }
-  }
-  return identities;
 }
 
 function windowsOwner(
@@ -626,14 +601,6 @@ function windowsOwner(
     throw new DaemonIdentityFileError("unsafe_owner", "unable to resolve daemon path owner");
   }
   return owner;
-}
-
-function isCurrentWindowsIdentity(
-  identity: string,
-  current: { readonly name: string; readonly sid: string },
-): boolean {
-  const normalized = identity.toLowerCase();
-  return normalized === current.name || normalized === current.sid;
 }
 
 function powerShellLiteral(value: string): string {

--- a/src/daemon/logger.ts
+++ b/src/daemon/logger.ts
@@ -16,6 +16,7 @@ import {
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import type { LogLevel } from "../config/startup_config.js";
+import { WindowsAcl, windowsCommandPath } from "../security/windows_acl.js";
 import { LOG_LINE_LIMIT_BYTES, sanitizeMetadata, utf8Bytes } from "../telemetry/sanitize.js";
 
 export const LOG_FILE_BYTES = 10 * 1024 * 1024;
@@ -203,16 +204,6 @@ function appendProtected(filePath: string, value: string, windowsSecurity: Windo
   }
 }
 
-function restrictWindowsAcl(target: string, directory: boolean): void {
-  const identity = currentWindowsIdentity();
-  const grant = directory ? `*${identity.sid}:(OI)(CI)(F)` : `*${identity.sid}:(F)`;
-  const icacls = windowsCommandPath("icacls");
-  execFileSync(icacls, [target, "/inheritance:r", "/grant:r", grant], {
-    encoding: "utf8",
-    windowsHide: true,
-  });
-}
-
 function assertSafeDirectory(target: string, windowsSecurity: WindowsLogSecurity): void {
   const stat = lstatSync(target);
   if (!stat.isDirectory() || stat.isSymbolicLink()) {
@@ -258,51 +249,22 @@ function isWindowsReparsePoint(target: string): boolean {
   return output.trim() === "true";
 }
 
+const WINDOWS_ACL = new WindowsAcl((file, args) => execFileSync(
+  windowsCommandPath(file),
+  [...args],
+  { encoding: "utf8", windowsHide: true },
+));
+
 function assertWindowsAcl(target: string): void {
-  const current = currentWindowsIdentity();
-  const icacls = windowsCommandPath("icacls");
-  const output = execFileSync(icacls, [target], { encoding: "utf8", windowsHide: true });
-  const identities: string[] = [];
-  for (const rawLine of output.split(/\r?\n/u)) {
-    const line = rawLine.trim();
-    if (line.length === 0 || line.startsWith("Successfully processed") || line.startsWith("Failed processing")) {
-      continue;
-    }
-    const entry = rawLine.startsWith(target) ? rawLine.slice(target.length).trim() : line;
-    const separator = entry.indexOf(":(");
-    if (separator > 0) {
-      identities.push(entry.slice(0, separator).toLowerCase());
-    }
-  }
-  if (identities.length !== 1
-    || (identities[0] !== current.sid.toLowerCase() && identities[0] !== current.name.toLowerCase())) {
+  if (!WINDOWS_ACL.isCurrentUserOnly(target)) {
     throw new Error("log ACL must be restricted to the current user");
   }
 }
 
-function windowsCommandPath(command: string): string {
-  if (process.platform === "win32") {
-    const systemRoot = process.env.SystemRoot ?? process.env.WINDIR ?? "C:\\Windows";
-    return path.join(systemRoot, "System32", `${command}.exe`);
-  }
-  return command;
-}
-
-function currentWindowsIdentity(): { readonly name: string; readonly sid: string } {
-  const whoami = windowsCommandPath("whoami");
-  const identity = execFileSync(whoami, ["/user", "/fo", "csv", "/nh"], {
-    encoding: "utf8",
-    windowsHide: true,
-  }).trim();
-  const match = /^"([^"]+)","([^"]+)"$/u.exec(identity);
-  if (match?.[1] === undefined || match[2] === undefined) {
-    throw new Error("unable to resolve current Windows identity");
-  }
-  return { name: match[1], sid: match[2] };
-}
-
 const DEFAULT_WINDOWS_LOG_SECURITY: WindowsLogSecurity = {
-  restrict: restrictWindowsAcl,
+  restrict(target, directory) {
+    WINDOWS_ACL.restrict(target, directory, { removeOtherIdentities: false });
+  },
   assertDirectory(target) {
     if (isWindowsReparsePoint(target)) {
       throw new Error("log directory must be a regular directory");

--- a/src/security/windows_acl.ts
+++ b/src/security/windows_acl.ts
@@ -1,0 +1,107 @@
+import path from "node:path";
+
+export interface WindowsIdentity {
+  readonly name: string;
+  readonly sid: string;
+}
+
+export type WindowsCommandRunner = (file: string, args: readonly string[]) => string;
+
+export interface WindowsAclRestriction {
+  readonly setOwner?: boolean;
+  readonly removeOtherIdentities?: boolean;
+  readonly currentIdentity?: Readonly<WindowsIdentity>;
+}
+
+export interface WindowsAclOptions {
+  readonly cacheIdentity?: boolean;
+}
+
+export class InvalidWindowsIdentityError extends Error {
+  constructor() {
+    super("unable to resolve current Windows identity");
+  }
+}
+
+/** Shared parsing and mutation rules for current-user-only Windows ACLs. */
+export class WindowsAcl {
+  private identity: WindowsIdentity | null = null;
+
+  constructor(
+    private readonly runCommand: WindowsCommandRunner,
+    private readonly options: Readonly<WindowsAclOptions> = {},
+  ) {}
+
+  currentIdentity(): WindowsIdentity {
+    if (this.options.cacheIdentity === true && this.identity !== null) {
+      return this.identity;
+    }
+    const output = this.runCommand("whoami", ["/user", "/fo", "csv", "/nh"]).trim();
+    const match = /^"([^"]+)","([^"]+)"$/u.exec(output);
+    if (match?.[1] === undefined || match[2] === undefined) {
+      throw new InvalidWindowsIdentityError();
+    }
+    const identity = { name: match[1].toLowerCase(), sid: match[2].toLowerCase() };
+    if (this.options.cacheIdentity === true) {
+      this.identity = identity;
+    }
+    return identity;
+  }
+
+  identities(target: string): readonly string[] {
+    const output = this.runCommand("icacls", [target]);
+    const identities: string[] = [];
+    for (const rawLine of output.split(/\r?\n/u)) {
+      const line = rawLine.trim();
+      if (line.length === 0 || line.startsWith("Successfully processed") || line.startsWith("Failed processing")) {
+        continue;
+      }
+      const entry = rawLine.startsWith(target) ? rawLine.slice(target.length).trim() : line;
+      const separator = entry.indexOf(":(");
+      if (separator > 0) {
+        identities.push(entry.slice(0, separator));
+      }
+    }
+    return identities;
+  }
+
+  isCurrentIdentity(identity: string, current: Readonly<WindowsIdentity>): boolean {
+    const normalized = identity.toLowerCase();
+    return normalized === current.name || normalized === current.sid;
+  }
+
+  isCurrentUserOnly(target: string): boolean {
+    const current = this.currentIdentity();
+    const identities = this.identities(target);
+    return identities.length === 1 && this.isCurrentIdentity(identities[0] ?? "", current);
+  }
+
+  restrict(target: string, directory: boolean, options: Readonly<WindowsAclRestriction> = {}): void {
+    const current = options.currentIdentity ?? this.currentIdentity();
+    const grant = directory ? `*${current.sid}:(OI)(CI)(F)` : `*${current.sid}:(F)`;
+    if (options.setOwner === true) {
+      this.runCommand("icacls", [target, "/setowner", `*${current.sid}`]);
+    }
+    this.runCommand("icacls", [target, "/inheritance:r", "/grant:r", grant]);
+    if (options.removeOtherIdentities === false) {
+      return;
+    }
+    for (const identity of this.identities(target)) {
+      if (!this.isCurrentIdentity(identity, current)) {
+        this.runCommand("icacls", [target, "/remove:g", identity]);
+      }
+    }
+  }
+}
+
+export function windowsCommandPath(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+  if (platform !== "win32") {
+    return command;
+  }
+  const systemRoot = environment.SystemRoot ?? environment.WINDIR ?? "C:\\Windows";
+  return path.join(systemRoot, "System32", `${command}.exe`);
+}

--- a/tests/contract/admin_agents.test.ts
+++ b/tests/contract/admin_agents.test.ts
@@ -196,6 +196,7 @@ describe("Admin agents API", () => {
       expect(applied.status).toBe(200);
       expect(await applied.json()).toMatchObject({ data: { id: "claude", state: "installed", canRestore: true } });
       expect(stub.calls).toContain("apply:claude:gpt-test");
+      expect(harness.dependencies.calls).toContain("agent-models");
 
       stub.failApply = "agent_conflict";
       const conflict = await harness.gateway.fetch(new Request(`${ORIGIN}/admin/api/v1/agents/apply`, {

--- a/tests/contract/admin_test_harness.ts
+++ b/tests/contract/admin_test_harness.ts
@@ -156,6 +156,10 @@ export function adminDependencies(now = { value: 1_800_000_000_000 }): TestAdmin
       invalidate: (accountId) => calls.push(`invalidate:${accountId}`),
       isCurrent: (snapshot) => snapshot.catalogGeneration === 7
         && snapshot.credentialGeneration === 4,
+      modelsUsableForAgentMapping: (snapshot) => {
+        calls.push("agent-models");
+        return snapshot.models;
+      },
     },
     preferences: {
       get: () => preference,

--- a/tests/contract/model_capability_registry.test.ts
+++ b/tests/contract/model_capability_registry.test.ts
@@ -334,6 +334,35 @@ describe("model capability registry", () => {
     expect(Object.isFrozen(capability(initial, "same").revision)).toBe(true);
   });
 
+  it("selects only models whose effective capabilities are usable for agent mapping", async () => {
+    const harness = await createHarness({
+      "github.com/1": [
+        model("responses", { supported_endpoints: ["/responses"], max_output_tokens: 8000 }),
+        model("chat", {
+          supported_endpoints: ["/chat/completions"],
+          max_output_tokens: 8000,
+          chat_output_token_field: "max_tokens",
+        }),
+        model("mixed", { supported_endpoints: ["/chat/completions", "/responses"], max_output_tokens: 8000 }),
+        model("chat-without-token-field", { supported_endpoints: ["/chat/completions"], max_output_tokens: 8000 }),
+        model("empty-protocols", { supported_endpoints: [], max_output_tokens: 8000 }),
+        model("missing-protocols", { max_output_tokens: 8000 }),
+        model("invalid-output-default", {
+          supported_endpoints: ["/responses"],
+          max_output_tokens: 8000,
+          default_output_tokens: 9000,
+        }),
+      ],
+    });
+    const snapshot = await harness.registry.get(harness.account1, signal);
+
+    expect(harness.registry.modelsUsableForAgentMapping(snapshot).map((item) => item.modelId)).toEqual([
+      "responses",
+      "chat",
+      "mixed",
+    ]);
+  });
+
   it("derives bounded output defaults from declarations and ceilings", async () => {
     const harness = await createHarness({
       "github.com/1": [

--- a/tests/unit/windows_acl.test.ts
+++ b/tests/unit/windows_acl.test.ts
@@ -1,0 +1,96 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { WindowsAcl, windowsCommandPath, type WindowsCommandRunner } from "../../src/security/windows_acl.js";
+
+describe("Windows ACL helper", () => {
+  it("resolves the current identity and parses explicit ACL principals through an injected runner", () => {
+    const calls: string[] = [];
+    const runCommand: WindowsCommandRunner = (file, args) => {
+      calls.push(`${file} ${args.join(" ")}`);
+      if (file === "whoami") return "\"CONTOSO\\User\",\"S-1-5-21-1000\"\r\n";
+      return "C:\\private CONTOSO\\User:(F)\r\n"
+        + "             S-1-5-32-544:(I)(F)\r\n"
+        + "Successfully processed 1 files; Failed processing 0 files\r\n";
+    };
+    const acl = new WindowsAcl(runCommand);
+
+    expect(acl.currentIdentity()).toEqual({ name: "contoso\\user", sid: "s-1-5-21-1000" });
+    expect(acl.identities("C:\\private")).toEqual(["CONTOSO\\User", "S-1-5-32-544"]);
+    expect(acl.isCurrentIdentity("CONTOSO\\USER", { name: "contoso\\user", sid: "s-1-5-21-1000" })).toBe(true);
+    expect(calls).toEqual([
+      "whoami /user /fo csv /nh",
+      "icacls C:\\private",
+    ]);
+  });
+
+  it("preserves the plain Error shape when the current identity cannot be parsed", () => {
+    const acl = new WindowsAcl(() => "unexpected output");
+
+    expect(() => acl.currentIdentity()).toThrow(expect.objectContaining({
+      name: "Error",
+      message: "unable to resolve current Windows identity",
+    }));
+  });
+
+  it("restricts a directory to the current SID and removes other explicit grants", () => {
+    const calls: Array<{ readonly file: string; readonly args: readonly string[] }> = [];
+    const runCommand: WindowsCommandRunner = (file, args) => {
+      calls.push({ file, args: [...args] });
+      if (file === "whoami") return "\"CONTOSO\\User\",\"S-1-5-21-1000\"\r\n";
+      if (args.length === 1) {
+        return "C:\\private CONTOSO\\User:(F)\r\n             BUILTIN\\Administrators:(F)\r\n";
+      }
+      return "";
+    };
+    const acl = new WindowsAcl(runCommand);
+
+    acl.restrict("C:\\private", true, { setOwner: true });
+
+    expect(calls).toEqual([
+      { file: "whoami", args: ["/user", "/fo", "csv", "/nh"] },
+      { file: "icacls", args: ["C:\\private", "/setowner", "*s-1-5-21-1000"] },
+      { file: "icacls", args: ["C:\\private", "/inheritance:r", "/grant:r", "*s-1-5-21-1000:(OI)(CI)(F)"] },
+      { file: "icacls", args: ["C:\\private"] },
+      { file: "icacls", args: ["C:\\private", "/remove:g", "BUILTIN\\Administrators"] },
+    ]);
+  });
+
+  it("optionally caches the current identity for repeated ACL operations", () => {
+    let identityCalls = 0;
+    const acl = new WindowsAcl((file) => {
+      if (file === "whoami") {
+        identityCalls += 1;
+        return "\"user\",\"S-1-5-21-1000\"";
+      }
+      return "C:\\private user:(F)";
+    }, { cacheIdentity: true });
+
+    expect(acl.currentIdentity()).toEqual({ name: "user", sid: "s-1-5-21-1000" });
+    expect(acl.isCurrentUserOnly("C:\\private")).toBe(true);
+    acl.restrict("C:\\private", false);
+
+    expect(identityCalls).toBe(1);
+  });
+
+  it("can preserve existing explicit grants for consumers that only protect newly-created paths", () => {
+    const calls: string[] = [];
+    const acl = new WindowsAcl((file, args) => {
+      calls.push(`${file} ${args.join(" ")}`);
+      return file === "whoami" ? "\"user\",\"S-1-5-21-1000\"" : "";
+    });
+
+    acl.restrict("C:\\logs", false, { removeOtherIdentities: false });
+
+    expect(calls).toEqual([
+      "whoami /user /fo csv /nh",
+      "icacls C:\\logs /inheritance:r /grant:r *s-1-5-21-1000:(F)",
+    ]);
+  });
+
+  it("resolves system commands without relying on the caller PATH", () => {
+    expect(windowsCommandPath("icacls", "win32", { SystemRoot: "D:\\Windows" })).toBe(
+      path.join("D:\\Windows", "System32", "icacls.exe"),
+    );
+    expect(windowsCommandPath("icacls", "linux", {})).toBe("icacls");
+  });
+});


### PR DESCRIPTION
Closes #170

## Summary

- extracts one injected Windows ACL implementation shared by credential storage, agent configuration, daemon identity, and daemon logging
- preserves each consumer's owner, grant-removal, identity-caching, error-mapping, and test-injection behavior
- moves the agent-model usability predicate from Admin into `ModelCapabilityRegistry`
- keeps catalog order, captured-snapshot currency, Admin APIs, and model behavior unchanged

## Review

Three independent review passes were completed. The first Spec review found that malformed `whoami` output changed `error.name` for credential/logger callers; that was corrected while retaining daemon-specific typed mapping, and a regression test was added. Final Standards and Spec reviews found no must-fix or safe-to-defer findings.

## Validation

- focused ACL / registry / Admin contracts: passed
- credential, agent-files, daemon-identity, and log-rotation focused tests: passed when run independently (platform skips unchanged)
- `npm run typecheck`: passed
- `npm run lint`: passed
- full `npm test`: 81/82 files and 1069 tests passed; two unchanged real-Windows daemon identity cases exceeded their 60-second timeout while unrelated ACL-heavy work ran concurrently, then passed in focused elevated-timeout validation
- `git diff --check`: passed

No official SDK suite or live inference was run.
