### PR TITLE
Bind endpoint discovery to credential generations

### DIFF
--- a/src/copilot/credential_provider.ts
+++ b/src/copilot/credential_provider.ts
@@ -1,5 +1,6 @@
 import type { BoundAccount } from "../accounts/account_directory.js";
 import type { CredentialStore } from "../accounts/credential_store.js";
+import type { EndpointDiscoveryFetch } from "./endpoint_discovery.js";
 import { copilotHeaders } from "./identity.js";
 import { TokenRefreshError } from "./token_refresh.js";
 
@@ -62,7 +63,7 @@ export async function refreshCopilotToken(
 
 export function createCopilotEndpointDiscovery(
   credentials: CredentialStore,
-): (account: Readonly<BoundAccount>, signal?: AbortSignal) => Promise<string | null> {
+): EndpointDiscoveryFetch {
   return async (account, signal) => await fetchCopilotDiscovery(credentials, account, signal);
 }
 

--- a/src/copilot/endpoint_discovery.ts
+++ b/src/copilot/endpoint_discovery.ts
@@ -9,61 +9,208 @@ export interface DiscoveredEndpoint {
   readonly cached: boolean;
 }
 
-const cache = new Map<string, string>();
-const locks = new Map<string, Promise<void>>();
-
-export async function discoverEndpoint(
-  account: BoundAccount,
-  fetchDiscovery: (account: BoundAccount, signal?: AbortSignal) => Promise<string | null>,
+export type EndpointDiscoveryFetch = (
+  account: Readonly<BoundAccount>,
   signal?: AbortSignal,
-): Promise<DiscoveredEndpoint> {
-  throwIfAborted(signal);
-  const cached = cache.get(account.accountId);
-  if (cached !== undefined) {
-    return { endpoint: cached, cached: true };
+) => Promise<string | null>;
+
+interface DiscoveryLane {
+  readonly credentialGeneration: number;
+  endpoint?: string;
+  operation?: DiscoveryOperation;
+}
+
+interface DiscoveryOperation {
+  readonly controller: AbortController;
+  completion: Promise<string>;
+  settled: boolean;
+  waiters: number;
+}
+
+export class EndpointDiscovery {
+  private readonly lanes = new Map<string, DiscoveryLane>();
+  private readonly joins = new Map<string, Map<number, DiscoveryOperation>>();
+  private readonly operations = new Set<DiscoveryOperation>();
+  private closed = false;
+  private closePromise: Promise<void> | undefined;
+
+  constructor(private readonly fetchDiscovery: EndpointDiscoveryFetch) {}
+
+  async discover(
+    account: Readonly<BoundAccount>,
+    signal?: AbortSignal,
+  ): Promise<DiscoveredEndpoint> {
+    throwIfAborted(signal);
+    if (this.closed) {
+      throw closedError();
+    }
+    const current = this.lanes.get(account.accountId);
+    if (current?.credentialGeneration === account.credentialGeneration && current.endpoint !== undefined) {
+      return { endpoint: current.endpoint, cached: true };
+    }
+    let lane: DiscoveryLane;
+    if (current === undefined || account.credentialGeneration > current.credentialGeneration) {
+      lane = { credentialGeneration: account.credentialGeneration };
+      this.lanes.set(account.accountId, lane);
+    } else if (current.credentialGeneration === account.credentialGeneration) {
+      lane = current;
+    } else {
+      lane = { credentialGeneration: account.credentialGeneration };
+    }
+    const operation = this.joinFor(account) ?? this.startOperation(account, lane);
+    const endpoint = await waitForOperation(operation, signal, () => {
+      this.removeJoin(account, operation);
+      if (lane.operation === operation) {
+        delete lane.operation;
+      }
+      if (this.lanes.get(account.accountId) === lane) {
+        this.lanes.delete(account.accountId);
+      }
+      operation.controller.abort();
+    });
+    return { endpoint, cached: false };
   }
-  const previous = locks.get(account.accountId) ?? Promise.resolve();
-  let release: () => void = () => undefined;
-  const gate = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queued = previous.then(() => gate);
-  locks.set(account.accountId, queued);
-  try {
-    await waitForPrevious(previous, signal);
-  } catch (error: unknown) {
-    release();
-    void queued.finally(() => {
-      if (locks.get(account.accountId) === queued) {
-        locks.delete(account.accountId);
+
+  invalidate(accountId: string): void {
+    this.lanes.delete(accountId);
+    this.joins.delete(accountId);
+  }
+
+  async close(): Promise<void> {
+    this.closePromise ??= this.closeDiscovery();
+    await this.closePromise;
+  }
+
+  forceClose(): void {
+    this.closed = true;
+    this.lanes.clear();
+    this.joins.clear();
+    for (const operation of this.operations) {
+      operation.controller.abort();
+    }
+    this.operations.clear();
+  }
+
+  private async closeDiscovery(): Promise<void> {
+    this.closed = true;
+    this.lanes.clear();
+    this.joins.clear();
+    const operations = [...this.operations];
+    for (const operation of operations) {
+      operation.controller.abort();
+    }
+    await Promise.allSettled(operations.map(async (operation) => await operation.completion));
+  }
+
+  private startOperation(account: Readonly<BoundAccount>, lane: DiscoveryLane): DiscoveryOperation {
+    const controller = new AbortController();
+    const operation: DiscoveryOperation = {
+      controller,
+      completion: Promise.resolve(fallbackEndpoint(account)),
+      settled: false,
+      waiters: 0,
+    };
+    lane.operation = operation;
+    let accountJoins = this.joins.get(account.accountId);
+    if (accountJoins === undefined) {
+      accountJoins = new Map<number, DiscoveryOperation>();
+      this.joins.set(account.accountId, accountJoins);
+    }
+    accountJoins.set(account.credentialGeneration, operation);
+    this.operations.add(operation);
+    let source: Promise<string | null>;
+    try {
+      source = this.fetchDiscovery(account, controller.signal);
+    } catch (error: unknown) {
+      source = Promise.reject(error);
+    }
+    operation.completion = waitForSource(source, controller.signal).then((discovered) => {
+      if (this.closed) {
+        throw closedError();
+      }
+      const endpoint = discovered ?? fallbackEndpoint(account);
+      if (this.lanes.get(account.accountId) === lane
+        && lane.operation === operation
+        && !controller.signal.aborted) {
+        lane.endpoint = endpoint;
+      }
+      return endpoint;
+    }).finally(() => {
+      operation.settled = true;
+      this.operations.delete(operation);
+      this.removeJoin(account, operation);
+      if (lane.operation === operation) {
+        delete lane.operation;
       }
     });
-    throw error;
+    return operation;
   }
-  throwIfAborted(signal);
+
+  private joinFor(account: Readonly<BoundAccount>): DiscoveryOperation | undefined {
+    return this.joins.get(account.accountId)?.get(account.credentialGeneration);
+  }
+
+  private removeJoin(account: Readonly<BoundAccount>, operation: DiscoveryOperation): void {
+    const accountJoins = this.joins.get(account.accountId);
+    if (accountJoins?.get(account.credentialGeneration) !== operation) {
+      return;
+    }
+    accountJoins.delete(account.credentialGeneration);
+    if (accountJoins.size === 0) {
+      this.joins.delete(account.accountId);
+    }
+  }
+}
+
+async function waitForOperation(
+  operation: DiscoveryOperation,
+  signal: AbortSignal | undefined,
+  onOrphaned: () => void,
+): Promise<string> {
+  operation.waiters += 1;
+  let removeAbortListener = (): void => undefined;
   try {
-    const again = cache.get(account.accountId);
-    if (again !== undefined) {
-      return { endpoint: again, cached: true };
-    }
-    const discovered = await fetchDiscovery(account, signal);
     throwIfAborted(signal);
-    const endpoint = discovered ?? fallbackEndpoint(account);
-    cache.set(account.accountId, endpoint);
-    return { endpoint, cached: false };
+    if (signal === undefined) {
+      return await operation.completion;
+    }
+    return await Promise.race([
+      operation.completion,
+      new Promise<never>((_resolve, reject) => {
+        const onAbort = (): void => reject(new DOMException("aborted", "AbortError"));
+        signal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+      }),
+    ]);
   } finally {
-    release();
-    if (locks.get(account.accountId) === queued) {
-      locks.delete(account.accountId);
+    removeAbortListener();
+    operation.waiters -= 1;
+    if (operation.waiters === 0 && !operation.settled) {
+      onOrphaned();
     }
   }
 }
 
-export function invalidateEndpoint(accountId: string): void {
-  cache.delete(accountId);
+async function waitForSource<T>(source: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    throw new DOMException("aborted", "AbortError");
+  }
+  let removeAbortListener = (): void => undefined;
+  try {
+    return await Promise.race([
+      source,
+      new Promise<never>((_resolve, reject) => {
+        const onAbort = (): void => reject(new DOMException("aborted", "AbortError"));
+        signal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+      }),
+    ]);
+  } finally {
+    removeAbortListener();
+  }
 }
 
-export function fallbackEndpoint(account: BoundAccount): string {
+export function fallbackEndpoint(account: Readonly<BoundAccount>): string {
   if (account.environment.kind === "github.com") {
     return GITHUB_COM_FALLBACK;
   }
@@ -98,19 +245,6 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
   }
 }
 
-async function waitForPrevious(previous: Promise<void>, signal: AbortSignal | undefined): Promise<void> {
-  throwIfAborted(signal);
-  if (signal === undefined) {
-    await previous;
-    return;
-  }
-  let removeAbortListener = (): void => undefined;
-  await Promise.race([
-    previous,
-    new Promise<void>((_resolve, reject) => {
-      const onAbort = (): void => reject(new DOMException("aborted", "AbortError"));
-      signal.addEventListener("abort", onAbort, { once: true });
-      removeAbortListener = () => signal.removeEventListener("abort", onAbort);
-    }),
-  ]).finally(removeAbortListener);
+function closedError(): DOMException {
+  return new DOMException("closed", "AbortError");
 }

--- a/src/copilot/transport.ts
+++ b/src/copilot/transport.ts
@@ -4,7 +4,7 @@ import type { Dispatcher } from "undici";
 import type { BoundAccount } from "../accounts/account_directory.js";
 import type { CredentialStore } from "../accounts/credential_store.js";
 import type { ChatResponse } from "../protocols/chat_completions/types.js";
-import { discoverEndpoint, MAX_REDIRECTS, stripSecretsOnRedirect } from "./endpoint_discovery.js";
+import { type EndpointDiscovery, MAX_REDIRECTS, stripSecretsOnRedirect } from "./endpoint_discovery.js";
 import {
   BoundedInferencePoolRegistry,
   DEFAULT_INFERENCE_POOL_LIMITS,
@@ -76,7 +76,7 @@ export interface CopilotTransportDeps {
   readonly credentials: CredentialStore;
   readonly nowMs?: () => number;
   readonly refreshCopilotToken: (githubToken: string, signal?: AbortSignal) => Promise<{ token: string; expiresAtMs: number }>;
-  readonly fetchDiscovery: (account: BoundAccount, signal?: AbortSignal) => Promise<string | null>;
+  readonly endpointDiscovery: Pick<EndpointDiscovery, "discover">;
   readonly fetchImpl?: typeof fetch;
   readonly poolLimits?: InferencePoolLimits;
   readonly createDispatcher?: (
@@ -116,7 +116,7 @@ export class HttpCopilotBackend implements CopilotBackend {
       this.deps.refreshCopilotToken,
       signal,
     );
-    const discovered = await discoverEndpoint(account, this.deps.fetchDiscovery, signal);
+    const discovered = await this.deps.endpointDiscovery.discover(account, signal);
     if (this.closed) {
       throw closedError();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import { ModelCapabilityRegistry } from "./copilot/capability_registry.js";
 import { HttpCopilotBackend } from "./copilot/transport.js";
 import type { CopilotBackend } from "./copilot/backend.js";
 import { getValidToken } from "./copilot/token_refresh.js";
-import { discoverEndpoint, invalidateEndpoint } from "./copilot/endpoint_discovery.js";
+import { EndpointDiscovery } from "./copilot/endpoint_discovery.js";
 import { CommandDispatcher } from "./cli/commands/dispatcher.js";
 import { RuntimeConfigStore } from "./config/runtime_config.js";
 import { defaultRuntimeConfigSnapshot, parseRuntimeConfigSnapshot, type RuntimeConfigSnapshot } from "./config/schema.js";
@@ -68,6 +68,7 @@ export interface ApplicationContext {
   readonly nowMs?: () => number;
   readonly createUuid?: () => string;
   readonly modelsSource?: CopilotModelsSource;
+  readonly endpointDiscovery?: EndpointDiscovery;
   readonly runtime?: RuntimeConfigStore;
   close?(): Promise<void> | void;
   forceClose?(): Promise<void> | void;
@@ -182,14 +183,14 @@ export async function createProductionApplicationContext(
     },
   );
   await directory.reconcile();
-  const fetchDiscovery = createCopilotEndpointDiscovery(credentials);
+  const endpointDiscovery = new EndpointDiscovery(createCopilotEndpointDiscovery(credentials));
   const modelsSource = HttpCopilotModelsSource.production(async (accountId, signal, credentialGeneration) => {
     const account = await directory.bindAccount(accountId, signal);
     if (credentialGeneration !== undefined && account.credentialGeneration !== credentialGeneration) {
       throw new DOMException("stale credential generation", "AbortError");
     }
     const token = await getValidToken(credentials, account, Date.now(), refreshCopilotToken, signal);
-    const { endpoint } = await discoverEndpoint(account, fetchDiscovery, signal);
+    const { endpoint } = await endpointDiscovery.discover(account, signal);
     return { token, endpoint };
   });
   const catalog = new CopilotModelCatalog(modelsSource);
@@ -197,7 +198,7 @@ export async function createProductionApplicationContext(
   const copilot = new HttpCopilotBackend({
     credentials,
     refreshCopilotToken,
-    fetchDiscovery,
+    endpointDiscovery,
   });
   const telemetry = new TelemetryRecorder(
     database,
@@ -229,12 +230,14 @@ export async function createProductionApplicationContext(
     telemetryRuntime,
     performanceObserver: telemetryRuntime.performance,
     modelsSource,
+    endpointDiscovery,
     runtime,
     async close() {
       const errors: unknown[] = [];
       for (const close of [
         async () => copilot.close(),
         async () => registry.close(),
+        async () => endpointDiscovery.close(),
         async () => telemetryRuntime.close(),
         async () => closeDatabaseOnce(),
       ]) {
@@ -251,6 +254,7 @@ export async function createProductionApplicationContext(
     forceClose() {
       copilot.forceClose();
       modelsSource.forceClose();
+      endpointDiscovery.forceClose();
       telemetryRuntime.forceClose();
       closeDatabaseOnce();
     },
@@ -319,7 +323,7 @@ export async function composeProductionDaemonGateway(
     const accountCaches = {
       invalidate(accountId: string): void {
         registry.invalidate(accountId);
-        invalidateEndpoint(accountId);
+        application.endpointDiscovery?.invalidate(accountId);
       },
     };
     const uptimeMs = options.uptimeMs ?? (() => Math.max(0, Math.floor(process.uptime() * 1000)));

--- a/tests/integration/copilot_transport.test.ts
+++ b/tests/integration/copilot_transport.test.ts
@@ -4,17 +4,23 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import type { BoundAccount } from "../../src/accounts/account_directory.js";
 import { resolveGitHubEnvironment } from "../../src/accounts/github_environment.js";
 import { outboundHeaders, ScriptedCopilotBackend } from "../../src/copilot/backend.js";
-import { discoverEndpoint, fallbackEndpoint, stripSecretsOnRedirect } from "../../src/copilot/endpoint_discovery.js";
+import { EndpointDiscovery, fallbackEndpoint, stripSecretsOnRedirect } from "../../src/copilot/endpoint_discovery.js";
 import { copilotHeaders } from "../../src/copilot/identity.js";
 import { HttpCopilotBackend } from "../../src/copilot/transport.js";
 import { getValidToken, needsRefresh } from "../../src/copilot/token_refresh.js";
 
 const execFileAsync = promisify(execFile);
+const testEndpointDiscoveries = new Set<EndpointDiscovery>();
+
+afterEach(async () => {
+  await Promise.all([...testEndpointDiscoveries].map(async (discovery) => await discovery.close()));
+  testEndpointDiscoveries.clear();
+});
 
 function account(kind: "github.com" | "ghes" = "github.com"): BoundAccount {
   const host = kind === "github.com" ? "github.com" : "ghe.example.com";
@@ -111,18 +117,184 @@ describe("Copilot transport", () => {
   it("discovers once per account with fallback", async () => {
     const bound = account();
     let calls = 0;
-    const first = await discoverEndpoint(bound, async () => {
+    const discovery = new EndpointDiscovery(async () => {
       calls += 1;
       return null;
     });
-    const second = await discoverEndpoint(bound, async () => {
-      calls += 1;
-      return "https://should-not-run";
-    });
+    const first = await discovery.discover(bound);
+    const second = await discovery.discover(bound);
     expect(first.endpoint).toBe("https://api.githubcopilot.com");
     expect(fallbackEndpoint(account("ghes"))).toBe("https://copilot-api.ghe.example.com");
     expect(second.cached).toBe(true);
     expect(calls).toBe(1);
+    await discovery.close();
+  });
+
+  it("isolates endpoint cache hits by Bound Account credential generation", async () => {
+    const generationOne = account();
+    const generationTwo = { ...generationOne, credentialGeneration: 2 };
+    let calls = 0;
+    const discovery = new EndpointDiscovery(async (current) => {
+      calls += 1;
+      return `https://generation-${current.credentialGeneration}.test.invalid`;
+    });
+    try {
+      await expect(discovery.discover(generationOne)).resolves.toEqual({
+        endpoint: "https://generation-1.test.invalid",
+        cached: false,
+      });
+      await expect(discovery.discover(generationOne)).resolves.toEqual({
+        endpoint: "https://generation-1.test.invalid",
+        cached: true,
+      });
+      await expect(discovery.discover(generationTwo)).resolves.toEqual({
+        endpoint: "https://generation-2.test.invalid",
+        cached: false,
+      });
+      await expect(discovery.discover(generationTwo)).resolves.toEqual({
+        endpoint: "https://generation-2.test.invalid",
+        cached: true,
+      });
+      expect(calls).toBe(2);
+    } finally {
+      await discovery.close();
+    }
+  });
+
+  it("keeps an invalidated stale completion out of the newer generation cache", async () => {
+    const generationOne = account();
+    const generationTwo = { ...generationOne, credentialGeneration: 2 };
+    const first = deferred<string | null>();
+    const second = deferred<string | null>();
+    let calls = 0;
+    const discovery = new EndpointDiscovery(async () => {
+      calls += 1;
+      return await (calls === 1 ? first.promise : second.promise);
+    });
+    try {
+      const stale = discovery.discover(generationOne);
+      discovery.invalidate(generationOne.accountId);
+      const current = discovery.discover(generationTwo);
+      second.resolve("https://generation-2.test.invalid");
+      await expect(current).resolves.toEqual({
+        endpoint: "https://generation-2.test.invalid",
+        cached: false,
+      });
+      first.resolve("https://generation-1.test.invalid");
+      await expect(stale).resolves.toEqual({
+        endpoint: "https://generation-1.test.invalid",
+        cached: false,
+      });
+      await expect(discovery.discover(generationTwo)).resolves.toEqual({
+        endpoint: "https://generation-2.test.invalid",
+        cached: true,
+      });
+      expect(calls).toBe(2);
+    } finally {
+      discovery.forceClose();
+    }
+  });
+
+  it("deduplicates same-generation discovery while canceling one waiter independently", async () => {
+    const source = deferred<string | null>();
+    let calls = 0;
+    const discovery = new EndpointDiscovery(async () => {
+      calls += 1;
+      return await source.promise;
+    });
+    const firstController = new AbortController();
+    try {
+      const first = discovery.discover(account(), firstController.signal);
+      const second = discovery.discover(account());
+      expect(calls).toBe(1);
+      firstController.abort();
+      await expect(first).rejects.toMatchObject({ name: "AbortError" });
+      source.resolve("https://shared.test.invalid");
+      await expect(second).resolves.toEqual({
+        endpoint: "https://shared.test.invalid",
+        cached: false,
+      });
+      await expect(discovery.discover(account())).resolves.toEqual({
+        endpoint: "https://shared.test.invalid",
+        cached: true,
+      });
+      expect(calls).toBe(1);
+    } finally {
+      discovery.forceClose();
+    }
+  });
+
+  it("drops an orphaned discovery before the next request", async () => {
+    const sources = [deferred<string | null>(), deferred<string | null>()];
+    const sourceSignals: AbortSignal[] = [];
+    let calls = 0;
+    const discovery = new EndpointDiscovery(async (_current, sourceSignal) => {
+      sourceSignals.push(sourceSignal!);
+      return await sources[calls++]!.promise;
+    });
+    const waiterController = new AbortController();
+    try {
+      const orphan = discovery.discover(account(), waiterController.signal);
+      waiterController.abort();
+      await expect(orphan).rejects.toMatchObject({ name: "AbortError" });
+      expect(sourceSignals[0]?.aborted).toBe(true);
+      sources[0]!.resolve("https://orphan.test.invalid");
+      await Promise.resolve();
+      const retry = discovery.discover(account());
+      expect(calls).toBe(2);
+      sources[1]!.resolve("https://retry.test.invalid");
+      await expect(retry).resolves.toEqual({
+        endpoint: "https://retry.test.invalid",
+        cached: false,
+      });
+    } finally {
+      discovery.forceClose();
+    }
+  });
+
+  it("does not retain a rejected discovery coordinator", async () => {
+    let calls = 0;
+    const discovery = new EndpointDiscovery(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("synthetic discovery failure");
+      }
+      return "https://retry.test.invalid";
+    });
+    try {
+      await expect(discovery.discover(account())).rejects.toThrow("synthetic discovery failure");
+      await expect(discovery.discover(account())).resolves.toEqual({
+        endpoint: "https://retry.test.invalid",
+        cached: false,
+      });
+      expect(calls).toBe(2);
+    } finally {
+      discovery.forceClose();
+    }
+  });
+
+  it("closes endpoint discovery without retaining in-flight work", async () => {
+    const source = deferred<string | null>();
+    let sourceSignal: AbortSignal | undefined;
+    const discovery = new EndpointDiscovery(async (_current, signal) => {
+      sourceSignal = signal;
+      return await source.promise;
+    });
+    const pending = discovery.discover(account());
+    const pendingResult = pending.catch((error: unknown) => error);
+    try {
+      const closing = discovery.close();
+      expect(sourceSignal?.aborted).toBe(true);
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      await closing;
+      await expect(discovery.discover(account())).rejects.toMatchObject({ name: "AbortError" });
+      discovery.forceClose();
+      discovery.forceClose();
+    } finally {
+      source.resolve("https://late.test.invalid");
+      await pendingResult;
+      discovery.forceClose();
+    }
   });
 
   it("binds a scripted backend to the provided account only", async () => {
@@ -161,7 +333,7 @@ describe("Copilot transport", () => {
     const backend = new HttpCopilotBackend({
       credentials: store,
       refreshCopilotToken: async () => ({ token: "unused", expiresAtMs: Date.now() + 120_000 }),
-      fetchDiscovery: async () => null,
+      endpointDiscovery: testEndpointDiscovery(async () => null),
       fetchImpl: async (input, init) => {
         captured = { input, init };
         return new Response("{}", { status: 200 });
@@ -207,7 +379,7 @@ describe("Copilot transport", () => {
     const backend = new HttpCopilotBackend({
       credentials: store,
       refreshCopilotToken: async () => ({ token: "unused", expiresAtMs: Date.now() + 120_000 }),
-      fetchDiscovery: async () => `http://127.0.0.1:${address.port}`,
+      endpointDiscovery: testEndpointDiscovery(async () => `http://127.0.0.1:${address.port}`),
     });
     try {
       const copilot = await backend.bind(bound, new AbortController().signal);
@@ -240,7 +412,7 @@ describe("Copilot transport", () => {
     const backend = new HttpCopilotBackend({
       credentials: store,
       refreshCopilotToken: async () => ({ token: "unused", expiresAtMs: Date.now() + 120_000 }),
-      fetchDiscovery: async () => null,
+      endpointDiscovery: testEndpointDiscovery(async () => null),
       fetchImpl: async () => {
         await new Promise((resolve) => setTimeout(resolve, 20));
         return new Response("{}", { status: 200 });
@@ -272,7 +444,7 @@ describe("Copilot transport", () => {
     const backend = new HttpCopilotBackend({
       credentials: store,
       refreshCopilotToken: async () => ({ token: "unused", expiresAtMs: Date.now() + 120_000 }),
-      fetchDiscovery: async () => null,
+      endpointDiscovery: testEndpointDiscovery(async () => null),
       fetchImpl: async () => new Response(new ReadableStream<Uint8Array>({
         cancel(): void {
           canceled = true;
@@ -306,7 +478,7 @@ describe("Copilot transport", () => {
     const backend = new HttpCopilotBackend({
       credentials: store,
       refreshCopilotToken: async () => ({ token: "unused", expiresAtMs: Date.now() + 120_000 }),
-      fetchDiscovery: async () => null,
+      endpointDiscovery: testEndpointDiscovery(async () => null),
       fetchImpl: async () => new Response(new ReadableStream<Uint8Array>({
         pull(): void {
           // keep headers open without body bytes
@@ -326,3 +498,25 @@ describe("Copilot transport", () => {
     })).rejects.toThrow(/upstream timeout/u);
   });
 });
+
+function testEndpointDiscovery(
+  source: ConstructorParameters<typeof EndpointDiscovery>[0],
+): EndpointDiscovery {
+  const discovery = new EndpointDiscovery(source);
+  testEndpointDiscoveries.add(discovery);
+  return discovery;
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (error: unknown) => void;
+  } {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/tests/integration/copilot_transport_lifecycle.test.ts
+++ b/tests/integration/copilot_transport_lifecycle.test.ts
@@ -2,10 +2,11 @@ import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Socket } from "node:net";
 import { Pool } from "undici";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BoundAccount } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import { resolveGitHubEnvironment } from "../../src/accounts/github_environment.js";
+import { EndpointDiscovery } from "../../src/copilot/endpoint_discovery.js";
 import {
   HttpCopilotBackend,
   InvalidUpstreamResponseError,
@@ -17,6 +18,12 @@ import type { ChatRequest } from "../../src/protocols/chat_completions/types.js"
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 let accountSequence = 0;
+const endpointDiscoveries = new Set<EndpointDiscovery>();
+
+afterEach(async () => {
+  await Promise.all([...endpointDiscoveries].map(async (discovery) => await discovery.close()));
+  endpointDiscoveries.clear();
+});
 
 describe("Copilot transport lifecycle", () => {
   it("reuses real loopback connections within the per-origin bound and closes them", async () => {
@@ -434,7 +441,7 @@ describe("Copilot transport lifecycle", () => {
     const backend = new HttpCopilotBackend({
       credentials: store,
       refreshCopilotToken: async () => ({ token: "unused", expiresAtMs: Date.now() + 120_000 }),
-      fetchDiscovery: async (current) => `http://127.0.0.1:${61_000 + Number(current.userId)}`,
+      endpointDiscovery: testEndpointDiscovery(async (current) => `http://127.0.0.1:${61_000 + Number(current.userId)}`),
     });
     for (let index = 0; index < 20; index += 1) {
       const current = syntheticAccount(String(index), `pool-${index}`);
@@ -675,7 +682,7 @@ async function backendAt(
   const backend = new HttpCopilotBackend({
     credentials: store,
     refreshCopilotToken: async () => ({ token: "unused", expiresAtMs: Date.now() + 120_000 }),
-    fetchDiscovery: async () => endpoint,
+    endpointDiscovery: testEndpointDiscovery(async () => endpoint),
     ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
     ...(options.poolLimits === undefined ? {} : { poolLimits: options.poolLimits }),
     ...(options.createDispatcher === undefined ? {} : { createDispatcher: options.createDispatcher }),
@@ -684,6 +691,14 @@ async function backendAt(
     backend,
     bound: await backend.bind(current, new AbortController().signal),
   };
+}
+
+function testEndpointDiscovery(
+  source: ConstructorParameters<typeof EndpointDiscovery>[0],
+): EndpointDiscovery {
+  const discovery = new EndpointDiscovery(source);
+  endpointDiscoveries.add(discovery);
+  return discovery;
 }
 
 function syntheticAccount(userId: string, suffix: string): BoundAccount {

--- a/tests/integration/daemon_composition.test.ts
+++ b/tests/integration/daemon_composition.test.ts
@@ -1,11 +1,12 @@
 import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { AccountDirectory, type AccountDirectoryError } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import { ScriptedCopilotBackend } from "../../src/copilot/backend.js";
-import { discoverEndpoint, invalidateEndpoint } from "../../src/copilot/endpoint_discovery.js";
+import { EndpointDiscovery } from "../../src/copilot/endpoint_discovery.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
 import { ModelCapabilityRegistry } from "../../src/copilot/capability_registry.js";
 import { RuntimeConfigStore } from "../../src/config/runtime_config.js";
@@ -51,10 +52,12 @@ describe("production composition", () => {
     const closeCopilot = application.copilot.close.bind(application.copilot);
     const closeCatalog = application.catalog.close.bind(application.catalog);
     const telemetryRuntime = application.telemetryRuntime;
+    const endpointDiscovery = application.endpointDiscovery;
     const database = application.database;
-    if (telemetryRuntime === undefined || database === undefined) {
+    if (telemetryRuntime === undefined || endpointDiscovery === undefined || database === undefined) {
       throw new Error("expected production close owners");
     }
+    const closeEndpointDiscovery = endpointDiscovery.close.bind(endpointDiscovery);
     const closeTelemetry = telemetryRuntime.close.bind(telemetryRuntime);
     const closeSqlite = database.close.bind(database);
     application.copilot.close = async () => {
@@ -64,6 +67,10 @@ describe("production composition", () => {
     application.catalog.close = async () => {
       order.push("catalog");
       await closeCatalog();
+    };
+    endpointDiscovery.close = async () => {
+      order.push("endpoint-discovery");
+      await closeEndpointDiscovery();
     };
     telemetryRuntime.close = async () => {
       order.push("telemetry");
@@ -75,7 +82,7 @@ describe("production composition", () => {
     };
     try {
       await application.close?.();
-      expect(order).toEqual(["copilot", "catalog", "telemetry", "sqlite"]);
+      expect(order).toEqual(["copilot", "catalog", "endpoint-discovery", "telemetry", "sqlite"]);
     } finally {
       application.forceClose?.();
       await rm(dataDir, { recursive: true, force: true });
@@ -98,9 +105,14 @@ describe("production composition", () => {
       throw new Error("catalog close failed");
     };
     const telemetryRuntime = application.telemetryRuntime;
-    if (telemetryRuntime === undefined || application.database === undefined) {
+    const endpointDiscovery = application.endpointDiscovery;
+    if (telemetryRuntime === undefined || endpointDiscovery === undefined || application.database === undefined) {
       throw new Error("expected production close owners");
     }
+    endpointDiscovery.close = async () => {
+      order.push("endpoint-discovery");
+      throw new Error("endpoint discovery close failed");
+    };
     const closeSqlite = application.database.close.bind(application.database);
     telemetryRuntime.close = async () => {
       order.push("telemetry");
@@ -116,17 +128,98 @@ describe("production composition", () => {
         errors: [
           expect.objectContaining({ message: "copilot close failed" }),
           expect.objectContaining({ message: "catalog close failed" }),
+          expect.objectContaining({ message: "endpoint discovery close failed" }),
           expect.objectContaining({ message: "telemetry close failed" }),
           expect.objectContaining({ message: "sqlite close failed" }),
         ],
       });
-      expect(order).toEqual(["copilot", "catalog", "telemetry", "sqlite"]);
+      expect(order).toEqual(["copilot", "catalog", "endpoint-discovery", "telemetry", "sqlite"]);
       expect(application.database.prepare("SELECT 1").get()).toEqual({ "1": 1 });
     } finally {
       application.database.close = closeSqlite;
       application.forceClose?.();
       expect(() => application.database?.prepare("SELECT 1").get()).toThrow();
       await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("owns endpoint discovery per application and shares it across catalog and backend", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ghc-gateway-discovery-owners-"));
+    const server = createServer((request, response) => {
+      modelRequests.push(request.url ?? "");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ data: [{
+        id: "gpt-test",
+        name: "GPT Test",
+        vendor: "openai",
+        model_picker_enabled: true,
+        model_info: { supported_endpoints: ["/chat/completions"] },
+      }] }));
+    });
+    const modelRequests: string[] = [];
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected model source listener");
+    }
+    const nativeFetch = globalThis.fetch;
+    const discoveryRequests: string[] = [];
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      const authorization = new Headers(init?.headers).get("authorization") ?? "";
+      const suffix = authorization.includes("context-a") ? "a" : "b";
+      if (url.endsWith("/copilot_internal/v2/token")) {
+        return new Response(JSON.stringify({ token: `copilot-${suffix}`, expires_at: 2_000_000_000 }), { status: 200 });
+      }
+      if (url.endsWith("/copilot_internal/user")) {
+        discoveryRequests.push(suffix);
+        return new Response(JSON.stringify({
+          copilot_plan: "individual",
+          quota_reset_date: "2026-10-01",
+          quota_snapshots: {
+            chat: quotaDetail(),
+            completions: quotaDetail(),
+            premium_interactions: quotaDetail(),
+          },
+          endpoints: { api: `http://127.0.0.1:${address.port}/${suffix}` },
+        }), { status: 200 });
+      }
+      throw new Error("unexpected scripted fetch");
+    }) as typeof fetch;
+    let contextA: ApplicationContext | undefined;
+    let contextB: ApplicationContext | undefined;
+    try {
+      contextA = await createProductionApplicationContext(
+        parseStartupConfig(["--data-dir", path.join(root, "a"), "--port", String(PORT)], {}),
+        {},
+      );
+      contextB = await createProductionApplicationContext(
+        parseStartupConfig(["--data-dir", path.join(root, "b"), "--port", String(PORT + 1)], {}),
+        {},
+      );
+      const accountA = await contextA.directory.upsertAuthenticated({
+        host: "github.com",
+        userId: "177",
+        secret: { generation: 0, githubToken: "context-a" },
+      });
+      const accountB = await contextB.directory.upsertAuthenticated({
+        host: "github.com",
+        userId: "177",
+        secret: { generation: 0, githubToken: "context-b" },
+      });
+      await contextA.registry!.get(accountA, signal());
+      await contextA.copilot.bind(accountA, signal());
+      expect(discoveryRequests).toEqual(["a"]);
+      await contextB.copilot.bind(accountB, signal());
+      expect(discoveryRequests).toEqual(["a", "b"]);
+      expect(modelRequests).toEqual(["/a/models"]);
+    } finally {
+      globalThis.fetch = nativeFetch;
+      await contextA?.close?.();
+      await contextB?.close?.();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await rm(root, { recursive: true, force: true });
     }
   });
 
@@ -148,13 +241,8 @@ describe("production composition", () => {
       });
       await harness.catalog.get(account.accountId, signal());
       expect(harness.catalogFetchCount()).toBe(1);
-      let endpointFetches = 0;
-      const endpointSource = async () => {
-        endpointFetches += 1;
-        return "https://copilot.test.invalid";
-      };
-      await discoverEndpoint(account, endpointSource);
-      expect(endpointFetches).toBe(1);
+      await harness.endpointDiscovery.discover(account);
+      expect(harness.endpointFetchCount()).toBe(1);
 
       const bootstrap = await control(gateway, "POST", "/admin-bootstrap");
       expect(bootstrap.status).toBe(200);
@@ -264,11 +352,57 @@ describe("production composition", () => {
       expect(removed.status).toBe(200);
       await harness.catalog.get(account.accountId, signal());
       expect(harness.catalogFetchCount()).toBe(3);
-      await discoverEndpoint(account, endpointSource);
-      expect(endpointFetches).toBe(2);
-      invalidateEndpoint(account.accountId);
+      await harness.endpointDiscovery.discover(account);
+      expect(harness.endpointFetchCount()).toBe(2);
     } finally {
-      invalidateEndpoint("github.com/91919");
+      await gateway.close();
+    }
+  });
+
+  it("fences in-flight discovery across account logout and relogin", async () => {
+    const first = deferred<string | null>();
+    const second = deferred<string | null>();
+    let fetches = 0;
+    const harness = compositionHarness(async () => {
+      fetches += 1;
+      return await (fetches === 1 ? first.promise : second.promise);
+    });
+    const gateway = await composeProductionDaemonGateway({
+      startup: harness.startup,
+      env: {},
+      identity: IDENTITY,
+      logger: { write() {} },
+      requestStop() {},
+    }, { application: harness.application });
+    try {
+      const generationOne = await harness.directory.upsertAuthenticated({
+        host: "github.com",
+        userId: "177",
+        secret: { generation: 0, githubToken: "generation-one" },
+      });
+      const stale = harness.endpointDiscovery.discover(generationOne);
+      const logout = await control(gateway, "POST", "/command", {
+        operation: "auth.logout",
+        arguments: { accountId: generationOne.accountId },
+      });
+      expect(logout.status).toBe(200);
+      const generationTwo = await harness.directory.upsertAuthenticated({
+        host: "github.com",
+        userId: "177",
+        secret: { generation: 0, githubToken: "generation-two" },
+      });
+      expect(generationTwo.credentialGeneration).toBeGreaterThan(generationOne.credentialGeneration);
+      const current = harness.endpointDiscovery.discover(generationTwo);
+      second.resolve("https://generation-two.test.invalid");
+      await expect(current).resolves.toMatchObject({ endpoint: "https://generation-two.test.invalid" });
+      first.resolve("https://generation-one.test.invalid");
+      await expect(stale).resolves.toMatchObject({ endpoint: "https://generation-one.test.invalid" });
+      await expect(harness.endpointDiscovery.discover(generationTwo)).resolves.toEqual({
+        endpoint: "https://generation-two.test.invalid",
+        cached: true,
+      });
+      expect(fetches).toBe(2);
+    } finally {
       await gateway.close();
     }
   });
@@ -283,10 +417,14 @@ interface CompositionHarness {
   readonly history: SqliteResponsesHistory;
   readonly telemetry: TelemetryRecorder;
   readonly runtime: RuntimeConfigStore;
+  readonly endpointDiscovery: EndpointDiscovery;
   readonly catalogFetchCount: () => number;
+  readonly endpointFetchCount: () => number;
 }
 
-function compositionHarness(): CompositionHarness {
+function compositionHarness(
+  endpointSource: ConstructorParameters<typeof EndpointDiscovery>[0] = async () => "https://copilot.test.invalid",
+): CompositionHarness {
   const database = openDatabase({
     path: ":memory:",
     migrations: [
@@ -325,6 +463,11 @@ function compositionHarness(): CompositionHarness {
   const registry = new ModelCapabilityRegistry(catalog, {
     get: () => null,
   });
+  let endpointFetches = 0;
+  const endpointDiscovery = new EndpointDiscovery(async (account, signal) => {
+    endpointFetches += 1;
+    return await endpointSource(account, signal);
+  });
   const application: ApplicationContext = {
     database,
     credentials,
@@ -334,10 +477,12 @@ function compositionHarness(): CompositionHarness {
     copilot: new ScriptedCopilotBackend({}),
     history,
     telemetry,
+    endpointDiscovery,
     runtime,
     async close() {
       await telemetry.flush();
       await catalog.close();
+      await endpointDiscovery.close();
       closeDatabase(database);
     },
   };
@@ -350,7 +495,9 @@ function compositionHarness(): CompositionHarness {
     history,
     telemetry,
     runtime,
+    endpointDiscovery,
     catalogFetchCount: () => catalogFetches,
+    endpointFetchCount: () => endpointFetches,
   };
 }
 
@@ -383,4 +530,19 @@ async function adminJson(
 
 function signal(): AbortSignal {
   return new AbortController().signal;
+}
+
+function quotaDetail(): Record<string, unknown> {
+  return { entitlement: 100, remaining: 100, percent_remaining: 100, unlimited: false };
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  } {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }

--- a/tests/sdk/replay_harness.ts
+++ b/tests/sdk/replay_harness.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import { AccountDirectory } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
+import { EndpointDiscovery } from "../../src/copilot/endpoint_discovery.js";
 import { HttpCopilotBackend } from "../../src/copilot/transport.js";
 import { HttpCopilotModelsSource } from "../../src/copilot/models_source.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
@@ -94,10 +95,11 @@ export async function startReplaySdkHarness(options: {
   const history = new SqliteResponsesHistory(database, { nowMs });
   const registry = new ModelCapabilityRegistry(catalog, { get: () => null });
 
+  const endpointDiscovery = new EndpointDiscovery(async () => replayEndpoint);
   const copilot = new HttpCopilotBackend({
     credentials,
     refreshCopilotToken: async () => ({ token: "dummy-token", expiresAtMs: nowMs() + 3_600_000 }),
-    fetchDiscovery: async () => replayEndpoint,
+    endpointDiscovery,
     fetchImpl: fetch,
   });
 
@@ -124,11 +126,13 @@ export async function startReplaySdkHarness(options: {
         await catalog.close();
         await copilot.close();
         await modelsSource.close();
+        await endpointDiscovery.close();
         closeState();
       },
       forceClose: () => {
         copilot.forceClose();
         modelsSource.forceClose();
+        endpointDiscovery.forceClose();
         closeState();
       },
     },

--- a/tests/unit/capture_recorder.test.ts
+++ b/tests/unit/capture_recorder.test.ts
@@ -6,8 +6,8 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import { resolveGitHubEnvironment } from "../../src/accounts/github_environment.js";
+import { EndpointDiscovery } from "../../src/copilot/endpoint_discovery.js";
 import { HttpCopilotBackend } from "../../src/copilot/transport.js";
-import { invalidateEndpoint } from "../../src/copilot/endpoint_discovery.js";
 import { recordCapture, type CaptureOptions } from "../../scripts/tooling/capture_recorder.js";
 import { expectedForecastArguments } from "../../scripts/tooling/capture_scenarios.js";
 
@@ -46,12 +46,16 @@ async function remote(protocol: Protocol, respond?: (response: ServerResponse, b
   await credentials.putGeneration(accountId, 1, {
     generation: 1, githubToken: "synthetic-github", copilotToken: "synthetic-copilot", copilotExpiresAtMs: Date.now() + 3_600_000,
   });
+  const endpointDiscovery = new EndpointDiscovery(async () => `http://127.0.0.1:${address.port}`);
   const backend = new HttpCopilotBackend({
     credentials,
     refreshCopilotToken: async () => { throw new Error("unexpected token refresh"); },
-    fetchDiscovery: async () => `http://127.0.0.1:${address.port}`,
+    endpointDiscovery,
   });
-  cleanup.push(async () => { await backend.close(); invalidateEndpoint(accountId); });
+  cleanup.push(async () => {
+    await backend.close();
+    await endpointDiscovery.close();
+  });
   let binds = 0;
   return {
     seen, backend,


### PR DESCRIPTION
## Summary

- replace module-global endpoint discovery state with an application-owned owner
- bind cache hits, in-flight joins, and commit eligibility to credential generation plus invalidation identity
- share discovery within one application while isolating independent application contexts
- preserve endpoint fallback, redirect stripping, token, protocol, wire, and history behavior

## Validation

- targeted integration/unit suite: 150 passed, 1 skipped
- full `npm test`: 1094 passed, 6 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Standards review: no findings
- Spec review: no findings

Official SDK suites and live inference/capture were not run because they require separate authorization. Fixtures and golden bytes were not changed.

Closes #177
