### PR TITLE
Add checkpoint benchmark diagnostics

### DIFF
--- a/scripts/tooling/bench.ts
+++ b/scripts/tooling/bench.ts
@@ -22,6 +22,7 @@ import {
 } from "../../src/main.js";
 import { closeDatabase, openDatabase } from "../../src/persistence/database.js";
 import { MIGRATION_MANIFEST } from "../../src/persistence/generated_migrations.js";
+import type { SqliteDatabase } from "../../src/persistence/sqlite.js";
 import type {
   NativeResponsesUpstreamRequest,
   UpstreamByteResponse,
@@ -36,6 +37,15 @@ import { TelemetryRecorder } from "../../src/telemetry/recorder.js";
 import { nearestRankP95, THRESHOLDS } from "../../src/telemetry/performance.js";
 import { assertNode24 } from "./node_version.js";
 import type { PerformanceMeasurement, ProtocolPerformanceObserver } from "../../src/telemetry/runtime.js";
+import {
+  CheckpointDiagnosticsCollector,
+  checkpointFilesystem,
+  checkpointResourceSnapshot,
+  checkpointSqliteConfiguration,
+  instrumentCheckpointDatabase,
+  type CheckpointDiagnostics,
+} from "./checkpoint_diagnostics.js";
+export type { CheckpointDiagnostics } from "./checkpoint_diagnostics.js";
 import "./ci_network_guard.js";
 
 const execFileAsync = promisify(execFile);
@@ -80,6 +90,10 @@ export interface LatencyMetricResult {
   readonly passed: boolean;
 }
 
+export interface CheckpointLatencyMetricResult extends LatencyMetricResult {
+  readonly diagnostics: CheckpointDiagnostics;
+}
+
 export interface BenchmarkEnvironment {
   readonly node: string;
   readonly platform: NodeJS.Platform;
@@ -120,7 +134,7 @@ export interface BenchmarkRunResult {
   };
   readonly buffered: LatencyMetricResult;
   readonly streamEvent: LatencyMetricResult;
-  readonly checkpoint: LatencyMetricResult;
+  readonly checkpoint: CheckpointLatencyMetricResult;
   readonly eventLoop: LatencyMetricResult;
   readonly passed: boolean;
 }
@@ -209,16 +223,31 @@ class MeasuredHistory extends SqliteResponsesHistory {
   readonly valuesMs: number[] = [];
   measuring = false;
 
+  constructor(
+    database: SqliteDatabase,
+    options: ConstructorParameters<typeof SqliteResponsesHistory>[1],
+    private readonly diagnostics: CheckpointDiagnosticsCollector,
+  ) {
+    super(database, options);
+  }
+
   override async recordCheckpoint(
     record: Readonly<ResponsesHistoryRecord>,
     ownership: Readonly<ResponsesContinuationOwnership>,
     checkpointState: "partial" | "complete",
     signal: AbortSignal,
   ): Promise<void> {
-    const started = performance.now();
-    await super.recordCheckpoint(record, ownership, checkpointState, signal);
-    if (this.measuring) {
-      this.valuesMs.push(elapsedMs(started));
+    const measurement = this.measuring ? this.diagnostics.startCheckpoint(checkpointState) : undefined;
+    const gateStartedAtMs = measurement === undefined ? undefined : performance.now();
+    try {
+      await super.recordCheckpoint(record, ownership, checkpointState, signal);
+    } catch (error: unknown) {
+      measurement?.abandon();
+      throw error;
+    }
+    if (measurement !== undefined && gateStartedAtMs !== undefined) {
+      const gateElapsedMs = elapsedMs(gateStartedAtMs);
+      this.valuesMs.push(measurement.complete(gateElapsedMs));
     }
   }
 }
@@ -262,7 +291,10 @@ class EventLoopSampler {
 interface BenchmarkRuntime {
   readonly gateway: Gateway;
   readonly backend: BenchmarkCopilotBackend;
+  readonly database: SqliteDatabase;
+  readonly databasePath: string;
   readonly history: MeasuredHistory;
+  readonly checkpointDiagnostics: CheckpointDiagnosticsCollector;
   readonly performance: BenchmarkPerformanceObserver;
   close(): Promise<void>;
 }
@@ -361,7 +393,7 @@ export async function runBenchmarkIteration(
 
     const bufferedValues = await measureBufferedRequests(runtime, workload.bufferedSamples);
     const streamEventValues = await measureStreamEvents(runtime, workload.eventSamples);
-    const checkpointValues = await measureCheckpoints(runtime, workload.checkpointStreams);
+    const checkpointMeasurement = await measureCheckpoints(runtime, workload.checkpointStreams);
     await ensureEventLoopSamples(eventLoop.valuesMs, 100);
     await eventLoop.stop();
 
@@ -370,7 +402,10 @@ export async function runBenchmarkIteration(
     const streamsPassed = streamDelta <= STABLE_DELTA_LIMIT_BYTES;
     const buffered = latencyResult(bufferedValues, THRESHOLDS.bufferedMs, LATENCY_WARMUP_REQUESTS);
     const streamEvent = latencyResult(streamEventValues, THRESHOLDS.eventMs, LATENCY_WARMUP_REQUESTS);
-    const checkpoint = latencyResult(checkpointValues, THRESHOLDS.checkpointMs, 2);
+    const checkpoint: CheckpointLatencyMetricResult = {
+      ...latencyResult(checkpointMeasurement.valuesMs, THRESHOLDS.checkpointMs, 2),
+      diagnostics: checkpointMeasurement.diagnostics,
+    };
     const eventLoopMetric = latencyResult(eventLoop.valuesMs, THRESHOLDS.eventLoopMs, 20);
     const passed = idlePassed && streamsPassed && buffered.passed && streamEvent.passed
       && checkpoint.passed && eventLoopMetric.passed;
@@ -412,6 +447,34 @@ export async function runBenchmarkIteration(
   }
 }
 
+export function benchmarkCliSummary(artifactPath: string, artifact: Readonly<BenchmarkArtifact>): object {
+  return {
+    artifactPath,
+    repeat: artifact.repeat,
+    passed: artifact.passed,
+    runs: artifact.runs.map((run) => ({
+      run: run.run,
+      idleMiB: run.idle.resident.medianBytes / MIB,
+      streamDeltaMiB: run.streams.deltaBytes / MIB,
+      bufferedP95Ms: run.buffered.p95Ms,
+      streamEventP95Ms: run.streamEvent.p95Ms,
+      checkpointP95Ms: run.checkpoint.p95Ms,
+      checkpointDiagnostics: {
+        observedCount: run.checkpoint.diagnostics.observedCount,
+        thresholdMs: run.checkpoint.diagnostics.thresholdMs,
+        thresholdExceededCount: run.checkpoint.diagnostics.thresholdExceededCount,
+        partialCount: run.checkpoint.diagnostics.states.partial.count,
+        completeCount: run.checkpoint.diagnostics.states.complete.count,
+        slowestMs: run.checkpoint.diagnostics.slowest.map((sample) => sample.elapsedMs),
+        transactionMaxMs: run.checkpoint.diagnostics.sqlite.transaction.maxMs,
+        transactionBoundaryMaxMs: run.checkpoint.diagnostics.sqlite.transactionBoundary.maxMs,
+      },
+      eventLoopP95Ms: run.eventLoop.p95Ms,
+      passed: run.passed,
+    })),
+  };
+}
+
 export async function runFullBenchmark(repeat: number): Promise<BenchmarkArtifact> {
   if (!Number.isInteger(repeat) || repeat < 1) {
     throw new Error("--repeat must be a positive integer");
@@ -447,8 +510,9 @@ async function createBenchmarkRuntime(): Promise<BenchmarkRuntime> {
   const dataDir = await benchmarkDataDir("runtime-");
   const port = await availablePort();
   const nowMs = (): number => 1_700_000_000_000;
+  const databasePath = path.join(dataDir, "state.db");
   const database = openDatabase({
-    path: path.join(dataDir, "state.db"),
+    path: databasePath,
     migrations: MIGRATION_MANIFEST,
     nowMs,
   });
@@ -479,7 +543,16 @@ async function createBenchmarkRuntime(): Promise<BenchmarkRuntime> {
     catalog,
     { get: () => null },
   );
-  const measuredHistory = new MeasuredHistory(database, { nowMs });
+  const checkpointDiagnostics = new CheckpointDiagnosticsCollector(
+    performance.now.bind(performance),
+    8,
+    THRESHOLDS.checkpointMs,
+  );
+  const measuredHistory = new MeasuredHistory(
+    instrumentCheckpointDatabase(database, checkpointDiagnostics),
+    { nowMs },
+    checkpointDiagnostics,
+  );
   const telemetry = new TelemetryRecorder(database, nowMs);
   const performanceObserver = new BenchmarkPerformanceObserver();
   let uuid = 0;
@@ -535,7 +608,10 @@ async function createBenchmarkRuntime(): Promise<BenchmarkRuntime> {
     return {
       gateway,
       backend,
+      database,
+      databasePath,
       history: measuredHistory,
+      checkpointDiagnostics,
       performance: performanceObserver,
       async close() {
         await gateway?.close();
@@ -616,12 +692,16 @@ async function measureCheckpoints(
   runtime: BenchmarkRuntime,
   streamCount: number,
   warmup = true,
-): Promise<number[]> {
+): Promise<{ readonly valuesMs: readonly number[]; readonly diagnostics: CheckpointDiagnostics }> {
   runtime.backend.mode = "checkpoint";
   if (warmup) {
     await measureCheckpoints(runtime, 2, false);
   }
   runtime.history.valuesMs.length = 0;
+  runtime.checkpointDiagnostics.reset();
+  const before = checkpointResourceSnapshot();
+  const cpuStarted = process.cpuUsage();
+  const wallStarted = performance.now();
   runtime.history.measuring = true;
   try {
     for (let index = 0; index < streamCount; index += 1) {
@@ -633,10 +713,26 @@ async function measureCheckpoints(
   } finally {
     runtime.history.measuring = false;
   }
+  const wallMs = elapsedMs(wallStarted);
+  const cpu = process.cpuUsage(cpuStarted);
+  const after = checkpointResourceSnapshot();
   if (runtime.history.valuesMs.length < streamCount) {
     throw new Error(`checkpoint benchmark expected at least ${streamCount} commits, received ${runtime.history.valuesMs.length}`);
   }
-  return [...runtime.history.valuesMs];
+  return {
+    valuesMs: [...runtime.history.valuesMs],
+    diagnostics: {
+      ...runtime.checkpointDiagnostics.report(),
+      measurement: {
+        wallMs,
+        cpuUserMicros: cpu.user,
+        cpuSystemMicros: cpu.system,
+      },
+      environment: { before, after },
+      sqliteConfiguration: checkpointSqliteConfiguration(runtime.database),
+      filesystem: await checkpointFilesystem(runtime.databasePath),
+    },
+  };
 }
 
 async function runStreamExecutions(runtime: BenchmarkRuntime, count: number, abort: boolean): Promise<void> {
@@ -944,7 +1040,7 @@ async function writeCompiledWorker(workerPath: string): Promise<void> {
   });
   await mkdir(path.dirname(workerPath), { recursive: true });
   await writeFile(workerPath, output.outputText.replaceAll("../../src/", "../../../../dist/src/"), "utf8");
-  for (const name of ["ci_network_guard", "node_version"]) {
+  for (const name of ["checkpoint_diagnostics", "ci_network_guard", "node_version"]) {
     const helperSource = fileURLToPath(new URL(`./${name}.ts`, import.meta.url));
     const helperOutput = ts.transpileModule(await readFile(helperSource, "utf8"), {
       compilerOptions,
@@ -960,8 +1056,20 @@ function benchmarkEnvironment(): BenchmarkEnvironment {
     platform: process.platform,
     arch: process.arch,
     cpus: os.cpus().length,
-    npmUserAgent: process.env.npm_config_user_agent ?? null,
+    npmUserAgent: sanitizedNpmUserAgent(process.env.npm_config_user_agent),
   };
+}
+
+export function sanitizedNpmUserAgent(value: string | undefined): string | null {
+  if (value === undefined || value.length > 256) return null;
+  const allowedExact = new Set([
+    "linux", "darwin", "win32", "x64", "arm64", "ia32",
+    "workspaces/true", "workspaces/false",
+  ]);
+  const safeTokens = value.split(" ").filter((token) =>
+    allowedExact.has(token)
+      || /^(?:npm|node)\/v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u.test(token));
+  return safeTokens.length === 0 ? null : safeTokens.join(" ");
 }
 
 function idleLaunchArgs(workerPath: string): string[] {
@@ -1094,21 +1202,7 @@ async function main(): Promise<void> {
   await mkdir(artifactDir, { recursive: true });
   const artifactPath = path.join(artifactDir, "full-gateway.json");
   await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
-  console.log(JSON.stringify({
-    artifactPath,
-    repeat: artifact.repeat,
-    passed: artifact.passed,
-    runs: artifact.runs.map((run) => ({
-      run: run.run,
-      idleMiB: run.idle.resident.medianBytes / MIB,
-      streamDeltaMiB: run.streams.deltaBytes / MIB,
-      bufferedP95Ms: run.buffered.p95Ms,
-      streamEventP95Ms: run.streamEvent.p95Ms,
-      checkpointP95Ms: run.checkpoint.p95Ms,
-      eventLoopP95Ms: run.eventLoop.p95Ms,
-      passed: run.passed,
-    })),
-  }));
+  console.log(JSON.stringify(benchmarkCliSummary(artifactPath, artifact)));
   if (!artifact.passed) {
     process.exitCode = 1;
   }

--- a/scripts/tooling/checkpoint_diagnostics.ts
+++ b/scripts/tooling/checkpoint_diagnostics.ts
@@ -1,0 +1,493 @@
+import { stat, statfs } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import type { SqliteDatabase, SqliteStatement } from "../../src/persistence/sqlite.js";
+
+const DEFAULT_SLOWEST_LIMIT = 8;
+
+export interface DiagnosticTimingAggregate {
+  readonly count: number;
+  readonly totalMs: number;
+  readonly maxMs: number;
+}
+
+export interface CheckpointResourceUsageDelta {
+  readonly cpuUserMicros: number | null;
+  readonly cpuSystemMicros: number | null;
+  readonly voluntaryContextSwitches: number | null;
+  readonly involuntaryContextSwitches: number | null;
+  readonly majorPageFaults: number | null;
+  readonly minorPageFaults: number | null;
+  readonly filesystemReads: number | null;
+  readonly filesystemWrites: number | null;
+}
+
+export interface CheckpointDiagnosticSample {
+  readonly ordinal: number;
+  readonly state: "partial" | "complete";
+  readonly thresholdExceeded: boolean;
+  readonly elapsedMs: number;
+  readonly sqlite: CheckpointSqliteTimings;
+  readonly sqliteAttributedMs: number;
+  readonly unattributedMs: number;
+  readonly resourceUsage: CheckpointResourceUsageDelta;
+}
+
+export interface CheckpointSqliteTimings {
+  readonly statementGet: DiagnosticTimingAggregate;
+  readonly statementAll: DiagnosticTimingAggregate;
+  readonly statementRun: DiagnosticTimingAggregate;
+  readonly transaction: DiagnosticTimingAggregate;
+  readonly transactionCallback: DiagnosticTimingAggregate;
+  readonly transactionBoundary: DiagnosticTimingAggregate;
+}
+
+export interface CheckpointTraceReport {
+  readonly observedCount: number;
+  readonly thresholdMs: number;
+  readonly thresholdExceededCount: number;
+  readonly retainedSlowestLimit: number;
+  readonly states: {
+    readonly partial: DiagnosticTimingAggregate;
+    readonly complete: DiagnosticTimingAggregate;
+  };
+  readonly sqlite: CheckpointSqliteTimings;
+  readonly slowest: readonly CheckpointDiagnosticSample[];
+}
+
+export interface CheckpointResourceSnapshot {
+  readonly loadAverage1m: number | null;
+  readonly freeMemoryBytes: number;
+  readonly totalMemoryBytes: number;
+  readonly processRssBytes: number;
+}
+
+export interface CheckpointDiagnostics extends CheckpointTraceReport {
+  readonly measurement: {
+    readonly wallMs: number;
+    readonly cpuUserMicros: number;
+    readonly cpuSystemMicros: number;
+  };
+  readonly environment: {
+    readonly before: CheckpointResourceSnapshot;
+    readonly after: CheckpointResourceSnapshot;
+  };
+  readonly sqliteConfiguration: {
+    readonly journalMode: "delete" | "truncate" | "persist" | "memory" | "wal" | "off" | "unknown";
+    readonly synchronous: number | null;
+    readonly busyTimeoutMs: number | null;
+    readonly walAutocheckpointPages: number | null;
+    readonly pageSizeBytes: number | null;
+  };
+  readonly filesystem: {
+    readonly databaseBytes: number;
+    readonly walBytes: number;
+    readonly sharedMemoryBytes: number;
+    readonly blockSizeBytes: number | null;
+    readonly totalBytes: number | null;
+    readonly freeBytes: number | null;
+  };
+}
+
+type CheckpointSqliteOperation = keyof CheckpointSqliteTimings;
+type MutableTimingAggregate = { count: number; totalMs: number; maxMs: number };
+type MutableSqliteTimings = Record<CheckpointSqliteOperation, MutableTimingAggregate>;
+type ResourceUsageField = keyof NodeJS.ResourceUsage;
+type ResourceUsageSnapshot = Partial<Record<ResourceUsageField, number>>;
+
+interface ActiveCheckpointDiagnostic {
+  readonly ordinal: number;
+  readonly state: "partial" | "complete";
+  readonly resourceUsage: ResourceUsageSnapshot;
+  readonly sqlite: MutableSqliteTimings;
+}
+
+export interface ActiveCheckpointMeasurement {
+  complete(elapsedMs: number): number;
+  abandon(): void;
+}
+
+export class CheckpointDiagnosticsCollector {
+  private readonly states = {
+    partial: emptyTimingAggregate(),
+    complete: emptyTimingAggregate(),
+  };
+  private readonly sqlite = emptySqliteTimings();
+  private readonly slowest: CheckpointDiagnosticSample[] = [];
+  private observedCount = 0;
+  private thresholdExceededCount = 0;
+  private active: ActiveCheckpointDiagnostic | undefined;
+
+  constructor(
+    private readonly now: () => number = performance.now.bind(performance),
+    private readonly retainedSlowestLimit = DEFAULT_SLOWEST_LIMIT,
+    private readonly thresholdMs = 5,
+    private readonly resourceUsage: () => ResourceUsageSnapshot = checkpointProcessResourceUsage,
+  ) {
+    if (!Number.isInteger(retainedSlowestLimit) || retainedSlowestLimit < 1) {
+      throw new Error("checkpoint diagnostic retention must be a positive integer");
+    }
+    if (!Number.isFinite(thresholdMs) || thresholdMs < 0) {
+      throw new Error("checkpoint diagnostic threshold must be nonnegative");
+    }
+  }
+
+  reset(): void {
+    if (this.active !== undefined) {
+      throw new Error("cannot reset checkpoint diagnostics while a sample is active");
+    }
+    this.observedCount = 0;
+    this.thresholdExceededCount = 0;
+    resetTimingAggregate(this.states.partial);
+    resetTimingAggregate(this.states.complete);
+    resetSqliteTimings(this.sqlite);
+    this.slowest.length = 0;
+  }
+
+  startCheckpoint(state: "partial" | "complete"): ActiveCheckpointMeasurement {
+    if (this.active !== undefined) {
+      throw new Error("checkpoint diagnostics do not support overlapping samples");
+    }
+    const active: ActiveCheckpointDiagnostic = {
+      ordinal: this.observedCount + 1,
+      state,
+      resourceUsage: this.resourceUsage(),
+      sqlite: emptySqliteTimings(),
+    };
+    this.active = active;
+    let finished = false;
+    const claim = (): void => {
+      if (finished || this.active !== active) {
+        throw new Error("checkpoint diagnostic sample was already finished");
+      }
+      finished = true;
+      this.active = undefined;
+    };
+    return {
+      complete: (elapsedMs) => {
+        if (!Number.isFinite(elapsedMs) || elapsedMs < 0) {
+          throw new Error("checkpoint gate elapsed time must be nonnegative");
+        }
+        claim();
+        const resourceUsage = resourceUsageDelta(active.resourceUsage, this.resourceUsage());
+        const sqlite = copySqliteTimings(active.sqlite);
+        const sqliteAttributedMs = attributedSqliteMs(sqlite);
+        const thresholdExceeded = elapsedMs > this.thresholdMs;
+        const sample: CheckpointDiagnosticSample = {
+          ordinal: active.ordinal,
+          state,
+          thresholdExceeded,
+          elapsedMs,
+          sqlite,
+          sqliteAttributedMs,
+          unattributedMs: Math.max(0, elapsedMs - sqliteAttributedMs),
+          resourceUsage,
+        };
+        this.observedCount += 1;
+        if (thresholdExceeded) this.thresholdExceededCount += 1;
+        observeTiming(this.states[state], elapsedMs);
+        mergeSqliteTimings(this.sqlite, active.sqlite);
+        retainSlowest(this.slowest, sample, this.retainedSlowestLimit);
+        return elapsedMs;
+      },
+      abandon: claim,
+    };
+  }
+
+  measureSqlite<T>(operation: CheckpointSqliteOperation, work: () => T): T {
+    const active = this.active;
+    if (active === undefined) return work();
+    const startedAtMs = this.now();
+    try {
+      return work();
+    } finally {
+      this.observeSqlite(operation, this.now() - startedAtMs);
+    }
+  }
+
+  observeSqlite(operation: CheckpointSqliteOperation, elapsedMs: number): void {
+    if (this.active !== undefined) observeTiming(this.active.sqlite[operation], elapsedMs);
+  }
+
+  clockMs(): number {
+    return this.now();
+  }
+
+  report(): CheckpointTraceReport {
+    return {
+      observedCount: this.observedCount,
+      thresholdMs: this.thresholdMs,
+      thresholdExceededCount: this.thresholdExceededCount,
+      retainedSlowestLimit: this.retainedSlowestLimit,
+      states: {
+        partial: copyTimingAggregate(this.states.partial),
+        complete: copyTimingAggregate(this.states.complete),
+      },
+      sqlite: copySqliteTimings(this.sqlite),
+      slowest: this.slowest.map((sample) => ({
+        ...sample,
+        sqlite: copySqliteTimings(sample.sqlite),
+        resourceUsage: { ...sample.resourceUsage },
+      })),
+    };
+  }
+}
+
+export function instrumentCheckpointDatabase(
+  database: SqliteDatabase,
+  collector: CheckpointDiagnosticsCollector,
+): SqliteDatabase {
+  return new Proxy(database, {
+    get(target, property): unknown {
+      if (property === "prepare") {
+        return (source: string): SqliteStatement => instrumentCheckpointStatement(
+          target.prepare(source),
+          collector,
+        );
+      }
+      if (property === "transaction") {
+        return <Args extends unknown[], Result>(work: (...args: Args) => Result) => {
+          let callbackElapsedMs = 0;
+          const transaction = target.transaction((...args: Args): Result => {
+            const callbackStartedAtMs = collector.clockMs();
+            try {
+              return work(...args);
+            } finally {
+              callbackElapsedMs = collector.clockMs() - callbackStartedAtMs;
+            }
+          });
+          return (...args: Args): Result => {
+            callbackElapsedMs = 0;
+            const transactionStartedAtMs = collector.clockMs();
+            try {
+              return transaction(...args);
+            } finally {
+              const transactionElapsedMs = collector.clockMs() - transactionStartedAtMs;
+              collector.observeSqlite("transaction", transactionElapsedMs);
+              collector.observeSqlite("transactionCallback", callbackElapsedMs);
+              collector.observeSqlite(
+                "transactionBoundary",
+                Math.max(0, transactionElapsedMs - callbackElapsedMs),
+              );
+            }
+          };
+        };
+      }
+      const value = Reflect.get(target, property, target) as unknown;
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+export function checkpointResourceSnapshot(): CheckpointResourceSnapshot {
+  const loadAverage = os.loadavg()[0];
+  return {
+    loadAverage1m: loadAverage !== undefined && Number.isFinite(loadAverage) && loadAverage >= 0
+      ? loadAverage
+      : null,
+    freeMemoryBytes: safeNonNegativeInteger(os.freemem()),
+    totalMemoryBytes: safeNonNegativeInteger(os.totalmem()),
+    processRssBytes: safeNonNegativeInteger(process.memoryUsage().rss),
+  };
+}
+
+export function checkpointSqliteConfiguration(
+  database: SqliteDatabase,
+): CheckpointDiagnostics["sqliteConfiguration"] {
+  const journalMode = database.pragma("journal_mode", { simple: true });
+  const normalizedJournalMode = typeof journalMode === "string" ? journalMode.toLowerCase() : "unknown";
+  return {
+    journalMode: isAllowedJournalMode(normalizedJournalMode) ? normalizedJournalMode : "unknown",
+    synchronous: safePragmaNumber(database.pragma("synchronous", { simple: true })),
+    busyTimeoutMs: safePragmaNumber(database.pragma("busy_timeout", { simple: true })),
+    walAutocheckpointPages: safePragmaNumber(database.pragma("wal_autocheckpoint", { simple: true })),
+    pageSizeBytes: safePragmaNumber(database.pragma("page_size", { simple: true })),
+  };
+}
+
+export async function checkpointFilesystem(
+  databasePath: string,
+): Promise<CheckpointDiagnostics["filesystem"]> {
+  const [databaseBytes, walBytes, sharedMemoryBytes, filesystem] = await Promise.all([
+    fileSize(databasePath),
+    fileSize(`${databasePath}-wal`),
+    fileSize(`${databasePath}-shm`),
+    statfs(path.dirname(databasePath)).catch(() => undefined),
+  ]);
+  const blockSizeBytes = filesystem === undefined ? null : safeNullableInteger(filesystem.bsize);
+  const blocks = filesystem === undefined ? null : safeNullableInteger(filesystem.blocks);
+  const freeBlocks = filesystem === undefined ? null : safeNullableInteger(filesystem.bfree);
+  return {
+    databaseBytes,
+    walBytes,
+    sharedMemoryBytes,
+    blockSizeBytes,
+    totalBytes: blockSizeBytes === null || blocks === null ? null : safeNullableInteger(blockSizeBytes * blocks),
+    freeBytes: blockSizeBytes === null || freeBlocks === null ? null : safeNullableInteger(blockSizeBytes * freeBlocks),
+  };
+}
+
+function instrumentCheckpointStatement(
+  statement: SqliteStatement,
+  collector: CheckpointDiagnosticsCollector,
+): SqliteStatement {
+  return new Proxy(statement, {
+    get(target, property): unknown {
+      const operation = property === "get"
+        ? "statementGet"
+        : property === "all"
+          ? "statementAll"
+          : property === "run"
+            ? "statementRun"
+            : undefined;
+      const value = Reflect.get(target, property, target) as unknown;
+      if (operation === undefined || typeof value !== "function") {
+        return typeof value === "function" ? value.bind(target) : value;
+      }
+      return (...args: unknown[]): unknown => collector.measureSqlite(
+        operation,
+        () => Reflect.apply(value, target, args) as unknown,
+      );
+    },
+  });
+}
+
+function checkpointProcessResourceUsage(): ResourceUsageSnapshot {
+  try {
+    return process.resourceUsage();
+  } catch {
+    return {};
+  }
+}
+
+function resourceUsageDelta(
+  before: Readonly<ResourceUsageSnapshot>,
+  after: Readonly<ResourceUsageSnapshot>,
+): CheckpointResourceUsageDelta {
+  return {
+    cpuUserMicros: safeResourceDelta(before, after, "userCPUTime"),
+    cpuSystemMicros: safeResourceDelta(before, after, "systemCPUTime"),
+    voluntaryContextSwitches: safeResourceDelta(before, after, "voluntaryContextSwitches"),
+    involuntaryContextSwitches: safeResourceDelta(before, after, "involuntaryContextSwitches"),
+    majorPageFaults: safeResourceDelta(before, after, "majorPageFault"),
+    minorPageFaults: safeResourceDelta(before, after, "minorPageFault"),
+    filesystemReads: safeResourceDelta(before, after, "fsRead"),
+    filesystemWrites: safeResourceDelta(before, after, "fsWrite"),
+  };
+}
+
+function safeResourceDelta(
+  before: Readonly<ResourceUsageSnapshot>,
+  after: Readonly<ResourceUsageSnapshot>,
+  field: ResourceUsageField,
+): number | null {
+  const earlier = before[field];
+  const later = after[field];
+  if (typeof earlier !== "number" || typeof later !== "number") return null;
+  const delta = later - earlier;
+  return Number.isSafeInteger(delta) && delta >= 0 ? delta : null;
+}
+
+function attributedSqliteMs(timings: CheckpointSqliteTimings): number {
+  return timings.statementGet.totalMs
+    + timings.statementAll.totalMs
+    + timings.statementRun.totalMs
+    + timings.transactionBoundary.totalMs;
+}
+
+function emptyTimingAggregate(): MutableTimingAggregate {
+  return { count: 0, totalMs: 0, maxMs: 0 };
+}
+
+function emptySqliteTimings(): MutableSqliteTimings {
+  return {
+    statementGet: emptyTimingAggregate(),
+    statementAll: emptyTimingAggregate(),
+    statementRun: emptyTimingAggregate(),
+    transaction: emptyTimingAggregate(),
+    transactionCallback: emptyTimingAggregate(),
+    transactionBoundary: emptyTimingAggregate(),
+  };
+}
+
+function resetTimingAggregate(aggregate: MutableTimingAggregate): void {
+  aggregate.count = 0;
+  aggregate.totalMs = 0;
+  aggregate.maxMs = 0;
+}
+
+function resetSqliteTimings(timings: MutableSqliteTimings): void {
+  for (const aggregate of Object.values(timings)) resetTimingAggregate(aggregate);
+}
+
+function observeTiming(aggregate: MutableTimingAggregate, elapsed: number): void {
+  aggregate.count += 1;
+  aggregate.totalMs += elapsed;
+  aggregate.maxMs = Math.max(aggregate.maxMs, elapsed);
+}
+
+function copyTimingAggregate(aggregate: Readonly<MutableTimingAggregate>): DiagnosticTimingAggregate {
+  return { count: aggregate.count, totalMs: aggregate.totalMs, maxMs: aggregate.maxMs };
+}
+
+function copySqliteTimings(timings: Readonly<MutableSqliteTimings | CheckpointSqliteTimings>): CheckpointSqliteTimings {
+  return {
+    statementGet: copyTimingAggregate(timings.statementGet),
+    statementAll: copyTimingAggregate(timings.statementAll),
+    statementRun: copyTimingAggregate(timings.statementRun),
+    transaction: copyTimingAggregate(timings.transaction),
+    transactionCallback: copyTimingAggregate(timings.transactionCallback),
+    transactionBoundary: copyTimingAggregate(timings.transactionBoundary),
+  };
+}
+
+function mergeSqliteTimings(target: MutableSqliteTimings, source: Readonly<MutableSqliteTimings>): void {
+  for (const operation of Object.keys(target) as CheckpointSqliteOperation[]) {
+    const aggregate = source[operation];
+    target[operation].count += aggregate.count;
+    target[operation].totalMs += aggregate.totalMs;
+    target[operation].maxMs = Math.max(target[operation].maxMs, aggregate.maxMs);
+  }
+}
+
+function retainSlowest(
+  samples: CheckpointDiagnosticSample[],
+  candidate: CheckpointDiagnosticSample,
+  limit: number,
+): void {
+  samples.push(candidate);
+  samples.sort((left, right) => right.elapsedMs - left.elapsedMs || left.ordinal - right.ordinal);
+  if (samples.length > limit) samples.length = limit;
+}
+
+function isAllowedJournalMode(
+  value: string,
+): value is CheckpointDiagnostics["sqliteConfiguration"]["journalMode"] {
+  return value === "delete"
+    || value === "truncate"
+    || value === "persist"
+    || value === "memory"
+    || value === "wal"
+    || value === "off";
+}
+
+async function fileSize(filename: string): Promise<number> {
+  try {
+    return safeNonNegativeInteger((await stat(filename)).size);
+  } catch {
+    return 0;
+  }
+}
+
+function safePragmaNumber(value: unknown): number | null {
+  return typeof value === "number" ? safeNullableInteger(value) : null;
+}
+
+function safeNullableInteger(value: number): number | null {
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function safeNonNegativeInteger(value: number): number {
+  return safeNullableInteger(value) ?? 0;
+}

--- a/tests/performance/benchmark_contract.test.ts
+++ b/tests/performance/benchmark_contract.test.ts
@@ -1,8 +1,77 @@
 import { describe, expect, it } from "vitest";
 import {
+  benchmarkCliSummary,
   evaluateBenchmarkRuns,
+  sanitizedNpmUserAgent,
+  type BenchmarkArtifact,
   type BenchmarkRunResult,
+  type CheckpointDiagnostics,
 } from "../../scripts/tooling/bench.js";
+
+function checkpointDiagnostics(): CheckpointDiagnostics {
+  const timing = { count: 1, totalMs: 1, maxMs: 1 };
+  return {
+    observedCount: 2,
+    thresholdMs: 5,
+    thresholdExceededCount: 0,
+    retainedSlowestLimit: 8,
+    states: { partial: timing, complete: timing },
+    sqlite: {
+      statementGet: timing,
+      statementAll: timing,
+      statementRun: timing,
+      transaction: timing,
+      transactionCallback: timing,
+      transactionBoundary: timing,
+    },
+    slowest: [{
+      ordinal: 1,
+      state: "partial",
+      thresholdExceeded: false,
+      elapsedMs: 5,
+      sqlite: {
+        statementGet: timing,
+        statementAll: timing,
+        statementRun: timing,
+        transaction: timing,
+        transactionCallback: timing,
+        transactionBoundary: timing,
+      },
+      sqliteAttributedMs: 4,
+      unattributedMs: 1,
+      resourceUsage: {
+        cpuUserMicros: 1,
+        cpuSystemMicros: 1,
+        voluntaryContextSwitches: 0,
+        involuntaryContextSwitches: 0,
+        majorPageFaults: 0,
+        minorPageFaults: 0,
+        filesystemReads: 0,
+        filesystemWrites: 0,
+      },
+    }],
+    measurement: { wallMs: 2, cpuUserMicros: 1, cpuSystemMicros: 1 },
+    environment: {
+      before: { loadAverage1m: 0, freeMemoryBytes: 1, totalMemoryBytes: 2, processRssBytes: 1 },
+      after: { loadAverage1m: 0, freeMemoryBytes: 1, totalMemoryBytes: 2, processRssBytes: 1 },
+    },
+    sqliteConfiguration: {
+      journalMode: "wal",
+      synchronous: 2,
+      busyTimeoutMs: 1_000,
+      walAutocheckpointPages: 1_000,
+      pageSizeBytes: 4_096,
+    },
+    filesystem: {
+      databaseBytes: 4_096,
+      walBytes: 0,
+      sharedMemoryBytes: 0,
+      blockSizeBytes: 4_096,
+      totalBytes: 8_192,
+      freeBytes: 4_096,
+    },
+  };
+}
 
 function passingRun(run: number): BenchmarkRunResult {
   const resident = {
@@ -40,7 +109,7 @@ function passingRun(run: number): BenchmarkRunResult {
     },
     buffered: latency,
     streamEvent: { ...latency, thresholdMs: 2 },
-    checkpoint: latency,
+    checkpoint: { ...latency, diagnostics: checkpointDiagnostics() },
     eventLoop: { ...latency, thresholdMs: 10 },
     passed: true,
   };
@@ -62,5 +131,55 @@ describe("benchmark gate contract", () => {
     expect(run.idle.resident.metric).not.toContain("heap");
     expect(run.streams.executionCount).toBe(1_000);
     expect(run.streams.completedCount + run.streams.abortedCount).toBe(1_000);
+  });
+
+  it("keeps bounded threshold-exceeded checkpoint evidence in the CLI summary", () => {
+    const run = passingRun(1);
+    const failedRun: BenchmarkRunResult = {
+      ...run,
+      checkpoint: { ...run.checkpoint, passed: false },
+      passed: false,
+    };
+    const artifact: BenchmarkArtifact = {
+      kind: "full-gateway",
+      generatedAt: "2026-01-02T03:04:05.000Z",
+      repeat: 1,
+      requiredRepeat: 3,
+      runs: [failedRun],
+      passed: false,
+    };
+
+    const summary = benchmarkCliSummary("artifacts/bench/full-gateway.json", artifact);
+    expect(summary).toMatchObject({
+      passed: false,
+      runs: [{
+        checkpointP95Ms: 1,
+        checkpointDiagnostics: {
+          observedCount: 2,
+          thresholdMs: 5,
+          thresholdExceededCount: 0,
+          partialCount: 1,
+          completeCount: 1,
+          slowestMs: [5],
+          transactionMaxMs: 1,
+        },
+        passed: false,
+      }],
+    });
+    expect(JSON.stringify(summary)).not.toContain("generatedAt");
+  });
+
+  it.each([
+    ["npm/10.9.2 node/v24.20.0 win32 x64 workspaces/false", "npm/10.9.2 node/v24.20.0 win32 x64 workspaces/false"],
+    ["npm/10.9.2-beta.1 node/v24.20.0", "node/v24.20.0"],
+    ["npm/10.9.2 node/v24.20.0-rc.1", "npm/10.9.2"],
+    ["npm/10.9.2-../../private node/v24.20.0-secret", null],
+    ["npm/10.9 node/v24.20.0.1 npm/v10.9.2+build", null],
+    ["npm/01.002.0003 node/v01.002.0003", null],
+    ["workspaces/true linux arm64 arbitrary/payload", "workspaces/true linux arm64"],
+    ["npm/10.9.2  node/v24.20.0\nSECRET_ENV=value", "npm/10.9.2"],
+    [undefined, null],
+  ] as const)("sanitizes npm user agent %# to numeric semver and fixed labels", (input, expected) => {
+    expect(sanitizedNpmUserAgent(input)).toBe(expected);
   });
 });

--- a/tests/performance/benchmark_smoke.test.ts
+++ b/tests/performance/benchmark_smoke.test.ts
@@ -1,5 +1,153 @@
 import { describe, expect, it } from "vitest";
-import { runBenchmarkIteration } from "../../scripts/tooling/bench.js";
+import {
+  runBenchmarkIteration,
+  type CheckpointDiagnostics,
+} from "../../scripts/tooling/bench.js";
+import type {
+  CheckpointDiagnosticSample,
+  CheckpointResourceUsageDelta,
+  CheckpointSqliteTimings,
+  DiagnosticTimingAggregate,
+} from "../../scripts/tooling/checkpoint_diagnostics.js";
+
+function expectExactKeys(value: object, keys: readonly string[]): void {
+  expect(Object.keys(value).sort()).toEqual([...keys].sort());
+}
+
+function expectNonnegativeNumber(value: number): void {
+  expect(typeof value).toBe("number");
+  expect(Number.isFinite(value)).toBe(true);
+  expect(value).toBeGreaterThanOrEqual(0);
+}
+
+function expectNullableNonnegativeNumber(value: number | null): void {
+  if (value !== null) expectNonnegativeNumber(value);
+}
+
+function expectTiming(value: DiagnosticTimingAggregate): void {
+  expectExactKeys(value, ["count", "totalMs", "maxMs"]);
+  expect(Number.isSafeInteger(value.count)).toBe(true);
+  expectNonnegativeNumber(value.count);
+  expectNonnegativeNumber(value.totalMs);
+  expectNonnegativeNumber(value.maxMs);
+  expect(value.maxMs).toBeLessThanOrEqual(value.totalMs);
+  if (value.count === 0) expect(value).toEqual({ count: 0, totalMs: 0, maxMs: 0 });
+}
+
+function expectSqlite(value: CheckpointSqliteTimings): void {
+  expectExactKeys(value, [
+    "statementGet", "statementAll", "statementRun", "transaction", "transactionCallback",
+    "transactionBoundary",
+  ]);
+  for (const timing of Object.values(value)) expectTiming(timing);
+}
+
+function expectResourceUsage(value: CheckpointResourceUsageDelta): void {
+  expectExactKeys(value, [
+    "cpuUserMicros", "cpuSystemMicros", "voluntaryContextSwitches", "involuntaryContextSwitches",
+    "majorPageFaults", "minorPageFaults", "filesystemReads", "filesystemWrites",
+  ]);
+  for (const measurement of Object.values(value)) expectNullableNonnegativeNumber(measurement);
+}
+
+function expectSample(sample: CheckpointDiagnosticSample, diagnostics: CheckpointDiagnostics): void {
+  expectExactKeys(sample, [
+    "ordinal", "state", "thresholdExceeded", "elapsedMs", "sqlite", "sqliteAttributedMs",
+    "unattributedMs", "resourceUsage",
+  ]);
+  expect(Number.isSafeInteger(sample.ordinal)).toBe(true);
+  expect(sample.ordinal).toBeGreaterThan(0);
+  expect(["partial", "complete"]).toContain(sample.state);
+  expect(typeof sample.thresholdExceeded).toBe("boolean");
+  expect(sample.thresholdExceeded).toBe(sample.elapsedMs > diagnostics.thresholdMs);
+  expectNonnegativeNumber(sample.elapsedMs);
+  expectSqlite(sample.sqlite);
+  expectNonnegativeNumber(sample.sqliteAttributedMs);
+  expectNonnegativeNumber(sample.unattributedMs);
+  expect(sample.sqliteAttributedMs).toBe(
+    sample.sqlite.statementGet.totalMs
+      + sample.sqlite.statementAll.totalMs
+      + sample.sqlite.statementRun.totalMs
+      + sample.sqlite.transactionBoundary.totalMs,
+  );
+  expect(sample.sqliteAttributedMs + sample.unattributedMs).toBeCloseTo(sample.elapsedMs, 8);
+  expectResourceUsage(sample.resourceUsage);
+}
+
+function expectContentFree(value: unknown): void {
+  const forbiddenKeys = /^(?:sql|query|path|error|errors|stack|payload|request|response|requestid|responseid|accountid|modelid|id|arguments|content|env)$/iu;
+  const forbiddenStrings = [
+    /\b(?:select|insert|update|delete|replace|pragma|create|drop)\b/iu,
+    /[\\/]/u,
+    /(?:resp|call|req|chatcmpl)_[a-z0-9_-]+/iu,
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/iu,
+    /\b(?:error|failure|exception|secret|token|credential|payload|stack trace)\b/iu,
+    /\b(?:env|environment|home|path|token|secret)[_a-z0-9]*\s*=/iu,
+  ];
+  const visit = (current: unknown): void => {
+    if (typeof current === "string") {
+      for (const forbidden of forbiddenStrings) expect(current).not.toMatch(forbidden);
+      return;
+    }
+    if (Array.isArray(current)) {
+      for (const item of current) visit(item);
+      return;
+    }
+    if (current === null || typeof current !== "object") return;
+    for (const [key, nested] of Object.entries(current)) {
+      expect(key).not.toMatch(forbiddenKeys);
+      visit(nested);
+    }
+  };
+  visit(value);
+}
+
+function expectDiagnosticContract(diagnostics: CheckpointDiagnostics): void {
+  expectExactKeys(diagnostics, [
+    "observedCount", "thresholdMs", "thresholdExceededCount", "retainedSlowestLimit", "states",
+    "sqlite", "slowest", "measurement", "environment", "sqliteConfiguration", "filesystem",
+  ]);
+  for (const count of [
+    diagnostics.observedCount,
+    diagnostics.thresholdExceededCount,
+    diagnostics.retainedSlowestLimit,
+  ]) {
+    expect(Number.isSafeInteger(count)).toBe(true);
+    expectNonnegativeNumber(count);
+  }
+  expect(diagnostics.thresholdExceededCount).toBeLessThanOrEqual(diagnostics.observedCount);
+  expectNonnegativeNumber(diagnostics.thresholdMs);
+  expectExactKeys(diagnostics.states, ["partial", "complete"]);
+  expectTiming(diagnostics.states.partial);
+  expectTiming(diagnostics.states.complete);
+  expectSqlite(diagnostics.sqlite);
+  expect(diagnostics.slowest.length).toBeLessThanOrEqual(diagnostics.retainedSlowestLimit);
+  for (const sample of diagnostics.slowest) expectSample(sample, diagnostics);
+
+  expectExactKeys(diagnostics.measurement, ["wallMs", "cpuUserMicros", "cpuSystemMicros"]);
+  for (const value of Object.values(diagnostics.measurement)) expectNonnegativeNumber(value);
+  expectExactKeys(diagnostics.environment, ["before", "after"]);
+  for (const snapshot of Object.values(diagnostics.environment)) {
+    expectExactKeys(snapshot, ["loadAverage1m", "freeMemoryBytes", "totalMemoryBytes", "processRssBytes"]);
+    expectNullableNonnegativeNumber(snapshot.loadAverage1m);
+    expectNonnegativeNumber(snapshot.freeMemoryBytes);
+    expectNonnegativeNumber(snapshot.totalMemoryBytes);
+    expectNonnegativeNumber(snapshot.processRssBytes);
+  }
+  expectExactKeys(diagnostics.sqliteConfiguration, [
+    "journalMode", "synchronous", "busyTimeoutMs", "walAutocheckpointPages", "pageSizeBytes",
+  ]);
+  expect(["delete", "truncate", "persist", "memory", "wal", "off", "unknown"])
+    .toContain(diagnostics.sqliteConfiguration.journalMode);
+  for (const [key, value] of Object.entries(diagnostics.sqliteConfiguration)) {
+    if (key !== "journalMode") expectNullableNonnegativeNumber(value as number | null);
+  }
+  expectExactKeys(diagnostics.filesystem, [
+    "databaseBytes", "walBytes", "sharedMemoryBytes", "blockSizeBytes", "totalBytes", "freeBytes",
+  ]);
+  for (const value of Object.values(diagnostics.filesystem)) expectNullableNonnegativeNumber(value);
+  expectContentFree(diagnostics);
+}
 
 describe("full-gateway benchmark smoke", () => {
   it("measures production gateway, stream, and SQLite seams with scripted remotes", async () => {
@@ -16,9 +164,33 @@ describe("full-gateway benchmark smoke", () => {
     expect(result.streams.executionCount).toBe(10);
     expect(result.buffered.valuesMs).toHaveLength(20);
     expect(result.streamEvent.valuesMs).toHaveLength(20);
-    expect(result.checkpoint.valuesMs.length).toBeGreaterThanOrEqual(4);
+    expect(result.checkpoint.valuesMs).toHaveLength(8);
+    expect(result.checkpoint.diagnostics.observedCount).toBe(8);
+    expect(result.checkpoint.diagnostics.states.partial.count).toBe(4);
+    expect(result.checkpoint.diagnostics.states.complete.count).toBe(4);
+    expect(result.checkpoint.diagnostics.thresholdMs).toBe(result.checkpoint.thresholdMs);
+    expect(result.checkpoint.diagnostics.thresholdExceededCount).toBe(
+      result.checkpoint.valuesMs.filter((value) => value > result.checkpoint.thresholdMs).length,
+    );
+    expect(result.checkpoint.diagnostics.slowest.map((sample) => sample.elapsedMs)).toEqual(
+      [...result.checkpoint.valuesMs].sort((left, right) => right - left).slice(
+        0,
+        result.checkpoint.diagnostics.retainedSlowestLimit,
+      ),
+    );
+    for (const sample of result.checkpoint.diagnostics.slowest) {
+      expect(result.checkpoint.valuesMs).toContain(sample.elapsedMs);
+    }
+    expectDiagnosticContract(result.checkpoint.diagnostics);
+    expect(result.checkpoint.diagnostics.sqlite.statementRun.count).toBeGreaterThan(0);
+    expect(result.checkpoint.diagnostics.sqlite.transaction.count).toBeGreaterThan(0);
+    expect(result.checkpoint.diagnostics.measurement.wallMs).toBeGreaterThan(0);
+    expect(result.checkpoint.diagnostics.environment.before.totalMemoryBytes).toBeGreaterThan(0);
+    expect(result.checkpoint.diagnostics.environment.after.processRssBytes).toBeGreaterThan(0);
+    expect(result.checkpoint.diagnostics.sqliteConfiguration.journalMode).toBe("wal");
+    expect(result.checkpoint.diagnostics.filesystem.databaseBytes).toBeGreaterThan(0);
     expect(result.eventLoop.valuesMs.length).toBeGreaterThanOrEqual(100);
     expect(result.buffered.valuesMs.some((value) => value > 0)).toBe(true);
-    expect(result.checkpoint.valuesMs.some((value) => value > 0)).toBe(true);
+    expect(result.checkpoint.valuesMs.every((value) => value > 0)).toBe(true);
   }, 60_000);
 });

--- a/tests/performance/checkpoint_diagnostics.test.ts
+++ b/tests/performance/checkpoint_diagnostics.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import type { SqliteDatabase } from "../../src/persistence/sqlite.js";
+import {
+  CheckpointDiagnosticsCollector,
+  instrumentCheckpointDatabase,
+} from "../../scripts/tooling/checkpoint_diagnostics.js";
+
+function expectNonnegative(value: number | null): void {
+  if (value === null) return;
+  expect(Number.isFinite(value)).toBe(true);
+  expect(value).toBeGreaterThanOrEqual(0);
+}
+
+describe("checkpoint benchmark diagnostics", () => {
+  it("counts threshold-exceeded persisted samples and retains the bounded slowest outliers", () => {
+    let now = 0;
+    let resourceTick = 0;
+    const resourceUsage = () => {
+      resourceTick += 1;
+      return {
+        userCPUTime: resourceTick * 10,
+        systemCPUTime: resourceTick * 20,
+        voluntaryContextSwitches: resourceTick * 2,
+        involuntaryContextSwitches: resourceTick * 3,
+        majorPageFault: resourceTick * 4,
+        minorPageFault: resourceTick * 5,
+        fsRead: resourceTick * 6,
+        fsWrite: resourceTick * 7,
+      };
+    };
+    const statement = {
+      get: () => { now += 2; return undefined; },
+      all: () => { now += 3; return []; },
+      run: () => { now += 4; return { changes: 1, lastInsertRowid: 1 }; },
+    };
+    const database = {
+      prepare: () => statement,
+      transaction: (work: () => unknown) => () => {
+        now += 1;
+        const result = work();
+        now += 1;
+        return result;
+      },
+    } as unknown as SqliteDatabase;
+    const collector = new CheckpointDiagnosticsCollector(() => now, 2, 15, resourceUsage);
+    const measured = instrumentCheckpointDatabase(database, collector);
+
+    const record = (
+      state: "partial" | "complete",
+      increment: number,
+      gateElapsedMs: number,
+    ): number => {
+      const measurement = collector.startCheckpoint(state);
+      measured.transaction(() => {
+        const prepared = measured.prepare("sensitive lowercase select from private_table");
+        prepared.get("private/path/id");
+        prepared.all("arbitrary payload");
+        prepared.run("secret binding");
+        now += increment;
+      })();
+      return measurement.complete(gateElapsedMs);
+    };
+
+    expect(record("partial", 1, 12)).toBe(12);
+    expect(record("complete", 5, 16)).toBe(16);
+    expect(record("partial", 10, 21)).toBe(21);
+
+    const report = collector.report();
+    expect(Object.keys(report).sort()).toEqual([
+      "observedCount", "retainedSlowestLimit", "slowest", "sqlite", "states",
+      "thresholdExceededCount", "thresholdMs",
+    ].sort());
+    expect(report.observedCount).toBe(3);
+    expect(report.thresholdMs).toBe(15);
+    expect(report.thresholdExceededCount).toBe(2);
+    expect(report.states).toEqual({
+      partial: { count: 2, totalMs: 33, maxMs: 21 },
+      complete: { count: 1, totalMs: 16, maxMs: 16 },
+    });
+    expect(report.sqlite.statementGet).toEqual({ count: 3, totalMs: 6, maxMs: 2 });
+    expect(report.sqlite.statementAll).toEqual({ count: 3, totalMs: 9, maxMs: 3 });
+    expect(report.sqlite.statementRun).toEqual({ count: 3, totalMs: 12, maxMs: 4 });
+    expect(report.sqlite.transaction).toEqual({ count: 3, totalMs: 49, maxMs: 21 });
+    expect(report.sqlite.transactionCallback).toEqual({ count: 3, totalMs: 43, maxMs: 19 });
+    expect(report.sqlite.transactionBoundary).toEqual({ count: 3, totalMs: 6, maxMs: 2 });
+    expect(report.slowest).toHaveLength(2);
+    expect(report.slowest.map((sample) => [sample.ordinal, sample.state, sample.elapsedMs])).toEqual([
+      [3, "partial", 21],
+      [2, "complete", 16],
+    ]);
+    for (const sample of report.slowest) {
+      expect(Object.keys(sample).sort()).toEqual([
+        "elapsedMs", "ordinal", "resourceUsage", "sqlite", "sqliteAttributedMs", "state",
+        "thresholdExceeded", "unattributedMs",
+      ].sort());
+      expect(sample.thresholdExceeded).toBe(true);
+      expect(sample.sqliteAttributedMs).toBe(11);
+      expect(sample.unattributedMs).toBe(sample.elapsedMs - 11);
+      expect(sample.sqliteAttributedMs + sample.unattributedMs).toBe(sample.elapsedMs);
+      expect(sample.resourceUsage).toEqual({
+        cpuUserMicros: 10,
+        cpuSystemMicros: 20,
+        voluntaryContextSwitches: 2,
+        involuntaryContextSwitches: 3,
+        majorPageFaults: 4,
+        minorPageFaults: 5,
+        filesystemReads: 6,
+        filesystemWrites: 7,
+      });
+      for (const value of Object.values(sample.resourceUsage)) expectNonnegative(value);
+    }
+    const serialized = JSON.stringify(report).toLowerCase();
+    for (const forbidden of ["sensitive", "select", "private_table", "private/path", "payload", "secret binding"]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
+  it("abandons unsuccessful operations without creating a checkpoint sample", () => {
+    let now = 0;
+    const collector = new CheckpointDiagnosticsCollector(() => now, 4, 5, () => ({}));
+    const measurement = collector.startCheckpoint("complete");
+    now = 7;
+    measurement.abandon();
+
+    expect(collector.report()).toMatchObject({
+      observedCount: 0,
+      thresholdExceededCount: 0,
+      slowest: [],
+      states: { partial: { count: 0 }, complete: { count: 0 } },
+    });
+
+    const next = collector.startCheckpoint("partial");
+    now = 10;
+    expect(next.complete(3)).toBe(3);
+    expect(collector.report()).toMatchObject({ observedCount: 1, thresholdExceededCount: 0 });
+  });
+
+  it("keeps the gate sample independent from diagnostic clocks and resource callbacks", () => {
+    let diagnosticNow = 0;
+    let resourceTick = 0;
+    const collector = new CheckpointDiagnosticsCollector(
+      () => {
+        diagnosticNow += 50;
+        return diagnosticNow;
+      },
+      4,
+      5,
+      () => {
+        resourceTick += 1;
+        diagnosticNow += 1_000;
+        return { userCPUTime: resourceTick * 10 };
+      },
+    );
+    const rawGateValuesMs: number[] = [];
+
+    const belowGate = collector.startCheckpoint("partial");
+    collector.measureSqlite("statementRun", () => { diagnosticNow += 25; });
+    rawGateValuesMs.push(belowGate.complete(4.5));
+    const aboveGate = collector.startCheckpoint("complete");
+    collector.measureSqlite("transactionBoundary", () => { diagnosticNow += 25; });
+    rawGateValuesMs.push(aboveGate.complete(6));
+
+    const report = collector.report();
+    expect(diagnosticNow).toBe(4_250);
+    expect(resourceTick).toBe(4);
+    expect(rawGateValuesMs).toEqual([4.5, 6]);
+    expect(report.states).toEqual({
+      partial: { count: 1, totalMs: 4.5, maxMs: 4.5 },
+      complete: { count: 1, totalMs: 6, maxMs: 6 },
+    });
+    expect(report.thresholdExceededCount).toBe(1);
+    expect(report.slowest.map((sample) => [sample.elapsedMs, sample.thresholdExceeded])).toEqual([
+      [6, true],
+      [4.5, false],
+    ]);
+  });
+
+  it("preserves SQLite operation exceptions", () => {
+    const failure = new Error("private operation failure");
+    const database = {
+      prepare: () => ({ run: () => { throw failure; } }),
+    } as unknown as SqliteDatabase;
+    const collector = new CheckpointDiagnosticsCollector(() => 0, 1, 5, () => ({}));
+    const measured = instrumentCheckpointDatabase(database, collector);
+    const measurement = collector.startCheckpoint("partial");
+
+    expect(() => measured.prepare("lowercase insert").run("payload")).toThrow(failure);
+    measurement.abandon();
+    expect(collector.report().observedCount).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #157

## Summary

- adds bounded, content-free per-checkpoint diagnostics while preserving the existing workload, raw gate values, nearest-rank p95, 5 ms threshold, and repeat behavior
- distinguishes partial/complete checkpoints and attributes SQLite statements, transaction boundaries, unattributed wall time, and per-sample process resource deltas
- retains the eight slowest details plus aggregates for every sample, so threshold-exceeded evidence remains bounded but visible
- records strictly allowlisted runtime, SQLite, resource, and filesystem-capacity metadata without SQL, bindings, IDs, payloads, paths, arbitrary environment values, or error text
- leaves production Responses History and CI retry policy unchanged

## Review

Three Standards/Spec review rounds were completed. Findings fixed included unsafe npm user-agent suffix acceptance, unreachable exception-outcome claims, insufficient per-sample attribution/privacy contracts, and diagnostic callback overhead influencing gate timing. Final Standards and Spec reviews found no must-fix or safe-to-defer findings. A final evidence review found the investigation acceptance criteria met and no production change justified.

## Controlled same-head evidence

Three independent workflows ran at head `5e12f97`:

- [34461399284](https://github.com/ljie-PI/ghc-gateway/actions/runs/34461399284): passed
- [34462224469](https://github.com/ljie-PI/ghc-gateway/actions/runs/34462224469): reproduced the checkpoint failure on Linux arm64
- [34463092022](https://github.com/ljie-PI/ghc-gateway/actions/runs/34463092022): passed

The failing Linux arm64 repetition had checkpoint p95 **8.124 ms** and 8/60 samples over 5 ms. All eight were retained:

- partial samples spent **7.087–9.210 ms** at the SQLite transaction boundary
- complete samples spent **7.043–10.438 ms** in one SQLite `run`/autocommit operation
- unattributed time was only **0.071–0.122 ms**
- samples had low CPU, 2–3 voluntary and zero involuntary context switches, and filesystem writes
- buffered, stream-event, and event-loop metrics in the same repetition remained within their gates

Across the supplied cross-platform artifacts there were 33 repetitions / 1,980 checkpoints. Only that repetition failed checkpoint p95; other p95 values were **0.367–2.112 ms**. This localizes the observed spike to native SQLite commit/autocommit persistence waiting, consistent with intermittent runner/storage latency rather than JS/history setup or a stable algorithm regression.

The evidence cannot distinguish SQLite WAL locking, fsync, kernel writeback, filesystem latency, or virtualized storage. It does not justify weakening the gate or changing transaction/durability/history semantics.

## Validation

- performance contract/smoke tests: 17 passed
- `npm run typecheck`: passed
- `npm run lint`: passed
- `npm run build`: passed
- local `npm run bench -- full --repeat 3`: passed; 60 checkpoints per repetition
- initial full `npm test`: 81 files and 1066 tests passed; two unchanged Windows ACL-sensitive daemon identity cases exceeded their timeout under concurrent host load
- latest GitHub Actions run: all 7 jobs passed, including Linux x64/arm64, macOS x64/arm64, Windows x64, and Node 24/26
- `git diff --check`: passed

No official SDK suite, live inference, or replay-byte changes were used.
