### PR TITLE
Polish Models and Agents Admin usability

### DIFF
--- a/tests/e2e/admin_agents.spec.ts
+++ b/tests/e2e/admin_agents.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 import { installAdminFixture } from "./fixtures/admin_fixture.js";
 
 async function openAgents(page: Page) {
@@ -10,30 +10,91 @@ async function openAgents(page: Page) {
   return fixture;
 }
 
-test("agents view sits between Models and Configuration with two consistent cards", async ({ page }) => {
+async function expectOnlyVisuallyHidden(locator: Locator): Promise<void> {
+  expect(await locator.evaluateAll((elements) => elements.every((element) => {
+    const box = element.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    return style.display === "none" || style.visibility === "hidden" || box.width <= 1 || box.height <= 1;
+  }))).toBe(true);
+}
+
+test("agents view presents concise Codex-first cards with primary actions", async ({ page }) => {
   await openAgents(page);
   const labels = await page.locator(".nav-item").allTextContents();
   expect(labels.map((label) => label.replace(/\[\d+\]/u, "").trim()))
     .toEqual(["Overview", "Accounts", "Models", "Agents", "Configuration", "Events"]);
 
-  for (const title of ["Claude Code", "Codex"]) {
+  const cards = page.locator(".agent-card");
+  await expect(cards).toHaveCount(2);
+  await expect(cards.nth(0).getByRole("heading", { level: 2 })).toHaveText("Codex");
+  await expect(cards.nth(1).getByRole("heading", { level: 2 })).toHaveText("Claude Code");
+  const refresh = page.getByRole("button", { name: "Refresh", exact: true });
+  await expect(refresh).toHaveClass(/(^|\s)primary(\s|$)/u);
+  await expect(refresh).toHaveCSS("background-color", "rgb(32, 29, 29)");
+  await expect(page.getByText(/Refresh only reads configuration/)).toHaveCount(0);
+  await expect(page.getByText(/Restart clients after applying or restoring/)).toHaveCount(0);
+
+  for (const title of ["Codex", "Claude Code"]) {
     const card = page.locator(".agent-card", { has: page.getByRole("heading", { name: title }) });
     await expect(card).toBeVisible();
     await expect(card.getByText("Model mapping")).toBeVisible();
-    await expect(card.getByRole("button", { name: "Apply changes" })).toBeVisible();
+    await expect(card.getByRole("button", { name: "Apply changes" })).toHaveClass(/(^|\s)primary(\s|$)/u);
     await expect(card.getByRole("button", { name: "Restore" })).toBeVisible();
     await expect(card.locator("select")).toHaveCount(0);
     await expect(card.locator("input[type='radio']")).toHaveCount(0);
     await expect(card.getByText(/first row is the startup model/)).toBeVisible();
   }
-  // Claude maps its three native roles; Codex rows are addable/removable.
+
   const claude = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Claude Code" }) });
+  await expect(claude.locator(".agent-role")).toHaveCount(0);
   await expect(claude.locator(".agent-mapping-row")).toHaveCount(3);
+  for (const role of ["Sonnet", "Opus", "Haiku"]) {
+    await expectOnlyVisuallyHidden(claude.getByText(role, { exact: true }));
+    await expect(claude.getByRole("textbox", { name: `${role} Display name`, exact: true })).toHaveValue(role);
+    await expect(claude.getByRole("textbox", { name: `${role} Copilot model ID`, exact: true })).toHaveCount(1);
+  }
+
   const codex = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Codex" }) });
+  await expect(codex.getByRole("textbox", { name: "Model 1 Display name", exact: true })).toHaveCount(1);
   await codex.getByRole("button", { name: "Add model" }).click();
-  await expect(codex.locator(".agent-mapping-row")).toHaveCount(2);
+  await expect(codex.getByRole("textbox", { name: "Model 2 Display name", exact: true })).toHaveCount(1);
   await codex.getByRole("button", { name: "Remove model 2" }).click();
   await expect(codex.locator(".agent-mapping-row")).toHaveCount(1);
+});
+
+test("Agents reuses the session snapshot until explicit Refresh", async ({ page }) => {
+  const fixture = await openAgents(page);
+  await expect(page.locator(".agent-card")).toHaveCount(2);
+  expect(fixture.requests.filter((request) => request.url().endsWith("/agents"))).toHaveLength(1);
+
+  fixture.state.agents.codex = { ...fixture.state.agents.codex, state: "installed" };
+  await page.getByRole("button", { name: "Overview", exact: true }).click();
+  await page.getByRole("button", { name: "Agents", exact: true }).click();
+  await expect(page.locator(".agent-card")).toHaveCount(2);
+  await expect(page.getByText("Reading agent configuration...", { exact: true })).toHaveCount(0);
+  expect(fixture.requests.filter((request) => request.url().endsWith("/agents"))).toHaveLength(1);
+
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(page.locator(".agent-card").first().locator(".badge")).toHaveText("Configuration installed");
+  expect(fixture.requests.filter((request) => request.url().endsWith("/agents"))).toHaveLength(2);
+
+  fixture.state.failAgents = true;
+  await page.getByRole("button", { name: "Refresh", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText("internal error");
+  await expect(page.locator(".agent-card")).toHaveCount(2);
+  expect(fixture.requests.filter((request) => request.url().endsWith("/agents"))).toHaveLength(3);
+});
+
+test("Claude additional settings explains the optional subagent mapping without a visible role label", async ({ page }) => {
+  await openAgents(page);
+  const claude = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Claude Code" }) });
+  await claude.getByText("Additional settings", { exact: true }).click();
+  await expect(claude.getByText(/model Claude Code uses for delegated subagent work/)).toBeVisible();
+  await claude.getByRole("button", { name: "Add subagent mapping", exact: true }).click();
+  await expect(claude.locator(".agent-role")).toHaveCount(0);
+  await expectOnlyVisuallyHidden(claude.getByText("Subagent", { exact: true }));
+  await expect(claude.getByRole("textbox", { name: "Subagent Display name", exact: true })).toHaveValue("Subagent");
+  await expect(claude.getByRole("textbox", { name: "Subagent Copilot model ID", exact: true })).toHaveCount(1);
 });
 
 test("mapping edits gate Apply changes and apply posts exact text mappings", async ({ page }) => {
@@ -43,10 +104,12 @@ test("mapping edits gate Apply changes and apply posts exact text mappings", asy
   await expect(apply).toBeDisabled();
   await expect(codex.getByText("No unapplied changes")).toBeVisible();
 
-  await codex.getByLabel("Display name").fill("Fast");
-  await codex.getByLabel("Copilot model ID").fill("gpt-alpha");
+  await codex.getByRole("textbox", { name: "Model 1 Display name", exact: true }).fill("Fast");
+  await codex.getByRole("textbox", { name: "Model 1 Copilot model ID", exact: true }).fill("gpt-alpha");
   await expect(codex.getByText("Unapplied changes")).toBeVisible();
   await expect(apply).toBeEnabled();
+  await expect(apply).toHaveAttribute("type", "submit");
+  await expect(apply).toHaveCSS("background-color", "rgb(32, 29, 29)");
 
   page.once("dialog", (dialog) => dialog.accept());
   await apply.click();
@@ -62,11 +125,26 @@ test("mapping edits gate Apply changes and apply posts exact text mappings", asy
   });
 });
 
+test("an in-flight Refresh cannot overwrite a newer Apply result", async ({ page }) => {
+  const fixture = await openAgents(page);
+  const codex = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Codex" }) });
+  await codex.getByRole("textbox", { name: "Model 1 Display name", exact: true }).fill("Fast");
+  await codex.getByRole("textbox", { name: "Model 1 Copilot model ID", exact: true }).fill("gpt-alpha");
+  fixture.state.agentsDelayMs = 1_000;
+  await page.getByRole("button", { name: "Refresh", exact: true }).click({ noWaitAfter: true });
+  page.once("dialog", (dialog) => dialog.accept());
+  await codex.getByRole("button", { name: "Apply changes", exact: true }).click();
+  await expect(codex.locator(".badge")).toHaveText("Configuration installed");
+  await page.waitForTimeout(1_100);
+  await expect(codex.locator(".badge")).toHaveText("Configuration installed");
+  await expect(page.getByRole("alert")).toHaveCount(0);
+});
+
 test("restore confirms and returns the card to Not managed", async ({ page }) => {
   const fixture = await openAgents(page);
   const claude = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Claude Code" }) });
-  for (const [index, model] of ["gpt-alpha", "gpt-alpha", "claude-beta"].entries()) {
-    await claude.getByLabel("Copilot model ID").nth(index).fill(model);
+  for (const [role, model] of [["Sonnet", "gpt-alpha"], ["Opus", "gpt-alpha"], ["Haiku", "claude-beta"]] as const) {
+    await claude.getByRole("textbox", { name: `${role} Copilot model ID`, exact: true }).fill(model);
   }
   page.once("dialog", (dialog) => dialog.accept());
   await claude.getByRole("button", { name: "Apply changes" }).click();
@@ -97,8 +175,8 @@ test("conflict and unavailable states block apply without destructive actions", 
   const codex = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Codex" }) });
   await expect(codex.locator(".badge")).toHaveText("External changes detected");
   await expect(codex.getByText(/Outside edits are never overwritten/)).toBeVisible();
-  await codex.getByLabel("Display name").fill("Fast");
-  await codex.getByLabel("Copilot model ID").fill("gpt-alpha");
+  await codex.getByRole("textbox", { name: "Model 1 Display name", exact: true }).fill("Fast");
+  await codex.getByRole("textbox", { name: "Model 1 Copilot model ID", exact: true }).fill("gpt-alpha");
   await expect(codex.getByRole("button", { name: "Apply changes" })).toBeDisabled();
 
   const claude = page.locator(".agent-card", { has: page.getByRole("heading", { name: "Claude Code" }) });
@@ -115,25 +193,11 @@ test("agents cards stay responsive without horizontal scrolling", async ({ page 
   }
 });
 
-test("agents mapping rows are keyboard operable with unique labels", async ({ page }) => {
+test("agents mapping rows are keyboard operable with unique accessible labels", async ({ page }) => {
   await openAgents(page);
-  await expect(page.locator(".agent-card")).toHaveCount(2);
-  const evidence = await page.evaluate(() => {
-    const controls = [...document.querySelectorAll<HTMLElement>(".agent-card input, .agent-card button")];
-    const name = (element: HTMLElement): string => {
-      const explicit = element.getAttribute("aria-label");
-      if (explicit !== null && explicit !== "") return explicit;
-      const wrapped = element.closest("label")?.textContent?.trim();
-      if (wrapped !== undefined && wrapped !== "") return wrapped;
-      return element.textContent?.trim() ?? "";
-    };
-    return {
-      controls: controls.length,
-      unnamed: controls.filter((element) => name(element) === "").length,
-      dialogs: document.querySelectorAll(".agent-card").length,
-    };
-  });
-  expect(evidence.dialogs).toBe(2);
-  expect(evidence.controls).toBeGreaterThan(10);
-  expect(evidence.unnamed).toBe(0);
+  const names = await page.locator(".agent-card input").evaluateAll((inputs) => inputs.map((input) =>
+    (input as HTMLInputElement).labels?.[0]?.textContent?.replace(/\s+/gu, " ").trim() ?? ""));
+  expect(names.length).toBe(8);
+  expect(names.every((name) => name !== "")).toBe(true);
+  expect(new Set(names).size).toBe(names.length);
 });

--- a/tests/e2e/admin_models_polish.spec.ts
+++ b/tests/e2e/admin_models_polish.spec.ts
@@ -3,15 +3,19 @@ import { installAdminFixture, type AdminFixture } from "./fixtures/admin_fixture
 
 test.use({ locale: "en-US" });
 
+async function navigateTo(page: Page, view: "Overview" | "Models"): Promise<void> {
+  const menu = page.getByRole("button", { name: "Open navigation" });
+  if (await menu.isVisible()) await menu.click();
+  await page.getByRole("button", { name: view, exact: true }).click();
+  await expect(page.getByRole("heading", { name: view, exact: true })).toBeVisible();
+}
+
 async function openModels(page: Page, configure?: (fixture: AdminFixture) => void): Promise<AdminFixture> {
   const fixture = await installAdminFixture(page);
   configure?.(fixture);
   await page.goto("/admin/#bootstrap_token=synthetic-models-bootstrap");
   await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeVisible();
-  const menu = page.getByRole("button", { name: "Open navigation" });
-  if (await menu.isVisible()) await menu.click();
-  await page.getByRole("button", { name: "Models", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Models", exact: true })).toBeVisible();
+  await navigateTo(page, "Models");
   await expect(page.getByRole("table")).toBeVisible();
   return fixture;
 }
@@ -33,6 +37,30 @@ for (const width of [1440, 1100, 390, 320]) {
     expect(await metadata.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
     await toolbar.screenshot({ path: testInfo.outputPath(`model-account-toolbar-${width}.png`) });
+  });
+}
+
+for (const width of [1440, 390, 320]) {
+  test(`Models keeps the empty Account selector width at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    const fixture = await openModels(page);
+    const populated = page.getByRole("combobox", { name: "Account", exact: true });
+    const populatedBox = (await populated.boundingBox())!;
+
+    fixture.state.accounts = { ...fixture.state.accounts, defaultAccountId: null, items: [] };
+    await navigateTo(page, "Overview");
+    await navigateTo(page, "Models");
+
+    const empty = page.getByRole("combobox", { name: "Account", exact: true });
+    await expect(empty).toHaveValue("");
+    await expect(empty.getByRole("option")).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "No active account", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Refresh", exact: true })).toBeDisabled();
+    const emptyBox = (await empty.boundingBox())!;
+    expect(Math.abs(emptyBox.width - populatedBox.width)).toBeLessThanOrEqual(1);
+    expect(emptyBox.x).toBeGreaterThanOrEqual(0);
+    expect(emptyBox.x + emptyBox.width).toBeLessThanOrEqual(width);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
   });
 }
 

--- a/tests/e2e/fixtures/admin_fixture.ts
+++ b/tests/e2e/fixtures/admin_fixture.ts
@@ -56,6 +56,8 @@ export interface AdminFixture {
     agents: Record<"claude" | "codex", AgentStatus>;
     agentsCatalogRevision: string | null;
     agentsApplyConflict: boolean;
+    agentsDelayMs: number;
+    failAgents: boolean;
     cancelCompletesDeviceFlow: boolean;
     streamBodies: string[];
     streamDelaysMs: number[];
@@ -143,6 +145,8 @@ export async function installAdminFixture(page: Page): Promise<AdminFixture> {
       agents: { claude: agentStatus("claude", 1), codex: agentStatus("codex", 7) },
       agentsCatalogRevision: "c".repeat(64),
       agentsApplyConflict: false,
+      agentsDelayMs: 0,
+      failAgents: false,
       cancelCompletesDeviceFlow: false,
       streamBodies: [sse("performance", { kind: "performance", status: status("healthy") })],
       streamDelaysMs: [],
@@ -309,11 +313,15 @@ async function handle(
     });
   }
   if (path === "/agents") {
+    if (fixture.state.failAgents) return failure(route, 500, "internal_error");
     const view: AgentsView = {
       items: [structuredClone(fixture.state.agents.claude), structuredClone(fixture.state.agents.codex)],
       catalogRevision: fixture.state.agentsCatalogRevision,
       modelsAvailable: fixture.state.agentsCatalogRevision !== null,
     };
+    if (fixture.state.agentsDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, fixture.state.agentsDelayMs));
+    }
     return json(route, 200, view);
   }
   if (path === "/agents/apply" && request.method() === "POST") {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, tick } from "svelte";
   import { AdminClient, errorMessage, takeBootstrapToken } from "./api.js";
+  import type { AgentStatus, AgentsView } from "../../src/agents/types.js";
   import type {
     AdminOperationalEvent,
     AdminSessionMetadata,
@@ -33,6 +34,9 @@
   let workspace: HTMLElement | null = $state(null);
   let menuButton: HTMLButtonElement | null = $state(null);
   let navigation: HTMLElement | null = $state(null);
+  let agentsSnapshot: AgentsView | null = $state(null);
+  let agentsRequest: { readonly controller: AbortController; readonly promise: Promise<AgentsView> } | null = null;
+  let agentsGeneration = 0;
   let pageNumber = $derived(String(views.indexOf(view) + 1).padStart(2, "0"));
   const client = new AdminClient(teardown);
 
@@ -104,6 +108,7 @@
   function teardown(): void {
     closeStream();
     client.clear();
+    clearAgentsSnapshot();
     session = null;
     liveStatus = null;
     liveEvents = [];
@@ -111,6 +116,45 @@
     phase = "signed-out";
     authError = "Your admin session ended. Run `ghcg admin open` to reconnect.";
     requestAnimationFrame(() => signedOutPanel?.focus());
+  }
+
+  function clearAgentsSnapshot(): void {
+    agentsGeneration += 1;
+    agentsRequest?.controller.abort();
+    agentsRequest = null;
+    agentsSnapshot = null;
+  }
+
+  function loadAgents(refresh = false): Promise<AgentsView> {
+    if (!refresh && agentsSnapshot !== null) return Promise.resolve(agentsSnapshot);
+    if (agentsRequest !== null) return agentsRequest.promise;
+    const generation = agentsGeneration;
+    const controller = new AbortController();
+    let promise: Promise<AgentsView>;
+    promise = client.agents(controller.signal).then((loaded) => {
+      if (agentsGeneration === generation) agentsSnapshot = loaded;
+      return loaded;
+    }).catch((error: unknown) => {
+      if (agentsGeneration !== generation && agentsSnapshot !== null) return agentsSnapshot;
+      throw error;
+    }).finally(() => {
+      if (agentsRequest?.promise === promise) agentsRequest = null;
+    });
+    agentsRequest = { controller, promise };
+    return promise;
+  }
+
+  function updateAgent(status: AgentStatus): void {
+    if (agentsSnapshot === null) return;
+    const snapshot = agentsSnapshot;
+    agentsGeneration += 1;
+    const staleRequest = agentsRequest;
+    agentsRequest = null;
+    staleRequest?.controller.abort();
+    agentsSnapshot = {
+      ...snapshot,
+      items: snapshot.items.map((item) => item.id === status.id ? status : item),
+    };
   }
 
   async function logout(): Promise<void> {
@@ -237,7 +281,13 @@
           {:else if view === "Models"}
             <Models {client} {pageNumber} />
           {:else if view === "Agents"}
-            <Agents {client} {pageNumber} />
+            <Agents
+              {client}
+              {pageNumber}
+              data={agentsSnapshot}
+              onload={loadAgents}
+              onchanged={updateAgent}
+            />
           {:else if view === "Configuration"}
             <Configuration {client} {pageNumber} />
           {:else}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -59,7 +59,9 @@ export class AdminClient {
   models(accountId?: string): Promise<AdminModels> {
     return this.request(`/models${accountId === undefined ? "" : `?accountId=${encodeURIComponent(accountId)}`}`);
   }
-  agents(): Promise<AgentsView> { return this.request("/agents"); }
+  agents(signal?: AbortSignal): Promise<AgentsView> {
+    return this.request("/agents", signal === undefined ? undefined : { signal });
+  }
   applyAgent(value: AgentApplyRequest): Promise<AgentStatus> { return this.mutate("/agents/apply", "POST", value); }
   restoreAgent(value: AgentRestoreRequest): Promise<AgentStatus> { return this.mutate("/agents/restore", "POST", value); }
   config(): Promise<AdminRuntimeConfig> { return this.request("/config"); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -462,7 +462,6 @@ tr.current-row > td:last-child, .account-table tr > td:last-child { padding-righ
 .agent-mapping-row { display: flex; gap: 12px; align-items: end; margin: 16px 0; flex-wrap: wrap; }
 .agent-mapping-row label { display: grid; gap: 6px; flex: 1 1 200px; min-width: 0; }
 .agent-mapping-row input { width: 100%; min-width: 0; }
-.agent-role { flex: 0 0 64px; align-self: center; }
 .agent-actions p { flex: 1 1 180px; }
 .agent-details { margin-top: 20px; }
 .agent-card summary { cursor: pointer; padding: 8px 0; }
@@ -471,6 +470,5 @@ tr.current-row > td:last-child, .account-table tr > td:last-child { padding-righ
 @media (max-width: 600px) {
   .agent-card { padding: 16px; }
   .agent-mapping-row { align-items: stretch; }
-  .agent-role { flex-basis: 100%; }
   .agent-mapping-row label { flex-basis: 100%; }
 }

--- a/web/src/views/AgentCard.svelte
+++ b/web/src/views/AgentCard.svelte
@@ -34,6 +34,10 @@
       : (status.id === "claude" ? ["Sonnet", "Opus", "Haiku"] : [""]).map((displayName) => ({ displayName, modelId: "" }));
     baseline = JSON.stringify(drafts);
   }
+  function mappingName(index: number): string {
+    if (status.id === "codex") return `Model ${index + 1}`;
+    return index === 3 ? "Subagent" : ["Sonnet", "Opus", "Haiku"][index] ?? `Mapping ${index + 1}`;
+  }
   function setRow(index: number, key: keyof AgentMapping, value: string): void {
     drafts = drafts.map((row, i) => i === index ? { ...row, [key]: value } : row);
     notice = "";
@@ -73,16 +77,15 @@
   <form onsubmit={(event) => { event.preventDefault(); void mutate(false); }}>
     <fieldset disabled={busy}>
       <legend>Model mapping</legend>
-      <p class="muted" id={`${status.id}-mapping-help`}>The first row is the startup model. Display names are labels; Copilot model IDs are sent unchanged.</p>
+      <p class="muted" id={`${status.id}-mapping-help`}>{status.id === "claude" ? "Rows are ordered Sonnet, Opus, Haiku. " : ""}The first row is the startup model. Display names are labels; Copilot model IDs are sent unchanged.</p>
       {#each drafts as row, index (index)}
         {#if index < 3 || status.id === "codex"}
           <div class="agent-mapping-row">
-            {#if status.id === "claude"}<strong class="agent-role">{["Sonnet", "Opus", "Haiku"][index]}</strong>{/if}
-            <label>Display name
+            <label><span><span class="visually-hidden">{mappingName(index)} </span>Display name</span>
               <input type="text" value={row.displayName} maxlength="80" required aria-describedby={`${status.id}-mapping-help`}
                 oninput={(event) => setRow(index, "displayName", event.currentTarget.value)} />
             </label>
-            <label>Copilot model ID
+            <label><span><span class="visually-hidden">{mappingName(index)} </span>Copilot model ID</span>
               <input type="text" value={row.modelId} maxlength="128" required spellcheck="false" autocomplete="off"
                 oninput={(event) => setRow(index, "modelId", event.currentTarget.value)} />
             </label>
@@ -97,11 +100,11 @@
       {:else}
         <details>
           <summary>Additional settings</summary>
+          <p class="muted">Optional model Claude Code uses for delegated subagent work. If omitted, Claude Code uses its own defaults.</p>
           {#if drafts[3]}
             <div class="agent-mapping-row">
-              <strong class="agent-role">Subagent</strong>
-              <label>Display name<input type="text" value={drafts[3].displayName} maxlength="80" required oninput={(event) => setRow(3, "displayName", event.currentTarget.value)} /></label>
-              <label>Copilot model ID<input type="text" value={drafts[3].modelId} maxlength="128" required oninput={(event) => setRow(3, "modelId", event.currentTarget.value)} /></label>
+              <label><span><span class="visually-hidden">Subagent </span>Display name</span><input type="text" value={drafts[3].displayName} maxlength="80" required oninput={(event) => setRow(3, "displayName", event.currentTarget.value)} /></label>
+              <label><span><span class="visually-hidden">Subagent </span>Copilot model ID</span><input type="text" value={drafts[3].modelId} maxlength="128" required oninput={(event) => setRow(3, "modelId", event.currentTarget.value)} /></label>
               <button type="button" onclick={() => drafts = drafts.slice(0, 3)}>Remove subagent mapping</button>
             </div>
           {:else}
@@ -112,7 +115,7 @@
     </fieldset>
     <div class="agent-actions">
       <p aria-live="polite">{dirty ? "Unapplied changes" : "No unapplied changes"}</p>
-      <button class="primary" disabled={busy || !dirty || !valid || !applyAllowed || catalogRevision === null}>Apply changes</button>
+      <button class="primary" type="submit" disabled={busy || !dirty || !valid || !applyAllowed || catalogRevision === null}>Apply changes</button>
       <button type="button" disabled={busy || !status.canRestore} onclick={() => void mutate(true)}>Restore</button>
     </div>
   </form>

--- a/web/src/views/Agents.svelte
+++ b/web/src/views/Agents.svelte
@@ -3,38 +3,58 @@
   import { errorMessage, type AdminClient } from "../api.js";
   import type { AgentsView, AgentStatus } from "../../../src/agents/types.js";
   import AgentCard from "./AgentCard.svelte";
-  let { client, pageNumber }: { client: AdminClient; pageNumber: string } = $props();
-  let data: AgentsView | null = $state(null);
+
+  let {
+    client,
+    pageNumber,
+    data,
+    onload,
+    onchanged,
+  }: {
+    client: AdminClient;
+    pageNumber: string;
+    data: AgentsView | null;
+    onload: (refresh?: boolean) => Promise<AgentsView>;
+    onchanged: (status: AgentStatus) => void;
+  } = $props();
   let loading = $state(false);
   let failure = $state("");
-  onMount(() => { void load(); });
-  async function load(): Promise<void> {
+  let disposed = false;
+  const orderedItems = $derived(data?.items.toSorted((left, right) =>
+    (left.id === "codex" ? 0 : 1) - (right.id === "codex" ? 0 : 1)) ?? []);
+
+  onMount(() => {
+    if (data === null) void load(false);
+    return () => { disposed = true; };
+  });
+
+  async function load(refresh: boolean): Promise<void> {
     loading = true;
     failure = "";
-    try { data = await client.agents(); }
-    catch (error: unknown) { failure = errorMessage(error); }
-    finally { loading = false; }
-  }
-  function changed(status: AgentStatus): void {
-    if (data) data = { ...data, items: data.items.map((item) => item.id === status.id ? status : item) };
+    try {
+      await onload(refresh);
+    } catch (error: unknown) {
+      if (!disposed) failure = errorMessage(error);
+    } finally {
+      if (!disposed) loading = false;
+    }
   }
 </script>
+
 <header class="page-head">
   <div>
     <p class="eyebrow">[{pageNumber}] LOCAL ADMINISTRATION</p>
     <h1 tabindex="-1">Agents</h1>
     <p>Reversible global configuration for this Gateway process user.</p>
   </div>
-  <button disabled={loading} onclick={() => void load()}>Refresh</button>
+  <button class="primary" disabled={loading} onclick={() => void load(true)}>Refresh</button>
 </header>
-<p class="muted">Refresh only reads configuration. Status means configuration installed, not a tested client or inference connection. Preferred Model and account selection are unchanged.</p>
-<p class="muted">Restart clients after applying or restoring. Command-line, project and managed-policy overrides are outside these global settings; do not use routing overrides with this integration.</p>
 {#if failure}<p class="notice error" role="alert">{failure}</p>{/if}
 {#if data}
   {#if !data.modelsAvailable}<p class="notice" role="status">Model catalog unavailable. Sign in and configure usable model capabilities in Models before applying. Inspection and Restore do not require a Copilot account.</p>{/if}
   <div class="agent-cards">
-    {#each data.items as status (status.id)}
-      <AgentCard {client} {status} catalogRevision={data.catalogRevision} onchanged={changed} />
+    {#each orderedItems as status (status.id)}
+      <AgentCard {client} {status} catalogRevision={data.catalogRevision} {onchanged} />
     {/each}
   </div>
 {:else if loading}<p class="loading-line" aria-busy="true">Reading agent configuration...</p>{/if}

--- a/web/src/views/Models.svelte
+++ b/web/src/views/Models.svelte
@@ -262,6 +262,7 @@
 <style>
   .account-toolbar { align-items: center; }
   .account-toolbar label { margin-bottom: 0; }
+  .account-toolbar select { width: 280px; max-width: 100%; }
 
   .catalog-help {
     margin-bottom: 16px;


### PR DESCRIPTION
Closes #174

## Summary

- keeps the Models Account selector at a stable responsive width even when no active account/options exist
- presents Agents cards Codex-first and removes the two long introductory paragraphs
- uses the same primary black treatment as Overview for Agents Refresh and actionable Apply changes
- removes visible Sonnet/Opus/Haiku/Subagent row labels while preserving unique accessible names and the default Claude mapping values
- explains the optional Claude subagent model as the model used for delegated subagent work
- retains the Agents snapshot for the authenticated Admin session so navigation does not repeat expensive Windows configuration/ACL inspection; explicit Refresh still performs a real read
- coalesces in-flight loads, clears/aborts them on session teardown, and prevents delayed Refresh responses from overwriting newer Apply/Restore results

## Loading diagnosis

Every navigation previously destroyed and remounted `Agents.svelte`; its unconditional `onMount` issued a new no-store `/agents` request. That endpoint performs live Claude/Codex file, ownership and ACL inspection, which requires expensive PowerShell work on Windows. The fix retains only the last successful view and in-flight request in `App.svelte`, scoped to the authenticated session. External edits remain visible through explicit Refresh, while server revision checks still fail closed on stale Apply.

## Review

Two Standards + Spec review rounds covered the complete frontend diff and surrounding `web/src` lifecycle/accessibility interactions. First-round findings fixed a delayed Refresh versus mutation race, strengthened actionable button-style and failure evidence, and retained concise visible Claude row-order guidance without restoring the removed per-row labels. Final review found no blockers or safe-to-defer findings.

## Validation

- focused Models/Agents browser tests: 24 passed
- `npm run typecheck`: passed
- `npm run lint`: passed
- `npm run build`: passed
- `npm run fixtures:verify`: 53 entries verified
- full Playwright: 102 passed plus one host-contention retry; the retried unchanged Models case then passed alone with retries disabled
- full Vitest: 82/83 files and 1084 tests passed; two unchanged Windows daemon-identity tests exceeded 60 seconds under slow ACL operations, then passed 14/14 with the existing Windows skips under a 180-second focused timeout
- `git diff --check`: passed

No official SDK suite or live inference was run.
