### PR TITLE
Deepen Stream Execution lifecycle ownership

### DIFF
--- a/src/gateway/converted_stream_response.ts
+++ b/src/gateway/converted_stream_response.ts
@@ -132,7 +132,11 @@ async function* convertedEmissions(
       } else if (emission.kind === "wire") {
         yield { kind: "wire", bytes: emission.bytes };
       } else if (emission.kind === "terminal") {
-        yield { kind: "terminal", value: observedUsage };
+        yield {
+          kind: "terminal",
+          outcome: { kind: "success", value: observedUsage },
+          writerMode: "close",
+        };
         return;
       }
     }

--- a/src/gateway/converted_stream_response.ts
+++ b/src/gateway/converted_stream_response.ts
@@ -1,11 +1,10 @@
 import type { UpstreamByteStream } from "../copilot/upstream_types.js";
 import type { RequestScope } from "./request_scope.js";
-import { createStreamResponseWriter } from "./stream_response.js";
 import {
-  createExchangeCancellation,
-  createOwnedStreamCleanup,
+  createStreamExecutionResponse,
   nextWithDeadline,
   withByteIdleDeadlines,
+  type StreamExecutionEmission,
 } from "./stream_execution.js";
 import { GatewayFailureError, failureFromSignal } from "./failures.js";
 import { normalizeChatStreamFailure } from "../copilot/failures.js";
@@ -33,17 +32,15 @@ export async function createConvertedStreamResponse(input: {
     | { readonly kind: "failure"; readonly error: unknown }
   >) => void;
 }): Promise<Response> {
-  const cancelExchange = createExchangeCancellation(input.upstream);
   const performanceObserver = input.performanceObserver;
   let eventElapsedMs = 0;
   const aggregateEventMeasurements = performanceObserver?.observe !== undefined;
-  const emissions = convertProtocolStream(
+  const converted = convertProtocolStream(
     withByteIdleDeadlines(
       input.upstream.bytes,
       input.scope.signal,
       input.scope.config.timeouts.firstByteMs,
       input.scope.config.timeouts.streamIdleMs,
-      cancelExchange,
     ),
     {
       source: input.plan.target,
@@ -76,8 +73,26 @@ export async function createConvertedStreamResponse(input: {
         },
     },
   );
-  const iterator = emissions[Symbol.asyncIterator]();
-  const cleanupUpstream = createOwnedStreamCleanup(input.upstream, iterator, 1_000, cancelExchange);
+
+  return await createStreamExecutionResponse({
+    upstream: input.upstream,
+    emissions: convertedEmissions(converted, input),
+    signal: input.scope.signal,
+    deliverySignal: input.scope.deliverySignal,
+    headers: input.headers,
+    firstEmissionTimeoutMs: input.scope.config.timeouts.firstByteMs,
+    normalizeFailure: (error) => normalizeStreamFailure(error, input),
+    onTerminal: (result) => result.kind === "success"
+      ? observeTerminal(input.onTerminal, { kind: "success", usage: result.value })
+      : observeTerminal(input.onTerminal, { kind: "failure", error: result.error }),
+  });
+}
+
+async function* convertedEmissions(
+  converted: AsyncIterable<ConvertedStreamEmission>,
+  input: Parameters<typeof createConvertedStreamResponse>[0],
+): AsyncIterable<StreamExecutionEmission<SemanticUsage>> {
+  const iterator = converted[Symbol.asyncIterator]();
   let observedUsage: SemanticUsage = {
     inputTokens: 0,
     outputTokens: 0,
@@ -85,22 +100,17 @@ export async function createConvertedStreamResponse(input: {
     cacheWriteTokens: 0,
     reasoningTokens: 0,
   };
-  const prefetched: Uint8Array[] = [];
-  const firstSemanticStartedAt = Date.now();
   let firstSemanticObserved = false;
+  const startedAt = Date.now();
   try {
     for (;;) {
       let next: IteratorResult<ConvertedStreamEmission>;
       if (firstSemanticObserved) {
         next = await iterator.next();
       } else {
-        const remaining = input.scope.config.timeouts.firstByteMs - (Date.now() - firstSemanticStartedAt);
+        const remaining = input.scope.config.timeouts.firstByteMs - (Date.now() - startedAt);
         if (remaining <= 0) {
-          throw new GatewayFailureError({
-            kind: "upstream_timeout",
-            source: "converter",
-            phase: "stream",
-          });
+          throw new GatewayFailureError({ kind: "upstream_timeout", source: "converter", phase: "stream" });
         }
         next = await nextWithDeadline(
           iterator,
@@ -120,81 +130,17 @@ export async function createConvertedStreamResponse(input: {
       } else if (emission.kind === "usage") {
         observedUsage = emission.usage;
       } else if (emission.kind === "wire") {
-        prefetched.push(emission.bytes);
-        break;
+        yield { kind: "wire", bytes: emission.bytes };
+      } else if (emission.kind === "terminal") {
+        yield { kind: "terminal", value: observedUsage };
+        return;
       }
     }
-  } catch (error: unknown) {
-    await cleanupUpstream();
-    throw normalizeStreamFailure(error, input);
+  } finally {
+    if (iterator.return !== undefined) {
+      await iterator.return();
+    }
   }
-
-  const writer = createStreamResponseWriter({
-    signal: input.scope.signal,
-    headers: input.headers,
-    onCancel: async () => await closeStream(),
-  });
-  let closed = false;
-  let cleanup: Promise<void> | undefined;
-  const closeStream = async (): Promise<void> => {
-    if (closed) {
-      await cleanup;
-      return;
-    }
-    closed = true;
-    input.scope.signal.removeEventListener("abort", onAbort);
-    cleanup = cleanupUpstream();
-    await cleanup;
-  };
-  const onAbort = (): void => {
-    observeTerminal(input.onTerminal, {
-      kind: "failure",
-      error: new GatewayFailureError(failureFromSignal(input.scope.signal, {
-        source: "converter",
-        phase: "stream",
-      })),
-    });
-    void closeStream();
-  };
-  void (async () => {
-    try {
-      for (const bytes of prefetched) {
-        if (!await writer.enqueue(bytes)) {
-          return;
-        }
-      }
-      for (;;) {
-        const next = await iterator.next();
-        if (next.done === true) {
-          throw truncated();
-        }
-        const emission = next.value;
-        if (emission.kind === "wire") {
-          if (!await writer.enqueue(emission.bytes)) {
-            return;
-          }
-        } else if (emission.kind === "checkpoint") {
-          await input.persistCheckpoint?.(emission.intent);
-        } else if (emission.kind === "usage") {
-          observedUsage = emission.usage;
-        } else if (emission.kind === "terminal") {
-          observeTerminal(input.onTerminal, { kind: "success", usage: observedUsage });
-          await closeStream();
-          writer.close();
-          return;
-        }
-      }
-    } catch (error: unknown) {
-      observeTerminal(input.onTerminal, { kind: "failure", error: normalizeStreamFailure(error, input) });
-      await closeStream();
-      writer.abort();
-    } finally {
-      await closeStream();
-    }
-
-  })();
-  input.scope.signal.addEventListener("abort", onAbort, { once: true });
-  return writer.response;
 }
 
 function normalizeStreamFailure(

--- a/src/gateway/hono_app.ts
+++ b/src/gateway/hono_app.ts
@@ -367,10 +367,6 @@ function attachLifecycle(
   };
 
   let delivery: StreamExecutionDelivery | undefined;
-  if (streamExecution !== undefined) {
-    delivery = streamExecution.claimDeliveryAdapter(once);
-  }
-
   const reader = body.getReader();
   let cancellation: Promise<void> | undefined;
   const cancelBody = async (): Promise<void> => {
@@ -421,7 +417,7 @@ function attachLifecycle(
       await cancelBody();
       await awaitOwner();
     },
-  });
+  }, { highWaterMark: 0 });
 
   onDeliveryAbort = () => {
     settleDelivery();
@@ -429,6 +425,9 @@ function attachLifecycle(
   };
   const alreadyAborted = deliverySignal.aborted;
   deliverySignal.addEventListener("abort", onDeliveryAbort, { once: true });
+  if (streamExecution !== undefined) {
+    delivery = streamExecution.claimDeliveryAdapter(once);
+  }
   if (alreadyAborted || deliverySignal.aborted) {
     onDeliveryAbort();
   }

--- a/src/gateway/hono_app.ts
+++ b/src/gateway/hono_app.ts
@@ -9,6 +9,7 @@ import { createRequestAttempt, type RequestAttempt } from "./request_attempt.js"
 import {
   boundedCleanup,
   getStreamExecutionHandle,
+  type StreamExecutionDelivery,
   type StreamExecutionHandle,
 } from "./stream_execution.js";
 import { abortWithTimeout, armTimeout, type TimeoutScheduler } from "./timeouts.js";
@@ -177,14 +178,25 @@ async function handleRoute(
       deliveryController.abort(error);
     }
   };
+  const cancelResponseDelivery = (failure: GatewayFailure): void => {
+    const error = new GatewayFailureError(failure);
+    attempt.failure(error);
+    if (!deliveryController.signal.aborted) {
+      deliveryController.abort(error);
+    }
+    if (!workController.signal.aborted) {
+      workController.abort(error);
+    }
+  };
   const inflight: InflightRequest = {
     abortForShutdown: async () => {
-      await streamExecution?.abort("shutdown");
+      const streamCompletion = streamExecution?.abort("shutdown");
       abortDelivery({
         kind: "aborted",
         source: "gateway",
         phase: "internal",
       });
+      await streamCompletion;
       await settled;
     },
   };
@@ -257,8 +269,8 @@ async function handleRoute(
 
     const response = await route.endpoint(decoded, scope);
     streamExecution = getStreamExecutionHandle(response);
-    streamExecution?.claimDeliveryAdapter();
     if (workController.signal.aborted) {
+      await streamExecution?.completion;
       const timeoutFailure = upstreamTimeoutFromSignal(workController.signal);
       if (timeoutFailure !== undefined && !request.signal.aborted) {
         attempt.failure(new GatewayFailureError(timeoutFailure));
@@ -282,7 +294,7 @@ async function handleRoute(
     return attachLifecycle(
       response,
       deliveryController.signal,
-      () => abortDelivery({ kind: "aborted", source: "request", phase: "stream" }),
+      () => cancelResponseDelivery({ kind: "aborted", source: "request", phase: "stream" }),
       attempt,
       cleanup,
       stream ? dependencies.streamFinished : undefined,
@@ -343,14 +355,21 @@ function attachLifecycle(
   }
 
   let cleaned = false;
+  let onDeliveryAbort: () => void = () => undefined;
   const once = (): void => {
     if (cleaned) {
       return;
     }
     cleaned = true;
+    deliverySignal.removeEventListener("abort", onDeliveryAbort);
     onFinished?.();
     cleanup();
   };
+
+  let delivery: StreamExecutionDelivery | undefined;
+  if (streamExecution !== undefined) {
+    delivery = streamExecution.claimDeliveryAdapter(once);
+  }
 
   const reader = body.getReader();
   let cancellation: Promise<void> | undefined;
@@ -358,44 +377,61 @@ function attachLifecycle(
     cancellation ??= boundedCleanup(reader.cancel(), RESPONSE_BODY_CLEANUP_MS);
     await cancellation;
   };
+  const settleDelivery = (): void => {
+    delivery?.settle();
+  };
+  const awaitOwner = async (): Promise<void> => {
+    await streamExecution?.completion;
+    if (streamExecution === undefined) {
+      once();
+    }
+  };
   const stream = new ReadableStream<Uint8Array>({
     async pull(streamController): Promise<void> {
       if (deliverySignal.aborted) {
+        settleDelivery();
         await cancelBody();
-        once();
+        await awaitOwner();
         streamController.close();
         return;
       }
       try {
         const next = await reader.read();
         if (next.done) {
+          settleDelivery();
           await cancellation;
-          await streamExecution?.completion;
-          once();
+          await awaitOwner();
           streamController.close();
           return;
         }
         if (next.value !== undefined) {
           attempt.markCommitted();
           streamController.enqueue(next.value);
-          streamExecution?.markDelivered();
+          delivery?.markDelivered();
         }
       } catch (error: unknown) {
-        await streamExecution?.completion;
-        once();
+        settleDelivery();
+        await awaitOwner();
         streamController.error(error);
       }
     },
     async cancel(): Promise<void> {
-      await cancelBody();
+      settleDelivery();
       abortDelivery();
-      once();
+      await cancelBody();
+      await awaitOwner();
     },
   });
 
-  deliverySignal.addEventListener("abort", () => {
-    void cancelBody().finally(once);
-  }, { once: true });
+  onDeliveryAbort = () => {
+    settleDelivery();
+    void cancelBody().then(awaitOwner, awaitOwner);
+  };
+  const alreadyAborted = deliverySignal.aborted;
+  deliverySignal.addEventListener("abort", onDeliveryAbort, { once: true });
+  if (alreadyAborted || deliverySignal.aborted) {
+    onDeliveryAbort();
+  }
 
   return new Response(stream, {
     status: response.status,

--- a/src/gateway/hono_app.ts
+++ b/src/gateway/hono_app.ts
@@ -417,7 +417,7 @@ function attachLifecycle(
       await cancelBody();
       await awaitOwner();
     },
-  }, { highWaterMark: 0 });
+  }, streamExecution === undefined ? undefined : { highWaterMark: 0 });
 
   onDeliveryAbort = () => {
     settleDelivery();

--- a/src/gateway/hono_app.ts
+++ b/src/gateway/hono_app.ts
@@ -6,7 +6,11 @@ import { readWireJsonObjectBody } from "./body_reader.js";
 import { failureFromUnknown, GatewayFailureError, type GatewayFailure } from "./failures.js";
 import { createRequestScope, type RequestScope } from "./request_scope.js";
 import { createRequestAttempt, type RequestAttempt } from "./request_attempt.js";
-import { boundedCleanup } from "./stream_execution.js";
+import {
+  boundedCleanup,
+  getStreamExecutionHandle,
+  type StreamExecutionHandle,
+} from "./stream_execution.js";
 import { abortWithTimeout, armTimeout, type TimeoutScheduler } from "./timeouts.js";
 import type { WireJsonObject } from "../serialization/wire_json.js";
 import type {
@@ -162,18 +166,20 @@ async function handleRoute(
   const settled = new Promise<void>((resolve) => {
     resolveSettled = resolve;
   });
+  let streamExecution: StreamExecutionHandle | undefined;
   const abortDelivery = (failure: GatewayFailure): void => {
     const error = new GatewayFailureError(failure);
     attempt.failure(error);
-    if (!deliveryController.signal.aborted) {
-      deliveryController.abort(error);
-    }
     if (!workController.signal.aborted) {
       workController.abort(error);
+    }
+    if (!deliveryController.signal.aborted) {
+      deliveryController.abort(error);
     }
   };
   const inflight: InflightRequest = {
     abortForShutdown: async () => {
+      await streamExecution?.abort("shutdown");
       abortDelivery({
         kind: "aborted",
         source: "gateway",
@@ -250,6 +256,8 @@ async function handleRoute(
     }
 
     const response = await route.endpoint(decoded, scope);
+    streamExecution = getStreamExecutionHandle(response);
+    streamExecution?.claimDeliveryAdapter();
     if (workController.signal.aborted) {
       const timeoutFailure = upstreamTimeoutFromSignal(workController.signal);
       if (timeoutFailure !== undefined && !request.signal.aborted) {
@@ -278,6 +286,7 @@ async function handleRoute(
       attempt,
       cleanup,
       stream ? dependencies.streamFinished : undefined,
+      streamExecution,
     );
   } catch (error: unknown) {
     const failure = failureFromUnknown(error);
@@ -325,6 +334,7 @@ function attachLifecycle(
   attempt: RequestAttempt,
   cleanup: () => void,
   onFinished?: () => void,
+  streamExecution?: StreamExecutionHandle,
 ): Response {
   const body = response.body;
   if (body === null) {
@@ -360,6 +370,7 @@ function attachLifecycle(
         const next = await reader.read();
         if (next.done) {
           await cancellation;
+          await streamExecution?.completion;
           once();
           streamController.close();
           return;
@@ -367,15 +378,17 @@ function attachLifecycle(
         if (next.value !== undefined) {
           attempt.markCommitted();
           streamController.enqueue(next.value);
+          streamExecution?.markDelivered();
         }
       } catch (error: unknown) {
+        await streamExecution?.completion;
         once();
         streamController.error(error);
       }
     },
     async cancel(): Promise<void> {
-      abortDelivery();
       await cancelBody();
+      abortDelivery();
       once();
     },
   });

--- a/src/gateway/stream_execution.ts
+++ b/src/gateway/stream_execution.ts
@@ -23,12 +23,16 @@ export type StreamExecutionEmission<T> =
   | { readonly kind: "wire"; readonly bytes: Uint8Array }
   | { readonly kind: "terminal"; readonly value: T; readonly writerMode?: "close" | "abort" };
 
+export interface StreamExecutionDelivery {
+  markDelivered(): void;
+  settle(): void;
+}
+
 export interface StreamExecutionHandle {
   readonly state: StreamExecutionState;
   readonly cause: StreamExecutionTerminalCause | undefined;
   readonly completion: Promise<void>;
-  claimDeliveryAdapter(): void;
-  markDelivered(): void;
+  claimDeliveryAdapter(finalize: () => Promise<void> | void): StreamExecutionDelivery;
   abort(cause: "shutdown" | "request_abort" | "total_timeout"): Promise<void>;
 }
 
@@ -67,15 +71,30 @@ export async function createStreamExecutionResponse<T>(input: {
   });
   let barrier: Promise<void> | undefined;
   let deliveryAdapterClaimed = false;
+  let deliveryFinalizer: (() => Promise<void> | void) | undefined;
   let deliverySettled = false;
   let resolveDelivery: () => void = () => undefined;
-  const firstDelivery = new Promise<void>((resolve) => {
+  const deliverySettlement = new Promise<void>((resolve) => {
     resolveDelivery = resolve;
+  });
+  let firstDelivered = false;
+  let resolveFirstDelivery: () => void = () => undefined;
+  const firstDelivery = new Promise<void>((resolve) => {
+    resolveFirstDelivery = resolve;
   });
   const settleDelivery = (): void => {
     if (!deliverySettled) {
       deliverySettled = true;
       resolveDelivery();
+    }
+  };
+  const markDelivered = (): void => {
+    if (!firstDelivered) {
+      firstDelivered = true;
+      if (state === "precommit") {
+        state = "committed";
+      }
+      resolveFirstDelivery();
     }
   };
 
@@ -101,35 +120,46 @@ export async function createStreamExecutionResponse<T>(input: {
     }
     cause = terminalCause;
     state = "terminating";
-    settleDelivery();
     barrier = (async () => {
-      observe(result);
-      if (writerMode === "abort") {
-        const error = result.kind === "failure"
-          ? (input.presentPostCommitFailure?.(result.error) ?? result.error)
-          : undefined;
-        resources.writer?.abort(error);
-      }
-      await boundedCleanup(
-        Promise.resolve().then(async () => await input.upstream.cancel()),
-        input.cleanupTimeoutMs ?? 1_000,
-      );
-      if (iterator.return !== undefined) {
+      try {
+        observe(result);
+        if (writerMode === "abort") {
+          const error = result.kind === "failure"
+            ? (input.presentPostCommitFailure?.(result.error) ?? result.error)
+            : undefined;
+          resources.writer?.abort(error);
+        }
         await boundedCleanup(
-          Promise.resolve().then(async () => await iterator.return!()),
+          Promise.resolve().then(async () => await input.upstream.cancel()),
           input.cleanupTimeoutMs ?? 1_000,
         );
+        if (iterator.return !== undefined) {
+          await boundedCleanup(
+            Promise.resolve().then(async () => await iterator.return!()),
+            input.cleanupTimeoutMs ?? 1_000,
+          );
+        }
+        if (!fromProducer && resources.producer !== undefined) {
+          await boundedCleanup(resources.producer, input.cleanupTimeoutMs ?? 1_000);
+        }
+        if (writerMode === "close") {
+          resources.writer?.close();
+        }
+        if (!deliveryAdapterClaimed) {
+          settleDelivery();
+        }
+        await deliverySettlement;
+        try {
+          await deliveryFinalizer?.();
+        } catch {
+          // Host finalization cannot prevent completion or listener cleanup.
+        }
+      } finally {
+        input.signal.removeEventListener("abort", onRequestAbort);
+        input.deliverySignal.removeEventListener("abort", onDeliveryAbort);
+        state = "completed";
+        resolveCompletion();
       }
-      if (!fromProducer && resources.producer !== undefined) {
-        await boundedCleanup(resources.producer, input.cleanupTimeoutMs ?? 1_000);
-      }
-      if (writerMode === "close") {
-        resources.writer?.close();
-      }
-      input.signal.removeEventListener("abort", onRequestAbort);
-      input.deliverySignal.removeEventListener("abort", onDeliveryAbort);
-      state = "completed";
-      resolveCompletion();
     })();
     await barrier;
   };
@@ -204,10 +234,13 @@ export async function createStreamExecutionResponse<T>(input: {
     ...(input.headers === undefined ? {} : { headers: input.headers }),
     onCommit: () => {
       if (!deliveryAdapterClaimed) {
-        settleDelivery();
+        markDelivered();
       }
     },
     onCancel: async () => {
+      if (!deliveryAdapterClaimed) {
+        settleDelivery();
+      }
       const error = new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
       await finish("client_cancel", { kind: "failure", error });
     },
@@ -221,10 +254,17 @@ export async function createStreamExecutionResponse<T>(input: {
       return cause;
     },
     completion,
-    claimDeliveryAdapter: () => {
+    claimDeliveryAdapter: (finalize) => {
+      if (deliveryAdapterClaimed) {
+        throw new Error("stream delivery adapter already claimed");
+      }
       deliveryAdapterClaimed = true;
+      deliveryFinalizer = finalize;
+      return {
+        markDelivered,
+        settle: settleDelivery,
+      };
     },
-    markDelivered: settleDelivery,
     abort: async (terminalCause) => {
       const error = terminalCause === "total_timeout"
         ? new GatewayFailureError({ kind: "upstream_timeout", source: "gateway", phase: "stream" })
@@ -243,7 +283,6 @@ export async function createStreamExecutionResponse<T>(input: {
       if (barrier !== undefined) {
         return;
       }
-      state = "committed";
       for (;;) {
         const next = await iterator.next();
         if (next.done === true) {

--- a/src/gateway/stream_execution.ts
+++ b/src/gateway/stream_execution.ts
@@ -32,7 +32,7 @@ export interface StreamExecutionHandle {
   readonly state: StreamExecutionState;
   readonly cause: StreamExecutionTerminalCause | undefined;
   readonly completion: Promise<void>;
-  claimDeliveryAdapter(finalize: () => Promise<void> | void): StreamExecutionDelivery;
+  claimDeliveryAdapter(finalize: () => void): StreamExecutionDelivery;
   abort(cause: "shutdown" | "request_abort" | "total_timeout"): Promise<void>;
 }
 
@@ -71,7 +71,8 @@ export async function createStreamExecutionResponse<T>(input: {
   });
   let barrier: Promise<void> | undefined;
   let deliveryAdapterClaimed = false;
-  let deliveryFinalizer: (() => Promise<void> | void) | undefined;
+  let deliveryFinalizer: (() => void) | undefined;
+  let deliveryFinalized = false;
   let deliverySettled = false;
   let resolveDelivery: () => void = () => undefined;
   const deliverySettlement = new Promise<void>((resolve) => {
@@ -95,6 +96,17 @@ export async function createStreamExecutionResponse<T>(input: {
         state = "committed";
       }
       resolveFirstDelivery();
+    }
+  };
+  const finalizeDelivery = (): void => {
+    if (deliveryFinalized || deliveryFinalizer === undefined) {
+      return;
+    }
+    deliveryFinalized = true;
+    try {
+      deliveryFinalizer();
+    } catch {
+      // Host finalization cannot prevent completion or listener cleanup.
     }
   };
 
@@ -149,11 +161,7 @@ export async function createStreamExecutionResponse<T>(input: {
           settleDelivery();
         }
         await deliverySettlement;
-        try {
-          await deliveryFinalizer?.();
-        } catch {
-          // Host finalization cannot prevent completion or listener cleanup.
-        }
+        finalizeDelivery();
       } finally {
         input.signal.removeEventListener("abort", onRequestAbort);
         input.deliverySignal.removeEventListener("abort", onDeliveryAbort);
@@ -260,6 +268,9 @@ export async function createStreamExecutionResponse<T>(input: {
       }
       deliveryAdapterClaimed = true;
       deliveryFinalizer = finalize;
+      if (state === "completed") {
+        finalizeDelivery();
+      }
       return {
         markDelivered,
         settle: settleDelivery,

--- a/src/gateway/stream_execution.ts
+++ b/src/gateway/stream_execution.ts
@@ -4,6 +4,281 @@ import {
   type GatewayFailureOrigin,
 } from "./failures.js";
 import type { UpstreamByteStream } from "../copilot/upstream_types.js";
+import { createStreamResponseWriter, type StreamResponseWriter } from "./stream_response.js";
+
+export type StreamExecutionState = "precommit" | "committed" | "terminating" | "completed";
+
+export type StreamExecutionTerminalCause =
+  | "semantic_success"
+  | "precommit_failure"
+  | "postcommit_failure"
+  | "client_cancel"
+  | "request_abort"
+  | "total_timeout"
+  | "first_byte_timeout"
+  | "idle_timeout"
+  | "shutdown";
+
+export type StreamExecutionEmission<T> =
+  | { readonly kind: "wire"; readonly bytes: Uint8Array }
+  | { readonly kind: "terminal"; readonly value: T; readonly writerMode?: "close" | "abort" };
+
+export interface StreamExecutionHandle {
+  readonly state: StreamExecutionState;
+  readonly cause: StreamExecutionTerminalCause | undefined;
+  readonly completion: Promise<void>;
+  claimDeliveryAdapter(): void;
+  markDelivered(): void;
+  abort(cause: "shutdown" | "request_abort" | "total_timeout"): Promise<void>;
+}
+
+const executionHandles = new WeakMap<Response, StreamExecutionHandle>();
+
+export function getStreamExecutionHandle(response: Response): StreamExecutionHandle | undefined {
+  return executionHandles.get(response);
+}
+
+export async function createStreamExecutionResponse<T>(input: {
+  readonly upstream: UpstreamByteStream;
+  readonly emissions: AsyncIterable<StreamExecutionEmission<T>>;
+  readonly signal: AbortSignal;
+  readonly deliverySignal: AbortSignal;
+  readonly status?: number;
+  readonly headers?: HeadersInit;
+  readonly firstEmissionTimeoutMs?: number;
+  readonly cleanupTimeoutMs?: number;
+  readonly normalizeFailure: (error: unknown) => unknown;
+  readonly presentPostCommitFailure?: (error: unknown) => unknown;
+  readonly onTerminal: (result: Readonly<
+    | { readonly kind: "success"; readonly value: T }
+    | { readonly kind: "failure"; readonly error: unknown }
+  >) => void;
+}): Promise<Response> {
+  const iterator = input.emissions[Symbol.asyncIterator]();
+  let state: StreamExecutionState = "precommit";
+  let cause: StreamExecutionTerminalCause | undefined;
+  const resources: {
+    writer?: StreamResponseWriter;
+    producer?: Promise<void>;
+  } = {};
+  let resolveCompletion: () => void = () => undefined;
+  const completion = new Promise<void>((resolve) => {
+    resolveCompletion = resolve;
+  });
+  let barrier: Promise<void> | undefined;
+  let deliveryAdapterClaimed = false;
+  let deliverySettled = false;
+  let resolveDelivery: () => void = () => undefined;
+  const firstDelivery = new Promise<void>((resolve) => {
+    resolveDelivery = resolve;
+  });
+  const settleDelivery = (): void => {
+    if (!deliverySettled) {
+      deliverySettled = true;
+      resolveDelivery();
+    }
+  };
+
+  const observe = (result: Parameters<typeof input.onTerminal>[0]): void => {
+    try {
+      input.onTerminal(result);
+    } catch {
+      // Observability cannot alter stream delivery or resource cleanup.
+    }
+  };
+
+  const finish = async (
+    terminalCause: StreamExecutionTerminalCause,
+    result: Parameters<typeof input.onTerminal>[0],
+    writerMode: "close" | "abort" = terminalCause === "semantic_success" ? "close" : "abort",
+    fromProducer = false,
+  ): Promise<void> => {
+    if (barrier !== undefined) {
+      if (!fromProducer) {
+        await barrier;
+      }
+      return;
+    }
+    cause = terminalCause;
+    state = "terminating";
+    settleDelivery();
+    barrier = (async () => {
+      observe(result);
+      if (writerMode === "abort") {
+        const error = result.kind === "failure"
+          ? (input.presentPostCommitFailure?.(result.error) ?? result.error)
+          : undefined;
+        resources.writer?.abort(error);
+      }
+      await boundedCleanup(
+        Promise.resolve().then(async () => await input.upstream.cancel()),
+        input.cleanupTimeoutMs ?? 1_000,
+      );
+      if (iterator.return !== undefined) {
+        await boundedCleanup(
+          Promise.resolve().then(async () => await iterator.return!()),
+          input.cleanupTimeoutMs ?? 1_000,
+        );
+      }
+      if (!fromProducer && resources.producer !== undefined) {
+        await boundedCleanup(resources.producer, input.cleanupTimeoutMs ?? 1_000);
+      }
+      if (writerMode === "close") {
+        resources.writer?.close();
+      }
+      input.signal.removeEventListener("abort", onRequestAbort);
+      input.deliverySignal.removeEventListener("abort", onDeliveryAbort);
+      state = "completed";
+      resolveCompletion();
+    })();
+    await barrier;
+  };
+
+  const signalCause = (): "request_abort" | "total_timeout" => {
+    const reason = input.signal.reason;
+    return reason instanceof GatewayFailureError && reason.failure.kind === "upstream_timeout"
+      ? "total_timeout"
+      : "request_abort";
+  };
+  const failureCause = (error: unknown, committed: boolean): StreamExecutionTerminalCause => {
+    if (error instanceof GatewayFailureError && error.failure.kind === "upstream_timeout") {
+      if (input.signal.aborted) {
+        return signalCause();
+      }
+      return committed ? "idle_timeout" : "first_byte_timeout";
+    }
+    return committed ? "postcommit_failure" : "precommit_failure";
+  };
+  const abortFailure = (): GatewayFailureError => new GatewayFailureError(failureFromSignal(input.signal, {
+    source: "parser",
+    phase: "stream",
+  }));
+  const onRequestAbort = (): void => {
+    const error = abortFailure();
+    void finish(signalCause(), { kind: "failure", error });
+  };
+  const onDeliveryAbort = (): void => {
+    const error = new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
+    void finish("client_cancel", { kind: "failure", error });
+  };
+
+  input.signal.addEventListener("abort", onRequestAbort, { once: true });
+  input.deliverySignal.addEventListener("abort", onDeliveryAbort, { once: true });
+  if (input.signal.aborted) {
+    onRequestAbort();
+    await completion;
+    throw abortFailure();
+  }
+  if (input.deliverySignal.aborted) {
+    onDeliveryAbort();
+    await completion;
+    throw new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
+  }
+
+  let firstWire: Uint8Array;
+  try {
+    const first = input.firstEmissionTimeoutMs === undefined
+      ? await iterator.next()
+      : await nextWithDeadline(
+        iterator,
+        input.firstEmissionTimeoutMs,
+        input.signal,
+        { source: "parser", phase: "stream" },
+      );
+    if (first.done === true || first.value.kind === "terminal") {
+      throw new GatewayFailureError({
+        kind: "upstream_stream_truncated",
+        source: "parser",
+        phase: "stream",
+      });
+    }
+    firstWire = first.value.bytes;
+  } catch (error: unknown) {
+    const failure = input.normalizeFailure(error);
+    await finish(failureCause(failure, false), { kind: "failure", error: failure });
+    throw failure;
+  }
+
+  resources.writer = createStreamResponseWriter({
+    ...(input.status === undefined ? {} : { status: input.status }),
+    ...(input.headers === undefined ? {} : { headers: input.headers }),
+    onCommit: () => {
+      if (!deliveryAdapterClaimed) {
+        settleDelivery();
+      }
+    },
+    onCancel: async () => {
+      const error = new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
+      await finish("client_cancel", { kind: "failure", error });
+    },
+  });
+  const response = resources.writer.response;
+  const handle: StreamExecutionHandle = {
+    get state() {
+      return state;
+    },
+    get cause() {
+      return cause;
+    },
+    completion,
+    claimDeliveryAdapter: () => {
+      deliveryAdapterClaimed = true;
+    },
+    markDelivered: settleDelivery,
+    abort: async (terminalCause) => {
+      const error = terminalCause === "total_timeout"
+        ? new GatewayFailureError({ kind: "upstream_timeout", source: "gateway", phase: "stream" })
+        : new GatewayFailureError({ kind: "aborted", source: "gateway", phase: "stream" });
+      await finish(terminalCause, { kind: "failure", error });
+    },
+  };
+  executionHandles.set(response, handle);
+
+  const produce = async (): Promise<void> => {
+    try {
+      if (!await resources.writer!.enqueue(firstWire)) {
+        return;
+      }
+      await firstDelivery;
+      if (barrier !== undefined) {
+        return;
+      }
+      state = "committed";
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done === true) {
+          throw new GatewayFailureError({
+            kind: "upstream_stream_truncated",
+            source: "parser",
+            phase: "stream",
+          });
+        }
+        if (next.value.kind === "wire") {
+          if (!await resources.writer!.enqueue(next.value.bytes)) {
+            return;
+          }
+          continue;
+        }
+        await finish(
+          next.value.writerMode === "abort" ? "postcommit_failure" : "semantic_success",
+          { kind: "success", value: next.value.value },
+          next.value.writerMode ?? "close",
+          true,
+        );
+        return;
+      }
+    } catch (error: unknown) {
+      const failure = input.normalizeFailure(error);
+      await finish(failureCause(failure, resources.writer!.committed), {
+        kind: "failure",
+        error: failure,
+      }, "abort", true);
+    }
+  };
+  resources.producer = produce();
+  void resources.producer.catch(() => undefined);
+  return response;
+}
 
 export async function nextWithDeadline<T>(
   iterator: AsyncIterator<T>,
@@ -39,49 +314,11 @@ export async function nextWithDeadline<T>(
   }
 }
 
-export async function cleanupOwnedStream(
-  upstream: UpstreamByteStream,
-  iterator?: AsyncIterator<unknown>,
-  timeoutMs = 1_000,
-): Promise<void> {
-  await createOwnedStreamCleanup(upstream, iterator, timeoutMs)();
-}
-
-export function createExchangeCancellation(
-  upstream: UpstreamByteStream,
-  timeoutMs = 1_000,
-): () => Promise<void> {
-  let cancellation: Promise<void> | undefined;
-  return async () => {
-    cancellation ??= boundedCleanup(upstream.cancel(), timeoutMs);
-    await cancellation;
-  };
-}
-
-export function createOwnedStreamCleanup(
-  upstream: UpstreamByteStream,
-  iterator?: AsyncIterator<unknown>,
-  timeoutMs = 1_000,
-  cancelExchange = createExchangeCancellation(upstream, timeoutMs),
-): () => Promise<void> {
-  let cleanup: Promise<void> | undefined;
-  return async () => {
-    cleanup ??= (async () => {
-      await cancelExchange();
-      if (iterator?.return !== undefined) {
-        await boundedCleanup(iterator.return(), timeoutMs);
-      }
-    })();
-    await cleanup;
-  };
-}
-
 export async function* withByteIdleDeadlines(
   source: AsyncIterable<Uint8Array>,
   signal: AbortSignal,
   firstByteMs: number,
   idleMs: number,
-  cancelExchange: () => Promise<void>,
 ): AsyncIterable<Uint8Array> {
   const iterator = source[Symbol.asyncIterator]();
   let seenBytes = false;
@@ -100,7 +337,6 @@ export async function* withByteIdleDeadlines(
       yield next.value;
     }
   } finally {
-    await cancelExchange();
     if (iterator.return !== undefined) {
       await boundedCleanup(iterator.return());
     }

--- a/src/gateway/stream_execution.ts
+++ b/src/gateway/stream_execution.ts
@@ -21,7 +21,14 @@ export type StreamExecutionTerminalCause =
 
 export type StreamExecutionEmission<T> =
   | { readonly kind: "wire"; readonly bytes: Uint8Array }
-  | { readonly kind: "terminal"; readonly value: T; readonly writerMode?: "close" | "abort" };
+  | {
+    readonly kind: "terminal";
+    readonly outcome: Readonly<
+      | { readonly kind: "success"; readonly value: T }
+      | { readonly kind: "failure"; readonly error: unknown }
+    >;
+    readonly writerMode: "close" | "abort";
+  };
 
 export interface StreamExecutionDelivery {
   markDelivered(): void;
@@ -268,7 +275,9 @@ export async function createStreamExecutionResponse<T>(input: {
       }
       deliveryAdapterClaimed = true;
       deliveryFinalizer = finalize;
-      if (state === "completed") {
+      if (state === "terminating") {
+        settleDelivery();
+      } else if (state === "completed") {
         finalizeDelivery();
       }
       return {
@@ -310,9 +319,9 @@ export async function createStreamExecutionResponse<T>(input: {
           continue;
         }
         await finish(
-          next.value.writerMode === "abort" ? "postcommit_failure" : "semantic_success",
-          { kind: "success", value: next.value.value },
-          next.value.writerMode ?? "close",
+          next.value.outcome.kind === "success" ? "semantic_success" : "postcommit_failure",
+          next.value.outcome,
+          next.value.writerMode,
           true,
         );
         return;

--- a/src/gateway/stream_response.ts
+++ b/src/gateway/stream_response.ts
@@ -65,7 +65,7 @@ export function createStreamResponseWriter(init: {
       wakeProducer();
       await cancelProducer();
     },
-  });
+  }, { highWaterMark: 0 });
 
   const writer: StreamResponseWriter = {
     get committed(): boolean {

--- a/src/gateway/stream_response.ts
+++ b/src/gateway/stream_response.ts
@@ -9,7 +9,6 @@ export interface StreamResponseWriter {
 export function createStreamResponseWriter(init: {
   readonly status?: number;
   readonly headers?: HeadersInit;
-  readonly signal?: AbortSignal;
   readonly onCommit?: () => void;
   readonly onCancel?: () => Promise<void> | void;
 }): StreamResponseWriter {
@@ -26,7 +25,6 @@ export function createStreamResponseWriter(init: {
     cancellation ??= Promise.resolve().then(() => init.onCancel?.());
     await cancellation;
   };
-  const isAborted = (): boolean => init.signal?.aborted ?? false;
 
   const deliver = (chunk: Uint8Array): void => {
     committed = true;
@@ -74,15 +72,15 @@ export function createStreamResponseWriter(init: {
       return committed;
     },
     async enqueue(chunk: Uint8Array): Promise<boolean> {
-      if (closed || isAborted()) {
+      if (closed) {
         return false;
       }
-      while (!closed && !isAborted() && lookahead !== undefined) {
+      while (!closed && lookahead !== undefined) {
         await new Promise<void>((resolve) => {
           waitingProducer = resolve;
         });
       }
-      if (closed || isAborted()) {
+      if (closed) {
         return false;
       }
       if (outstandingPulls > 0) {
@@ -125,17 +123,6 @@ export function createStreamResponseWriter(init: {
       ? { status: init.status ?? 200 }
       : { status: init.status ?? 200, headers: init.headers }),
   };
-
-  if (init.signal !== undefined) {
-    const abort = (): void => {
-      void cancelProducer().finally(() => writer.abort());
-    };
-    if (init.signal.aborted) {
-      abort();
-    } else {
-      init.signal.addEventListener("abort", abort, { once: true });
-    }
-  }
 
   return writer;
 }

--- a/src/gateway/stream_response.ts
+++ b/src/gateway/stream_response.ts
@@ -2,14 +2,15 @@ export interface StreamResponseWriter {
   readonly committed: boolean;
   enqueue(chunk: Uint8Array): Promise<boolean>;
   close(): void;
-  abort(): void;
+  abort(error?: unknown): void;
   readonly response: Response;
 }
 
 export function createStreamResponseWriter(init: {
   readonly status?: number;
   readonly headers?: HeadersInit;
-  readonly signal: AbortSignal;
+  readonly signal?: AbortSignal;
+  readonly onCommit?: () => void;
   readonly onCancel?: () => Promise<void> | void;
 }): StreamResponseWriter {
   let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
@@ -18,16 +19,22 @@ export function createStreamResponseWriter(init: {
   let outstandingPulls = 0;
   let lookahead: Uint8Array | undefined;
   let waitingProducer: (() => void) | undefined;
+  let settleLookahead: ((accepted: boolean) => void) | undefined;
   let cancellation: Promise<void> | undefined;
 
   const cancelProducer = async (): Promise<void> => {
     cancellation ??= Promise.resolve().then(() => init.onCancel?.());
     await cancellation;
   };
+  const isAborted = (): boolean => init.signal?.aborted ?? false;
 
   const deliver = (chunk: Uint8Array): void => {
     committed = true;
     controller?.enqueue(chunk);
+    init.onCommit?.();
+    const settle = settleLookahead;
+    settleLookahead = undefined;
+    settle?.(true);
   };
 
   const wakeProducer = (): void => {
@@ -54,6 +61,9 @@ export function createStreamResponseWriter(init: {
     async cancel(): Promise<void> {
       closed = true;
       lookahead = undefined;
+      const settle = settleLookahead;
+      settleLookahead = undefined;
+      settle?.(false);
       wakeProducer();
       await cancelProducer();
     },
@@ -64,15 +74,15 @@ export function createStreamResponseWriter(init: {
       return committed;
     },
     async enqueue(chunk: Uint8Array): Promise<boolean> {
-      if (closed || init.signal.aborted) {
+      if (closed || isAborted()) {
         return false;
       }
-      while (!closed && !init.signal.aborted && lookahead !== undefined) {
+      while (!closed && !isAborted() && lookahead !== undefined) {
         await new Promise<void>((resolve) => {
           waitingProducer = resolve;
         });
       }
-      if (closed || init.signal.aborted) {
+      if (closed || isAborted()) {
         return false;
       }
       if (outstandingPulls > 0) {
@@ -81,7 +91,9 @@ export function createStreamResponseWriter(init: {
         return true;
       }
       lookahead = chunk;
-      return true;
+      return await new Promise<boolean>((resolve) => {
+        settleLookahead = resolve;
+      });
     },
     close(): void {
       closed = true;
@@ -96,11 +108,14 @@ export function createStreamResponseWriter(init: {
       }
       wakeProducer();
     },
-    abort(): void {
+    abort(error = new Error("aborted")): void {
       closed = true;
       lookahead = undefined;
+      const settle = settleLookahead;
+      settleLookahead = undefined;
+      settle?.(false);
       try {
-        controller?.error(new Error("aborted"));
+        controller?.error(error);
       } catch (_error) {
         // already closed
       }
@@ -111,9 +126,16 @@ export function createStreamResponseWriter(init: {
       : { status: init.status ?? 200, headers: init.headers }),
   };
 
-  init.signal.addEventListener("abort", () => {
-    void cancelProducer().finally(() => writer.abort());
-  }, { once: true });
+  if (init.signal !== undefined) {
+    const abort = (): void => {
+      void cancelProducer().finally(() => writer.abort());
+    };
+    if (init.signal.aborted) {
+      abort();
+    } else {
+      init.signal.addEventListener("abort", abort, { once: true });
+    }
+  }
 
   return writer;
 }

--- a/src/protocols/anthropic_messages/native.ts
+++ b/src/protocols/anthropic_messages/native.ts
@@ -1,11 +1,9 @@
-import { GatewayFailureError, failureFromSignal } from "../../gateway/failures.js";
+import { GatewayFailureError } from "../../gateway/failures.js";
 import type { RequestScope } from "../../gateway/request_scope.js";
-import { createStreamResponseWriter } from "../../gateway/stream_response.js";
 import {
-  createExchangeCancellation,
-  createOwnedStreamCleanup,
-  nextWithDeadline,
+  createStreamExecutionResponse,
   withByteIdleDeadlines,
+  type StreamExecutionEmission,
 } from "../../gateway/stream_execution.js";
 import {
   isWireJsonNumber,
@@ -98,131 +96,83 @@ export async function createNativeMessagesStreamResponse(input: {
     | { readonly kind: "failure"; readonly error: unknown }
   >) => void;
 }): Promise<Response> {
-  const cancelExchange = createExchangeCancellation(input.upstream);
   const timed = withByteIdleDeadlines(
     input.upstream.bytes,
     input.scope.signal,
     input.scope.config.timeouts.firstByteMs,
     input.scope.config.timeouts.streamIdleMs,
-    cancelExchange,
   );
-  const iterator = timed[Symbol.asyncIterator]();
-  const cleanupUpstream = createOwnedStreamCleanup(input.upstream, iterator, 1_000, cancelExchange);
-  const observer = new NativeMessagesObserver(input.scope.config.limits.sseEventBytes);
-  const prefetched: Uint8Array[] = [];
-  let prefetchedBytes = 0;
-  const startedAt = Date.now();
-  try {
-    while (!observer.hasSemantic) {
-      const elapsed = Date.now() - startedAt;
-      if (elapsed >= input.scope.config.timeouts.firstByteMs) {
-        throw new GatewayFailureError({
-          kind: "upstream_timeout",
-          source: "parser",
-          phase: "stream",
-        });
-      }
-      const remaining = input.scope.config.timeouts.firstByteMs - elapsed;
-      const next = await nextWithDeadline(
-        iterator,
-        remaining,
-        input.scope.signal,
-        { source: "parser", phase: "stream" },
-      );
-      if (next.done === true) {
-        throw truncated();
-      }
-      prefetchedBytes += next.value.byteLength;
-      if (prefetchedBytes > input.scope.config.limits.accumulatorBytes) {
-        invalid();
-      }
-      prefetched.push(...observer.consume(next.value));
-    }
-  } catch (error: unknown) {
-    await cleanupUpstream();
-    throw error;
-  }
-
-  const writer = createStreamResponseWriter({
+  return await createStreamExecutionResponse({
+    upstream: input.upstream,
+    emissions: nativeMessagesEmissions(
+      timed,
+      input.scope.config.limits.sseEventBytes,
+      input.scope.config.limits.accumulatorBytes,
+    ),
     signal: input.scope.signal,
+    deliverySignal: input.scope.deliverySignal,
     headers: {
       "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-store",
       "request-id": input.scope.requestId,
     },
-    onCancel: async () => await closeStream(),
+    firstEmissionTimeoutMs: input.scope.config.timeouts.firstByteMs,
+    normalizeFailure: (error) => error,
+    onTerminal: (result) => result.kind === "success"
+      ? observe(input.onTerminal, { kind: "success", usage: result.value })
+      : observe(input.onTerminal, { kind: "failure", error: result.error }),
   });
-  let closed = false;
-  let cleanup: Promise<void> | undefined;
-  const closeStream = async (): Promise<void> => {
-    if (closed) {
-      await cleanup;
+}
+
+async function* nativeMessagesEmissions(
+  bytes: AsyncIterable<Uint8Array>,
+  eventLimitBytes: number,
+  accumulatorBytes: number,
+): AsyncIterable<StreamExecutionEmission<SemanticUsage>> {
+  const iterator = bytes[Symbol.asyncIterator]();
+  const observer = new NativeMessagesObserver(eventLimitBytes);
+  let prefetchedBytes = 0;
+  try {
+    while (!observer.hasSemantic) {
+      const next = await iterator.next();
+      if (next.done === true) {
+        throw truncated();
+      }
+      prefetchedBytes += next.value.byteLength;
+      if (prefetchedBytes > accumulatorBytes) {
+        invalid();
+      }
+      for (const record of observer.consume(next.value)) {
+        yield { kind: "wire", bytes: record };
+      }
+    }
+    if (observer.isTerminal) {
+      yield { kind: "terminal", value: observer.observedUsage };
       return;
     }
-    closed = true;
-    input.scope.signal.removeEventListener("abort", onAbort);
-    cleanup = cleanupUpstream();
-    await cleanup;
-  };
-  const onAbort = (): void => {
-    observe(input.onTerminal, {
-      kind: "failure",
-      error: new GatewayFailureError(failureFromSignal(input.scope.signal, {
-        source: "parser",
-        phase: "stream",
-      })),
-    });
-    void closeStream();
-  };
-  void (async () => {
-    try {
-      for (const value of prefetched) {
-        if (!await writer.enqueue(value)) {
-          return;
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done === true) {
+        const finished = observer.finish();
+        for (const record of finished.records) {
+          yield { kind: "wire", bytes: record };
         }
-      }
-      if (observer.isTerminal) {
-        observe(input.onTerminal, { kind: "success", usage: observer.observedUsage });
-        await closeStream();
-        writer.close();
+        yield { kind: "terminal", value: finished.usage };
         return;
       }
-      for (;;) {
-        const next = await iterator.next();
-        if (next.done === true) {
-          const finished = observer.finish();
-          for (const value of finished.records) {
-            if (!await writer.enqueue(value)) {
-              return;
-            }
-          }
-          observe(input.onTerminal, { kind: "success", usage: finished.usage });
-          await closeStream();
-          writer.close();
-          return;
-        }
-        for (const value of observer.consume(next.value)) {
-          if (!await writer.enqueue(value)) {
-            return;
-          }
-        }
-        if (observer.isTerminal) {
-          observe(input.onTerminal, { kind: "success", usage: observer.observedUsage });
-          await closeStream();
-          writer.close();
-          return;
-        }
+      for (const record of observer.consume(next.value)) {
+        yield { kind: "wire", bytes: record };
       }
-    } catch (error: unknown) {
-      observe(input.onTerminal, { kind: "failure", error });
-      await closeStream();
-      writer.abort();
-    } finally {
-      await closeStream();
+      if (observer.isTerminal) {
+        yield { kind: "terminal", value: observer.observedUsage };
+        return;
+      }
     }
-  })();
-  input.scope.signal.addEventListener("abort", onAbort, { once: true });
-  return writer.response;
+  } finally {
+    if (iterator.return !== undefined) {
+      await iterator.return();
+    }
+  }
 }
 
 class NativeRecordAccumulator {

--- a/src/protocols/anthropic_messages/native.ts
+++ b/src/protocols/anthropic_messages/native.ts
@@ -131,6 +131,7 @@ async function* nativeMessagesEmissions(
 ): AsyncIterable<StreamExecutionEmission<SemanticUsage>> {
   const iterator = bytes[Symbol.asyncIterator]();
   const observer = new NativeMessagesObserver(eventLimitBytes);
+  const presemanticRecords: Uint8Array[] = [];
   let prefetchedBytes = 0;
   try {
     while (!observer.hasSemantic) {
@@ -142,9 +143,10 @@ async function* nativeMessagesEmissions(
       if (prefetchedBytes > accumulatorBytes) {
         invalid();
       }
-      for (const record of observer.consume(next.value)) {
-        yield { kind: "wire", bytes: record };
-      }
+      presemanticRecords.push(...observer.consume(next.value));
+    }
+    for (const record of presemanticRecords) {
+      yield { kind: "wire", bytes: record };
     }
     if (observer.isTerminal) {
       yield { kind: "terminal", value: observer.observedUsage };

--- a/src/protocols/anthropic_messages/native.ts
+++ b/src/protocols/anthropic_messages/native.ts
@@ -149,7 +149,11 @@ async function* nativeMessagesEmissions(
       yield { kind: "wire", bytes: record };
     }
     if (observer.isTerminal) {
-      yield { kind: "terminal", value: observer.observedUsage };
+      yield {
+        kind: "terminal",
+        outcome: { kind: "success", value: observer.observedUsage },
+        writerMode: "close",
+      };
       return;
     }
     for (;;) {
@@ -159,14 +163,22 @@ async function* nativeMessagesEmissions(
         for (const record of finished.records) {
           yield { kind: "wire", bytes: record };
         }
-        yield { kind: "terminal", value: finished.usage };
+        yield {
+          kind: "terminal",
+          outcome: { kind: "success", value: finished.usage },
+          writerMode: "close",
+        };
         return;
       }
       for (const record of observer.consume(next.value)) {
         yield { kind: "wire", bytes: record };
       }
       if (observer.isTerminal) {
-        yield { kind: "terminal", value: observer.observedUsage };
+        yield {
+          kind: "terminal",
+          outcome: { kind: "success", value: observer.observedUsage },
+          writerMode: "close",
+        };
         return;
       }
     }

--- a/src/protocols/anthropic_messages/stream.ts
+++ b/src/protocols/anthropic_messages/stream.ts
@@ -55,7 +55,7 @@ export async function createAnthropicStreamResponse(input: {
     firstEmissionTimeoutMs: input.scope.config.timeouts.firstByteMs,
     normalizeFailure: (error) => normalizeChatStreamFailure(error, input.scope.signal),
     onTerminal: (result) => result.kind === "success"
-      ? observeTerminal(input.onTerminal, result.value)
+      ? observeTerminal(input.onTerminal, { kind: "success", usage: result.value })
       : observeTerminal(input.onTerminal, { kind: "failure", error: result.error }),
   });
 }
@@ -63,7 +63,7 @@ export async function createAnthropicStreamResponse(input: {
 async function* anthropicEmissions(
   frames: AsyncGenerator<ChatStreamFrame>,
   input: Parameters<typeof createAnthropicStreamResponse>[0],
-): AsyncIterable<StreamExecutionEmission<AnthropicTerminal>> {
+): AsyncIterable<StreamExecutionEmission<ObservedUsage>> {
   const converter = new AnthropicStreamConverter(input.model, input.createUuid);
   const firstFrames = await readThroughFirstSemanticChatFrame(
     frames,
@@ -107,12 +107,16 @@ async function* anthropicEmissions(
         for (const event of converter.finish()) {
           yield { kind: "wire", bytes: encodeAnthropicSse(event) };
         }
-        yield { kind: "terminal", value: { kind: "success", usage: observedUsage } };
+        yield {
+          kind: "terminal",
+          outcome: { kind: "success", value: observedUsage },
+          writerMode: "close",
+        };
         return;
       } else {
         yield {
           kind: "terminal",
-          value: { kind: "failure", error: upstreamStreamEventFailure() },
+          outcome: { kind: "failure", error: upstreamStreamEventFailure() },
           writerMode: "close",
         };
         return;

--- a/src/protocols/anthropic_messages/stream.ts
+++ b/src/protocols/anthropic_messages/stream.ts
@@ -3,13 +3,12 @@ import {
   normalizeChatStreamFailure,
   upstreamStreamEventFailure,
 } from "../../copilot/failures.js";
-import { failureFromSignal, GatewayFailureError } from "../../gateway/failures.js";
+import { GatewayFailureError } from "../../gateway/failures.js";
 import type { RequestScope } from "../../gateway/request_scope.js";
-import { createStreamResponseWriter } from "../../gateway/stream_response.js";
 import {
-  createExchangeCancellation,
-  createOwnedStreamCleanup,
+  createStreamExecutionResponse,
   withByteIdleDeadlines,
+  type StreamExecutionEmission,
 } from "../../gateway/stream_execution.js";
 import type { UpstreamByteStream } from "../../copilot/upstream_types.js";
 import type { ChatStreamFrame } from "../chat_completions/types.js";
@@ -24,19 +23,19 @@ const STREAM_HEADERS = {
   "Cache-Control": "no-store",
 } as const;
 
+type AnthropicTerminal = Readonly<
+  | { readonly kind: "success"; readonly usage: ObservedUsage }
+  | { readonly kind: "failure"; readonly error: unknown }
+>;
+
 export async function createAnthropicStreamResponse(input: {
   readonly upstream: UpstreamByteStream;
   readonly model: string;
   readonly createUuid: () => string;
   readonly scope: Readonly<RequestScope>;
   readonly performanceObserver?: ProtocolPerformanceObserver;
-  readonly onTerminal?: (result: Readonly<
-    | { readonly kind: "success"; readonly usage: { readonly inputTokens: number; readonly outputTokens: number; readonly cacheTokens: number } }
-    | { readonly kind: "failure"; readonly error: unknown }
-  >) => void;
+  readonly onTerminal?: (result: AnthropicTerminal) => void;
 }): Promise<Response> {
-  const converter = new AnthropicStreamConverter(input.model, input.createUuid);
-  const cancelExchange = createExchangeCancellation(input.upstream);
   const timedUpstream = {
     ...input.upstream,
     bytes: withByteIdleDeadlines(
@@ -44,125 +43,84 @@ export async function createAnthropicStreamResponse(input: {
       input.scope.signal,
       input.scope.config.timeouts.firstByteMs,
       input.scope.config.timeouts.streamIdleMs,
-      cancelExchange,
     ),
   };
   const frames = iterateChatFrames(timedUpstream);
-  const cleanupUpstream = createOwnedStreamCleanup(input.upstream, frames, 1_000, cancelExchange);
-  let firstFrames: readonly ChatStreamFrame[];
-  try {
-    firstFrames = await readThroughFirstSemanticChatFrame(
-      frames,
-      input.scope.signal,
-      input.scope.config.timeouts.firstByteMs,
-    );
-  } catch (error: unknown) {
-    await cleanupUpstream();
-    throw normalizeChatStreamFailure(error, input.scope.signal);
-  }
+  return await createStreamExecutionResponse({
+    upstream: input.upstream,
+    emissions: anthropicEmissions(frames, input),
+    signal: input.scope.signal,
+    deliverySignal: input.scope.deliverySignal,
+    headers: { ...STREAM_HEADERS, "request-id": input.scope.requestId },
+    firstEmissionTimeoutMs: input.scope.config.timeouts.firstByteMs,
+    normalizeFailure: (error) => normalizeChatStreamFailure(error, input.scope.signal),
+    onTerminal: (result) => result.kind === "success"
+      ? observeTerminal(input.onTerminal, result.value)
+      : observeTerminal(input.onTerminal, { kind: "failure", error: result.error }),
+  });
+}
+
+async function* anthropicEmissions(
+  frames: AsyncGenerator<ChatStreamFrame>,
+  input: Parameters<typeof createAnthropicStreamResponse>[0],
+): AsyncIterable<StreamExecutionEmission<AnthropicTerminal>> {
+  const converter = new AnthropicStreamConverter(input.model, input.createUuid);
+  const firstFrames = await readThroughFirstSemanticChatFrame(
+    frames,
+    input.scope.signal,
+    input.scope.config.timeouts.firstByteMs,
+  );
   if (firstFrames.at(-1)?.kind === "error") {
-    await cleanupUpstream();
     throw upstreamStreamEventFailure();
   }
-
-  let observedUsage = { inputTokens: 0, outputTokens: 0, cacheTokens: 0 };
-  const writer = createStreamResponseWriter({
-    signal: input.scope.signal,
-    headers: { ...STREAM_HEADERS, "request-id": input.scope.requestId },
-    onCancel: async () => await closeStream(),
-  });
-  let closed = false;
-  let cleanup: Promise<void> | undefined;
-  const closeStream = async (): Promise<void> => {
-    if (closed) {
-      await cleanup;
-      return;
+  let observedUsage: ObservedUsage = { inputTokens: 0, outputTokens: 0, cacheTokens: 0 };
+  try {
+    for (const event of converter.start()) {
+      yield { kind: "wire", bytes: encodeAnthropicSse(event) };
     }
-    closed = true;
-    input.scope.signal.removeEventListener("abort", onAbort);
-    cleanup = cleanupUpstream();
-    await cleanup;
-  };
-  const onAbort = (): void => {
-    observeTerminal(input.onTerminal, {
-      kind: "failure",
-      error: new GatewayFailureError(failureFromSignal(input.scope.signal, {
-        source: "parser",
-        phase: "stream",
-      })),
-    });
-    void closeStream();
-  };
-  void (async () => {
-    try {
-      for (const event of converter.start()) {
-        if (!await writer.enqueue(encodeAnthropicSse(event))) {
-          return;
-        }
+    const pending = [...firstFrames];
+    for (;;) {
+      const next = pending.length === 0
+        ? await frames.next()
+        : { done: false as const, value: pending.shift() as ChatStreamFrame };
+      if (next.done === true) {
+        throw new GatewayFailureError({
+          kind: "upstream_stream_truncated",
+          source: "parser",
+          phase: "stream",
+        });
       }
-      const pending = [...firstFrames];
-      for (;;) {
-        const next = pending.length === 0
-          ? await frames.next()
-          : { done: false as const, value: pending.shift() as ChatStreamFrame };
-        if (next.done === true) {
-          throw new GatewayFailureError({
-            kind: "upstream_stream_truncated",
-            source: "parser",
-            phase: "stream",
-          });
+      const frame = next.value;
+      if (frame.kind === "chunk") {
+        const chunk = wireToJson(frame.chunk.payload);
+        if (input.onTerminal !== undefined) {
+          observedUsage = mergeObservedUsage(observedUsage, chunk);
         }
-        const frame = next.value;
-        if (input.scope.signal.aborted) {
-          await closeStream();
-          writer.abort();
-          return;
+        const events = measureEvents(input.performanceObserver, () => converter.consume(chunk));
+        for (const event of events) {
+          yield {
+            kind: "wire",
+            bytes: measureEvents(input.performanceObserver, () => encodeAnthropicSse(event)),
+          };
         }
-        if (frame.kind === "chunk") {
-          const chunk = wireToJson(frame.chunk.payload);
-          if (input.onTerminal !== undefined) {
-            observedUsage = mergeObservedUsage(observedUsage, chunk);
-          }
-          const events = measureEvents(input.performanceObserver, () => converter.consume(chunk));
-          for (const event of events) {
-            const bytes = measureEvents(input.performanceObserver, () => encodeAnthropicSse(event));
-            if (!await writer.enqueue(bytes)) {
-              return;
-            }
-          }
-        } else if (frame.kind === "done") {
-          for (const event of converter.finish()) {
-            if (!await writer.enqueue(encodeAnthropicSse(event))) {
-              return;
-            }
-          }
-          observeTerminal(input.onTerminal, { kind: "success", usage: observedUsage });
-          await closeStream();
-          writer.close();
-          return;
-        } else {
-          observeTerminal(input.onTerminal, {
-            kind: "failure",
-            error: upstreamStreamEventFailure(),
-          });
-          await closeStream();
-          writer.close();
-          return;
+      } else if (frame.kind === "done") {
+        for (const event of converter.finish()) {
+          yield { kind: "wire", bytes: encodeAnthropicSse(event) };
         }
+        yield { kind: "terminal", value: { kind: "success", usage: observedUsage } };
+        return;
+      } else {
+        yield {
+          kind: "terminal",
+          value: { kind: "failure", error: upstreamStreamEventFailure() },
+          writerMode: "close",
+        };
+        return;
       }
-    } catch (error: unknown) {
-      observeTerminal(input.onTerminal, {
-        kind: "failure",
-        error: normalizeChatStreamFailure(error, input.scope.signal),
-      });
-      await closeStream();
-      writer.abort();
-    } finally {
-      await closeStream();
     }
-  })();
-  input.scope.signal.addEventListener("abort", onAbort, { once: true });
-  return writer.response;
+  } finally {
+    await frames.return(undefined);
+  }
 }
 
 

--- a/src/protocols/openai_chat/endpoint.ts
+++ b/src/protocols/openai_chat/endpoint.ts
@@ -1,6 +1,7 @@
 import type { AccountDirectory, BoundAccount } from "../../accounts/account_directory.js";
 import type { AccountModelPreferences, ModelPreference } from "../../accounts/model_preferences.js";
 import type { BoundCopilot, CopilotBackend } from "../../copilot/backend.js";
+import type { UpstreamByteStream } from "../../copilot/upstream_types.js";
 import { loadCapabilitySnapshot, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
 import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
 import { parseChatSse } from "../../copilot/chat_sse.js";
@@ -23,9 +24,9 @@ import { createRequestAttempt, type RequestAttempt } from "../../gateway/request
 import { createConvertedStreamResponse } from "../../gateway/converted_stream_response.js";
 import {
   boundedCleanup,
-  createExchangeCancellation,
-  createOwnedStreamCleanup,
+  createStreamExecutionResponse,
   withByteIdleDeadlines,
+  type StreamExecutionEmission,
 } from "../../gateway/stream_execution.js";
 import {
   duplicateMemberNames,
@@ -156,9 +157,6 @@ export function createOpenAiChatRoute(dependencies: OpenAiChatRouteDependencies)
         }), "chat");
       }
 
-      const upstreamController = new AbortController();
-      const abortUpstream = (): void => upstreamController.abort();
-      scope.signal.addEventListener("abort", abortUpstream, { once: true });
       const upstream = await openChatStream(copilot, {
         model: prepared.resolvedModel,
         body: prepared.bytes,
@@ -167,54 +165,16 @@ export function createOpenAiChatRoute(dependencies: OpenAiChatRouteDependencies)
         nonstreamBodyBytes: scope.config.limits.nonstreamBodyBytes,
         connectTimeoutMs: scope.config.timeouts.connectMs,
         firstByteTimeoutMs: scope.config.timeouts.firstByteMs,
-        signal: upstreamController.signal,
+        signal: scope.signal,
       });
       if (upstream.status < 200 || upstream.status >= 300) {
         await boundedCleanup(upstream.cancel());
       }
       assertUpstreamSuccess(upstream.status, upstream.headers);
 
-      const cancelExchange = createExchangeCancellation(upstream);
-      const frames = parseChatSse(withByteIdleDeadlines(
-        upstream.bytes,
-        scope.signal,
-        scope.config.timeouts.firstByteMs,
-        scope.config.timeouts.streamIdleMs,
-        cancelExchange,
-      ), scope.config.limits.sseEventBytes);
-      const cleanupUpstream = createOwnedStreamCleanup(upstream, frames, 1_000, cancelExchange);
-      let firstFrames: readonly ChatStreamFrame[];
-      try {
-        firstFrames = await readThroughFirstSemanticChatFrame(
-          frames,
-          scope.signal,
-          scope.config.timeouts.firstByteMs,
-        );
-      } catch (error: unknown) {
-        const failure = normalizeChatStreamFailure(error, scope.signal);
-        if (failure.failure.kind === "upstream_timeout") {
-          upstreamController.abort(failure);
-        }
-        upstreamController.abort();
-        await cleanupUpstream();
-        throw failure;
-      }
-      if (firstFrames.at(-1)?.kind === "error") {
-        upstreamController.abort();
-        await cleanupUpstream();
-        throw upstreamStreamEventFailure();
-      }
-
-      return withUpstreamProtocol(openAiChatStreamResponse({
-        status: upstream.status,
-        signal: scope.signal,
-        requestId: scope.requestId,
-        firstFrames,
-        frames,
-        cleanupUpstream,
+      return withUpstreamProtocol(await openAiChatStreamResponse({
+        upstream,
         scope,
-        abortUpstream,
-        releaseUpstreamAbort: () => scope.signal.removeEventListener("abort", abortUpstream),
         dependencies,
         usage,
       }), "chat");
@@ -557,96 +517,85 @@ function retryAfter(headers: Headers): string | undefined {
   return safeRetryAfter(headers.get("retry-after") ?? undefined);
 }
 
-async function nextFrame(frames: AsyncGenerator<ChatStreamFrame>, signal: AbortSignal): Promise<ChatStreamFrame> {
-  try {
-    const next = await frames.next();
-    if (next.done === true) {
-      throw new GatewayFailureError({
-        kind: "upstream_stream_truncated",
-        source: "parser",
-        phase: "stream",
-      });
-    }
-    return next.value;
-  } catch (error: unknown) {
-    throw normalizeChatStreamFailure(error, signal);
-  }
-}
-
-function openAiChatStreamResponse(input: {
-  readonly status: number;
-  readonly signal: AbortSignal;
-  readonly requestId: string;
-  readonly firstFrames: readonly ChatStreamFrame[];
-  readonly frames: AsyncGenerator<ChatStreamFrame>;
-  readonly cleanupUpstream: () => Promise<void>;
+async function openAiChatStreamResponse(input: {
+  readonly upstream: UpstreamByteStream;
   readonly scope: Readonly<RequestScope>;
-  readonly abortUpstream: () => void;
-  readonly releaseUpstreamAbort: () => void;
   readonly dependencies: OpenAiChatRouteDependencies;
   readonly usage: RequestAttempt;
-}): Response {
-  const pending = [...input.firstFrames];
-  let closed = false;
-  let usage: ChatUsageCounters = {};
-  const closeFrames = async (): Promise<void> => {
-    if (closed) {
-      await input.cleanupUpstream();
-      return;
-    }
-    closed = true;
-    input.releaseUpstreamAbort();
-    await input.cleanupUpstream();
-  };
-  const stream = new ReadableStream<Uint8Array>({
-    async pull(controller): Promise<void> {
-      if (input.signal.aborted) {
-        await closeFrames();
-        controller.close();
-        return;
-      }
-      try {
-        const frame = pending.shift() ?? await nextFrame(input.frames, input.signal);
-        if (frame.kind === "chunk") {
-          measure(input.dependencies.performanceObserver, "event", () => {
-            usage = mergeChatUsageCounters(usage, usageObservationFromPayload(frame.chunk.payload));
-            input.usage.observeUsage(usageNumbers(usage));
-            controller.enqueue(encodeOpenAiChatSseChunk(frame.chunk.payload));
-          });
-          return;
-        }
-        if (frame.kind === "done") {
-          measure(input.dependencies.performanceObserver, "event", () => controller.enqueue(encodeOpenAiChatDone()));
-          input.usage.success(usageNumbers(usage));
-          await closeFrames();
-          controller.close();
-          return;
-        }
-        input.usage.failure(upstreamStreamEventFailure());
-        await closeFrames();
-        controller.error(new Error("upstream stream error", { cause: upstreamStreamEventFailure() }));
-      } catch (error: unknown) {
-        input.usage.failure(normalizeChatStreamFailure(error, input.signal));
-        await closeFrames();
-        controller.error(new Error("upstream stream error", {
-          cause: normalizeChatStreamFailure(error, input.signal),
-        }));
-      }
-    },
-    async cancel(): Promise<void> {
-      await closeFrames();
-    },
-  });
-  input.signal.addEventListener("abort", () => {
-    void closeFrames();
-  }, { once: true });
-  return new Response(stream, {
-    status: input.status,
+}): Promise<Response> {
+  const frames = parseChatSse(withByteIdleDeadlines(
+    input.upstream.bytes,
+    input.scope.signal,
+    input.scope.config.timeouts.firstByteMs,
+    input.scope.config.timeouts.streamIdleMs,
+  ), input.scope.config.limits.sseEventBytes);
+  return await createStreamExecutionResponse({
+    upstream: input.upstream,
+    emissions: chatEmissions(frames, input),
+    signal: input.scope.signal,
+    deliverySignal: input.scope.deliverySignal,
+    status: input.upstream.status,
     headers: {
       "Content-Type": "text/event-stream; charset=utf-8",
-      "x-request-id": input.requestId,
+      "x-request-id": input.scope.requestId,
     },
+    firstEmissionTimeoutMs: input.scope.config.timeouts.firstByteMs,
+    normalizeFailure: (error) => normalizeChatStreamFailure(error, input.scope.signal),
+    presentPostCommitFailure: (error) => new Error("upstream stream error", { cause: error }),
+    onTerminal: (result) => result.kind === "success"
+      ? input.usage.success(usageNumbers(result.value))
+      : input.usage.failure(result.error),
   });
+}
+
+async function* chatEmissions(
+  frames: AsyncGenerator<ChatStreamFrame>,
+  input: Parameters<typeof openAiChatStreamResponse>[0],
+): AsyncIterable<StreamExecutionEmission<ChatUsageCounters>> {
+  const firstFrames = await readThroughFirstSemanticChatFrame(
+    frames,
+    input.scope.signal,
+    input.scope.config.timeouts.firstByteMs,
+  );
+  if (firstFrames.at(-1)?.kind === "error") {
+    throw upstreamStreamEventFailure();
+  }
+  const pending = [...firstFrames];
+  let usage: ChatUsageCounters = {};
+  try {
+    for (;;) {
+      const next = pending.length === 0
+        ? await frames.next()
+        : { done: false as const, value: pending.shift() as ChatStreamFrame };
+      if (next.done === true) {
+        throw new GatewayFailureError({
+          kind: "upstream_stream_truncated",
+          source: "parser",
+          phase: "stream",
+        });
+      }
+      const frame = next.value;
+      if (frame.kind === "chunk") {
+        const bytes = measure(input.dependencies.performanceObserver, "event", () => {
+          usage = mergeChatUsageCounters(usage, usageObservationFromPayload(frame.chunk.payload));
+          input.usage.observeUsage(usageNumbers(usage));
+          return encodeOpenAiChatSseChunk(frame.chunk.payload);
+        });
+        yield { kind: "wire", bytes };
+      } else if (frame.kind === "done") {
+        yield {
+          kind: "wire",
+          bytes: measure(input.dependencies.performanceObserver, "event", encodeOpenAiChatDone),
+        };
+        yield { kind: "terminal", value: usage };
+        return;
+      } else {
+        throw upstreamStreamEventFailure();
+      }
+    }
+  } finally {
+    await frames.return(undefined);
+  }
 }
 
 function usageObservationFromPayload(value: WireJson): ChatUsageCounters {

--- a/src/protocols/openai_chat/endpoint.ts
+++ b/src/protocols/openai_chat/endpoint.ts
@@ -587,7 +587,11 @@ async function* chatEmissions(
           kind: "wire",
           bytes: measure(input.dependencies.performanceObserver, "event", encodeOpenAiChatDone),
         };
-        yield { kind: "terminal", value: usage };
+        yield {
+          kind: "terminal",
+          outcome: { kind: "success", value: usage },
+          writerMode: "close",
+        };
         return;
       } else {
         throw upstreamStreamEventFailure();

--- a/src/protocols/responses/endpoint.ts
+++ b/src/protocols/responses/endpoint.ts
@@ -666,7 +666,11 @@ async function* responseByteEmissions(
     for (;;) {
       const next = await iterator.next();
       if (next.done === true) {
-        yield { kind: "terminal", value: undefined };
+        yield {
+          kind: "terminal",
+          outcome: { kind: "success", value: undefined },
+          writerMode: "close",
+        };
         return;
       }
       yield { kind: "wire", bytes: next.value };

--- a/src/protocols/responses/endpoint.ts
+++ b/src/protocols/responses/endpoint.ts
@@ -19,13 +19,11 @@ import type { RequestScope } from "../../gateway/request_scope.js";
 import { createRequestAttempt, type AttemptUsage, type RequestAttempt } from "../../gateway/request_attempt.js";
 import { createConvertedStreamResponse } from "../../gateway/converted_stream_response.js";
 import { isOpenAiStrictSchemaCompatible } from "../conversion/strict_schema.js";
-import { createStreamResponseWriter } from "../../gateway/stream_response.js";
 import {
   boundedCleanup,
-  createExchangeCancellation,
-  createOwnedStreamCleanup,
-  nextWithDeadline,
+  createStreamExecutionResponse,
   withByteIdleDeadlines,
+  type StreamExecutionEmission,
 } from "../../gateway/stream_execution.js";
 import { duplicateMemberNames, isWireJsonArray, isWireJsonNumber, isWireJsonObject, memberValues, parseWireJson, serializeWireJson, type WireJson, type WireJsonArray, type WireJsonObject } from "../../serialization/wire_json.js";
 import type { UpstreamByteResponse, UpstreamByteStream } from "../../copilot/upstream_types.js";
@@ -328,13 +326,11 @@ async function nativeStreamResponse(
     await boundedCleanup(upstream.cancel());
   }
   assertUpstreamSuccess(upstream);
-  const cancelExchange = createExchangeCancellation(upstream);
   const bytes = withByteIdleDeadlines(
     upstream.bytes,
     scope.signal,
     scope.config.timeouts.firstByteMs,
     scope.config.timeouts.streamIdleMs,
-    cancelExchange,
   );
   const observed = usage.enabled ? createNativeStreamObservation(usage) : undefined;
   return await streamBytesResponse(
@@ -361,7 +357,7 @@ async function nativeStreamResponse(
     upstream,
     scope,
     usage.failure,
-    cancelExchange,
+    () => observed?.finish(),
   );
 }
 
@@ -642,63 +638,44 @@ async function streamBytesResponse(
   upstream: UpstreamByteStream,
   scope: Readonly<RequestScope>,
   onFailure: (error: unknown) => void,
-  cancelExchange = createExchangeCancellation(upstream),
+  onSuccess?: () => void,
 ): Promise<Response> {
-  const iterator = bytes[Symbol.asyncIterator]();
-  const cleanup = createOwnedStreamCleanup(upstream, iterator, 1_000, cancelExchange);
-  let first: IteratorResult<Uint8Array>;
-  try {
-    first = await nextWithDeadline(
-      iterator,
-      scope.config.timeouts.firstByteMs,
-      scope.signal,
-      { source: "parser", phase: "stream" },
-    );
-  } catch (error: unknown) {
-    onFailure(error);
-    await cleanup();
-    throw error;
-  }
-  const writer = createStreamResponseWriter({
+  return await createStreamExecutionResponse({
+    upstream,
+    emissions: responseByteEmissions(bytes),
     signal: scope.signal,
+    deliverySignal: scope.deliverySignal,
     headers: { ...RESPONSES_STREAM_HEADERS, "x-request-id": scope.requestId },
-    onCancel: cleanup,
+    firstEmissionTimeoutMs: scope.config.timeouts.firstByteMs,
+    normalizeFailure: (error) => error,
+    onTerminal: (result) => {
+      if (result.kind === "failure") {
+        onFailure(result.error);
+      } else {
+        onSuccess?.();
+      }
+    },
   });
-  const onAbort = (): void => {
-    onFailure(new GatewayFailureError(failureFromSignal(scope.signal, {
-      source: "parser",
-      phase: "stream",
-    })));
-  };
-  scope.signal.addEventListener("abort", onAbort, { once: true });
-  void (async () => {
-    try {
-      if (first.done !== true && !await writer.enqueue(first.value)) {
-        await cleanup();
+}
+
+async function* responseByteEmissions(
+  bytes: AsyncIterable<Uint8Array>,
+): AsyncIterable<StreamExecutionEmission<undefined>> {
+  const iterator = bytes[Symbol.asyncIterator]();
+  try {
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done === true) {
+        yield { kind: "terminal", value: undefined };
         return;
       }
-      for (;;) {
-        const next = await iterator.next();
-        if (next.done === true) {
-          break;
-        }
-        if (!await writer.enqueue(next.value)) {
-          await cleanup();
-          return;
-        }
-      }
-      await cleanup();
-      writer.close();
-    } catch (error: unknown) {
-      onFailure(error);
-      await cleanup();
-      writer.abort();
-    } finally {
-      scope.signal.removeEventListener("abort", onAbort);
-      await cleanup();
+      yield { kind: "wire", bytes: next.value };
     }
-  })();
-  return writer.response;
+  } finally {
+    if (iterator.return !== undefined) {
+      await iterator.return();
+    }
+  }
 }
 
 function extendedChatRequest(
@@ -1480,16 +1457,23 @@ function nativeOutcome(payload: WireJsonObject): UsageUpdate["outcome"] {
     : "success";
 }
 
-function createNativeStreamObservation(usage: RequestAttempt): { readonly observe: (event: Readonly<WireJsonObject>) => void } {
+function createNativeStreamObservation(usage: RequestAttempt): {
+  readonly observe: (event: Readonly<WireJsonObject>) => void;
+  readonly finish: () => void;
+} {
   let observation: UsageObservation = {};
+  let outcome: UsageUpdate["outcome"] = "success";
   return {
     observe(event) {
       const observed = responsesUsageObservation(event);
       observation = { ...observation, ...observed };
       const type = memberValue(event, "type");
       if (type === "response.completed" || type === "response.incomplete" || type === "response.failed" || type === "error") {
-        usage.finish(nativeOutcome(event), responsesUsageNumbers(observation));
+        outcome = nativeOutcome(event);
       }
+    },
+    finish() {
+      usage.finish(outcome, responsesUsageNumbers(observation));
     },
   };
 }

--- a/tests/contract/anthropic_stream.test.ts
+++ b/tests/contract/anthropic_stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ScriptedCopilotBackend } from "../../src/copilot/backend.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import type { UsageUpdate } from "../../src/telemetry/recorder.js";
@@ -152,6 +152,83 @@ describe("Anthropic stream lifecycle", () => {
     }
   });
 
+  it("preserves native keepalive ordering while finalizing usage and iterator cleanup once", async () => {
+    const usageUpdates: UsageUpdate[] = [];
+    let returned = 0;
+    const records = [
+      ": keepalive\n\n",
+      "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":2,\"output_tokens\":0}}}\n\n",
+      "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+    ];
+    const backend = new ScriptedCopilotBackend({
+      messagesStream: (async function* () {
+        try {
+          for (const record of records) {
+            yield new TextEncoder().encode(record);
+          }
+        } finally {
+          returned += 1;
+        }
+      })(),
+    });
+    const opened = await anthropicGateway({
+      backend,
+      usageUpdates,
+      catalogFetch: nativeMessagesCatalog,
+    });
+    try {
+      const response = await opened.gw.fetch(anthropicRequest({
+        model: "claude-native",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      }));
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe(records.join(""));
+      expect(returned).toBe(1);
+      expect(usageUpdates).toHaveLength(1);
+      expect(usageUpdates).toMatchObject([{ outcome: "success", inputTokens: 2, outputTokens: 0 }]);
+    } finally {
+      await opened.close();
+    }
+  });
+
+  it("times out a native keepalive-only stream before committing any stream bytes", async () => {
+    vi.useFakeTimers();
+    const usageUpdates: UsageUpdate[] = [];
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.timeouts.firstByteMs = 100;
+    runtime.timeouts.streamIdleMs = 60_000;
+    const backend = new ScriptedCopilotBackend({
+      messagesStream: (request) => commentThenStall(request.signal),
+    });
+    const opened = await anthropicGateway({
+      backend,
+      runtime,
+      usageUpdates,
+      catalogFetch: nativeMessagesCatalog,
+    });
+    try {
+      const pending = opened.gw.fetch(anthropicRequest({
+        model: "claude-native",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      }));
+      await vi.advanceTimersByTimeAsync(5_000);
+      const response = await pending;
+      expect(response.status).toBe(504);
+      expect(await response.text()).toBe(
+        "{\"type\":\"error\",\"error\":{\"type\":\"timeout_error\",\"message\":\"upstream timeout\"},\"request_id\":\"req_test_1\"}",
+      );
+      expect(usageUpdates).toHaveLength(1);
+      expect(usageUpdates).toMatchObject([{ outcome: "timeout" }]);
+    } finally {
+      vi.useRealTimers();
+      await opened.close();
+    }
+  });
+
   it("keeps synthetic message_start behind the first semantic deadline", async () => {
     const usageUpdates: UsageUpdate[] = [];
     const runtime = defaultRuntimeConfigSnapshot();
@@ -246,6 +323,19 @@ describe("Anthropic stream lifecycle", () => {
     }
   });
 });
+
+function nativeMessagesCatalog() {
+  return {
+    data: [{
+      id: "claude-native",
+      name: "Claude Native",
+      vendor: "test",
+      model_picker_enabled: true,
+      capabilities: { type: "chat" },
+      model_info: { supported_endpoints: ["/v1/messages"] },
+    }],
+  };
+}
 
 async function* commentThenStall(signal: AbortSignal): AsyncIterable<Uint8Array> {
   yield new TextEncoder().encode(": keepalive\n\n");

--- a/tests/contract/anthropic_stream.test.ts
+++ b/tests/contract/anthropic_stream.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { ScriptedCopilotBackend } from "../../src/copilot/backend.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
+import { createRequestAttempt } from "../../src/gateway/request_attempt.js";
+import { getStreamExecutionHandle } from "../../src/gateway/stream_execution.js";
+import { createAnthropicStreamResponse } from "../../src/protocols/anthropic_messages/stream.js";
 import type { UsageUpdate } from "../../src/telemetry/recorder.js";
 import { anthropicGateway, anthropicRequest, sse } from "./anthropic_harness.js";
 
@@ -114,6 +117,58 @@ describe("Anthropic stream lifecycle", () => {
     } finally {
       await close();
     }
+  });
+
+  it("records an explicit upstream error as failure while gracefully closing unchanged Anthropic bytes", async () => {
+    const usageUpdates: UsageUpdate[] = [];
+    const attempt = createRequestAttempt({
+      requestId: "req_explicit_error",
+      protocol: "anthropic",
+      abortedErrorCount: 1,
+      recorder: { recordUsage: (update) => usageUpdates.push(update) },
+    });
+    const terminalKinds: string[] = [];
+    const signal = new AbortController().signal;
+    const response = await createAnthropicStreamResponse({
+      upstream: {
+        status: 200,
+        headers: new Headers(),
+        bytes: (async function* () {
+          yield sse({ id: "chunk_1", choices: [{ delta: { content: "partial" } }] });
+          yield new TextEncoder().encode("event: error\ndata: {\"error\":{\"message\":\"private\"}}\n\n");
+        })(),
+        cancel: async () => undefined,
+      },
+      model: "gpt",
+      createUuid: () => "00000000-0000-4000-8000-000000000001",
+      scope: {
+        requestId: "req_explicit_error",
+        signal,
+        deliverySignal: signal,
+        config: defaultRuntimeConfigSnapshot(),
+        attempt,
+      },
+      onTerminal: (result) => {
+        terminalKinds.push(result.kind);
+        if (result.kind === "failure") {
+          attempt.failure(result.error);
+        } else {
+          attempt.success();
+        }
+      },
+    });
+    const handle = getStreamExecutionHandle(response);
+
+    expect(await response.text()).toBe([
+      "event: message_start\ndata: {\"type\": \"message_start\", \"message\": {\"id\": \"msg_00000000-0000-4000-8000-000000000001\", \"type\": \"message\", \"role\": \"assistant\", \"content\": [], \"model\": \"gpt\", \"stop_reason\": null, \"stop_sequence\": null, \"usage\": {\"input_tokens\": 0, \"output_tokens\": 0, \"cache_creation_input_tokens\": 0, \"cache_read_input_tokens\": 0}}}\n\n",
+      "event: content_block_start\ndata: {\"type\": \"content_block_start\", \"index\": 0, \"content_block\": {\"type\": \"text\", \"text\": \"\"}}\n\n",
+      "event: content_block_delta\ndata: {\"type\": \"content_block_delta\", \"index\": 0, \"delta\": {\"type\": \"text_delta\", \"text\": \"partial\"}}\n\n",
+    ].join(""));
+    await handle?.completion;
+
+    expect(handle?.cause).toBe("postcommit_failure");
+    expect(terminalKinds).toEqual(["failure"]);
+    expect(usageUpdates).toMatchObject([{ protocol: "anthropic", outcome: "upstream_error" }]);
   });
 
   it("classifies post-commit parser failures without synthetic success terminals", async () => {

--- a/tests/integration/gateway_stream_lifecycle.test.ts
+++ b/tests/integration/gateway_stream_lifecycle.test.ts
@@ -60,7 +60,14 @@ describe("Stream Execution owner", () => {
               nextCalls += 1;
               return nextCalls === 1
                 ? { done: false, value: { kind: "wire", bytes: new TextEncoder().encode("ok") } }
-                : { done: false, value: { kind: "terminal", value: "success" } };
+                : {
+                  done: false,
+                  value: {
+                    kind: "terminal",
+                    outcome: { kind: "success", value: "success" },
+                    writerMode: "close",
+                  },
+                };
             },
           };
         },
@@ -93,7 +100,11 @@ describe("Stream Execution owner", () => {
       emissions: {
         async *[Symbol.asyncIterator]() {
           yield { kind: "wire", bytes: new TextEncoder().encode("ok") } as const;
-          yield { kind: "terminal", value: "success" } as const;
+          yield {
+            kind: "terminal",
+            outcome: { kind: "success", value: "success" },
+            writerMode: "close",
+          } as const;
         },
       },
       signal: new AbortController().signal,
@@ -113,6 +124,56 @@ describe("Stream Execution owner", () => {
     expect(finalized).toBe(1);
   });
 
+  it("settles a terminating late claim after direct delivery without public body demand", async () => {
+    let cancelStarted!: () => void;
+    const started = new Promise<void>((resolve) => { cancelStarted = resolve; });
+    let releaseCancel!: () => void;
+    const cancelBarrier = new Promise<void>((resolve) => { releaseCancel = resolve; });
+    let finalized = 0;
+    const response = await createStreamExecutionResponse({
+      upstream: {
+        status: 200,
+        headers: new Headers(),
+        bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+        cancel: async () => {
+          cancelStarted();
+          await cancelBarrier;
+        },
+      },
+      emissions: {
+        async *[Symbol.asyncIterator]() {
+          yield { kind: "wire", bytes: new TextEncoder().encode("ok") } as const;
+          yield {
+            kind: "terminal",
+            outcome: { kind: "success", value: "success" },
+            writerMode: "close",
+          } as const;
+        },
+      },
+      signal: new AbortController().signal,
+      deliverySignal: new AbortController().signal,
+      onTerminal: () => undefined,
+      normalizeFailure: (error) => error,
+    });
+    const handle = getStreamExecutionHandle(response);
+    const reader = response.body?.getReader();
+    expect(new TextDecoder().decode((await reader?.read())?.value)).toBe("ok");
+    await started;
+    expect(handle?.state).toBe("terminating");
+
+    const delivery = handle?.claimDeliveryAdapter(() => { finalized += 1; });
+    releaseCancel();
+    const completionState = await Promise.race([
+      handle?.completion.then(() => "completed" as const),
+      new Promise<"pending">((resolve) => setImmediate(() => resolve("pending"))),
+    ]);
+    delivery?.settle();
+    await handle?.completion;
+
+    expect(completionState).toBe("completed");
+    expect(finalized).toBe(1);
+  });
+
   it("keeps completion pending until claimed delivery settles and then runs its finalizer", async () => {
     const order: string[] = [];
     const upstream: UpstreamByteStream = {
@@ -124,7 +185,11 @@ describe("Stream Execution owner", () => {
     const emissions: AsyncIterable<StreamExecutionEmission<string>> = {
       async *[Symbol.asyncIterator]() {
         yield { kind: "wire", bytes: new TextEncoder().encode("ok") } as const;
-        yield { kind: "terminal", value: "success" } as const;
+        yield {
+          kind: "terminal",
+          outcome: { kind: "success", value: "success" },
+          writerMode: "close",
+        } as const;
       },
     };
     const response = await createStreamExecutionResponse({
@@ -167,7 +232,14 @@ describe("Stream Execution owner", () => {
         return {
           next: async () => index++ === 0
             ? { done: false, value: { kind: "wire", bytes: new TextEncoder().encode("ok") } }
-            : { done: false, value: { kind: "terminal", value: "success" } },
+            : {
+              done: false,
+              value: {
+                kind: "terminal",
+                outcome: { kind: "success", value: "success" },
+                writerMode: "close",
+              },
+            },
           return: async () => {
             counts.returned += 1;
             return { done: true, value: undefined };
@@ -671,7 +743,11 @@ describe("stream route lifecycle", () => {
           emissions: {
             async *[Symbol.asyncIterator]() {
               yield { kind: "wire", bytes: new TextEncoder().encode("delivered-directly") } as const;
-              yield { kind: "terminal", value: "done" } as const;
+              yield {
+                kind: "terminal",
+                outcome: { kind: "success", value: "done" },
+                writerMode: "close",
+              } as const;
             },
           },
           signal: scope.signal,
@@ -706,6 +782,84 @@ describe("stream route lifecycle", () => {
         expect(listeners.size).toBe(0);
       }
     } finally {
+      await gw.close();
+    }
+  });
+
+  it("releases Hono admission after a terminating late claim without public body demand", async () => {
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.admission.activeMax = 1;
+    runtime.admission.queueMax = 0;
+    let requestCount = 0;
+    let cleanupStarted!: () => void;
+    const started = new Promise<void>((resolve) => { cleanupStarted = resolve; });
+    let releaseCleanup!: () => void;
+    const cleanupBarrier = new Promise<void>((resolve) => { releaseCleanup = resolve; });
+    let ownerCompletion: Promise<void> | undefined;
+    const route: RouteRegistration = {
+      method: "POST",
+      path: "/v1/terminating-late-claim",
+      admission: "inference",
+      body: "none",
+      presentFailure: (failure) => new Response(JSON.stringify({ kind: failure.kind }), {
+        status: failure.kind === "queue_full" ? 503 : 400,
+      }),
+      endpoint: async (_request, scope) => {
+        if (requestCount++ > 0) {
+          return new Response("next");
+        }
+        const response = await createStreamExecutionResponse({
+          upstream: {
+            status: 200,
+            headers: new Headers(),
+            bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+            cancel: async () => {
+              cleanupStarted();
+              await cleanupBarrier;
+            },
+          },
+          emissions: {
+            async *[Symbol.asyncIterator]() {
+              yield { kind: "wire", bytes: new TextEncoder().encode("delivered-directly") } as const;
+              yield {
+                kind: "terminal",
+                outcome: { kind: "success", value: "done" },
+                writerMode: "close",
+              } as const;
+            },
+          },
+          signal: scope.signal,
+          deliverySignal: scope.deliverySignal,
+          headers: { "Content-Type": "text/event-stream" },
+          onTerminal: () => undefined,
+          normalizeFailure: (error) => error,
+        });
+        const reader = response.body!.getReader();
+        expect(new TextDecoder().decode((await reader.read()).value)).toBe("delivered-directly");
+        await started;
+        expect(getStreamExecutionHandle(response)?.state).toBe("terminating");
+        reader.releaseLock();
+        ownerCompletion = getStreamExecutionHandle(response)?.completion;
+        return response;
+      },
+    };
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: "Q:\\tmp-ghc-gateway" }),
+      runtime,
+    }, [route]);
+    try {
+      const first = await gw.fetch(new Request("http://127.0.0.1:31400/v1/terminating-late-claim", { method: "POST" }));
+      expect(first.status).toBe(200);
+      expect(first.body).not.toBeNull();
+
+      releaseCleanup();
+      await ownerCompletion;
+
+      const second = await gw.fetch(new Request("http://127.0.0.1:31400/v1/terminating-late-claim", { method: "POST" }));
+      expect(second.status).toBe(200);
+      expect(await second.text()).toBe("next");
+    } finally {
+      releaseCleanup();
       await gw.close();
     }
   });
@@ -768,7 +922,14 @@ describe("stream route lifecycle", () => {
                   if (index === 0) {
                     return await blockedNext;
                   }
-                  return { done: false, value: { kind: "terminal", value: "done" } };
+                  return {
+                    done: false,
+                    value: {
+                      kind: "terminal",
+                      outcome: { kind: "success", value: "done" },
+                      writerMode: "close",
+                    },
+                  };
                 },
                 return: async () => {
                   counts.returned += 1;

--- a/tests/integration/gateway_stream_lifecycle.test.ts
+++ b/tests/integration/gateway_stream_lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
 import { createGateway } from "../../src/gateway/create_gateway.js";
@@ -17,8 +17,7 @@ import type { UsageUpdate } from "../../src/telemetry/recorder.js";
 
 describe("stream writer", () => {
   it("is pull-based, commits on first body byte, and writes nothing after abort", async () => {
-    const abort = new AbortController();
-    const writer = createStreamResponseWriter({ signal: abort.signal });
+    const writer = createStreamResponseWriter({});
     expect(writer.committed).toBe(false);
 
     const first = new Uint8Array([1, 2, 3]);
@@ -36,7 +35,7 @@ describe("stream writer", () => {
     expect(writer.committed).toBe(true);
     expect(chunk?.value).toEqual(first);
 
-    abort.abort();
+    writer.abort();
     const rejected = await writer.enqueue(new Uint8Array([9]));
     expect(rejected).toBe(false);
     writer.close();
@@ -44,6 +43,46 @@ describe("stream writer", () => {
 });
 
 describe("Stream Execution owner", () => {
+  it("keeps completion pending until claimed delivery settles and then runs its finalizer", async () => {
+    const order: string[] = [];
+    const upstream: UpstreamByteStream = {
+      status: 200,
+      headers: new Headers(),
+      bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+      cancel: async () => { order.push("upstream"); },
+    };
+    const emissions: AsyncIterable<StreamExecutionEmission<string>> = {
+      async *[Symbol.asyncIterator]() {
+        yield { kind: "wire", bytes: new TextEncoder().encode("ok") } as const;
+        yield { kind: "terminal", value: "success" } as const;
+      },
+    };
+    const response = await createStreamExecutionResponse({
+      upstream,
+      emissions,
+      signal: new AbortController().signal,
+      deliverySignal: new AbortController().signal,
+      onTerminal: () => { order.push("terminal"); },
+      normalizeFailure: (error) => error,
+    });
+    const handle = getStreamExecutionHandle(response);
+    const delivery = handle?.claimDeliveryAdapter(() => { order.push("finalizer"); });
+    const reader = response.body?.getReader();
+    expect(new TextDecoder().decode((await reader?.read())?.value)).toBe("ok");
+    delivery?.markDelivered();
+
+    let completed = false;
+    void handle?.completion.then(() => { completed = true; });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(completed).toBe(false);
+    expect(order).not.toContain("finalizer");
+
+    delivery?.settle();
+    await handle?.completion;
+    expect(order.at(-1)).toBe("finalizer");
+  });
+
   it("tracks semantic terminal and resource cleanup exactly once", async () => {
     const counts = { cancel: 0, returned: 0, terminal: 0 };
     const upstream: UpstreamByteStream = {
@@ -134,6 +173,56 @@ describe("Stream Execution owner", () => {
     expect(counts).toEqual({ cancel: 1, returned: 1, terminal: 1 });
   });
 
+  it("lets a claimed delivery settle before reader cancellation without deadlocking completion", async () => {
+    let releaseNext: ((value: IteratorResult<StreamExecutionEmission<string>>) => void) | undefined;
+    const blockedNext = new Promise<IteratorResult<StreamExecutionEmission<string>>>((resolve) => {
+      releaseNext = resolve;
+    });
+    const counts = { cancel: 0, returned: 0, terminal: 0, finalized: 0 };
+    const upstream: UpstreamByteStream = {
+      status: 200,
+      headers: new Headers(),
+      bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+      cancel: async () => { counts.cancel += 1; },
+    };
+    const response = await createStreamExecutionResponse({
+      upstream,
+      emissions: {
+        [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+          let emitted = false;
+          return {
+            next: async () => {
+              if (!emitted) {
+                emitted = true;
+                return { done: false, value: { kind: "wire", bytes: new TextEncoder().encode("prefix") } };
+              }
+              return await blockedNext;
+            },
+            return: async () => {
+              counts.returned += 1;
+              releaseNext?.({ done: true, value: undefined });
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      },
+      signal: new AbortController().signal,
+      deliverySignal: new AbortController().signal,
+      onTerminal: () => { counts.terminal += 1; },
+      normalizeFailure: (error) => error,
+    });
+    const handle = getStreamExecutionHandle(response);
+    const delivery = handle?.claimDeliveryAdapter(() => { counts.finalized += 1; });
+    const reader = response.body?.getReader();
+    expect(new TextDecoder().decode((await reader?.read())?.value)).toBe("prefix");
+    delivery?.markDelivered();
+
+    delivery?.settle();
+    await reader?.cancel();
+    await handle?.completion;
+    expect(counts).toEqual({ cancel: 1, returned: 1, terminal: 1, finalized: 1 });
+  });
+
   it("classifies response reader cancellation separately and tracks the stopped producer", async () => {
     let releaseNext: ((value: IteratorResult<StreamExecutionEmission<string>>) => void) | undefined;
     const blockedNext = new Promise<IteratorResult<StreamExecutionEmission<string>>>((resolve) => {
@@ -183,6 +272,35 @@ describe("Stream Execution owner", () => {
     expect(counts).toEqual({ cancel: 1, returned: 1, terminal: 1 });
   });
 
+  it("classifies a delivery signal aborted before registration and still completes cleanup", async () => {
+    const deliveryAbort = new AbortController();
+    deliveryAbort.abort();
+    let cancelled = 0;
+    const upstream: UpstreamByteStream = {
+      status: 200,
+      headers: new Headers(),
+      bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+      cancel: async () => { cancelled += 1; },
+    };
+    const emissions: AsyncIterable<StreamExecutionEmission<string>> = {
+      [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+        return {
+          next: async () => { throw new Error("producer must not start"); },
+        };
+      },
+    };
+
+    await expect(createStreamExecutionResponse({
+      upstream,
+      emissions,
+      signal: new AbortController().signal,
+      deliverySignal: deliveryAbort.signal,
+      onTerminal: () => undefined,
+      normalizeFailure: (error) => error,
+    })).rejects.toMatchObject({ failure: { kind: "aborted" } });
+    expect(cancelled).toBe(1);
+  });
+
   it("classifies a signal aborted before registration and still completes cleanup", async () => {
     const abort = new AbortController();
     abort.abort();
@@ -221,9 +339,8 @@ describe("stream route lifecycle", () => {
       admission: "none",
       body: "none",
       presentFailure: (failure) => new Response(JSON.stringify({ kind: failure.kind }), { status: 400 }),
-      endpoint: async (_request, scope) => {
+      endpoint: async (_request, _scope) => {
         const writer = createStreamResponseWriter({
-          signal: scope.signal,
           headers: { "Content-Type": "text/event-stream" },
         });
         expect(writer.committed).toBe(false);
@@ -442,6 +559,113 @@ describe("stream route lifecycle", () => {
     expect(closeSawCleanup).toBe(true);
   });
 
+  it("settles response cancellation through the owner before releasing admission", async () => {
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.admission.activeMax = 1;
+    runtime.admission.queueMax = 0;
+    let requestCount = 0;
+    let firstCancelStarted!: () => void;
+    const cancelStarted = new Promise<void>((resolve) => { firstCancelStarted = resolve; });
+    let releaseFirstCancel!: () => void;
+    const firstCancelBarrier = new Promise<void>((resolve) => { releaseFirstCancel = resolve; });
+    const counts = { cancel: 0, returned: 0, terminal: 0 };
+    const deliveryListenerRemovals: number[] = [];
+    const route: RouteRegistration = {
+      method: "POST",
+      path: "/v1/owned-cancel",
+      admission: "inference",
+      body: "none",
+      presentFailure: (failure) => new Response(JSON.stringify({ kind: failure.kind }), {
+        status: failure.kind === "queue_full" ? 503 : 400,
+      }),
+      endpoint: async (_request, scope) => {
+        const index = requestCount++;
+        deliveryListenerRemovals[index] = 0;
+        const removeDeliveryListener = scope.deliverySignal.removeEventListener.bind(scope.deliverySignal);
+        vi.spyOn(scope.deliverySignal, "removeEventListener").mockImplementation((type, listener, options) => {
+          if (type === "abort") {
+            deliveryListenerRemovals[index] = (deliveryListenerRemovals[index] ?? 0) + 1;
+          }
+          removeDeliveryListener(type, listener, options);
+        });
+        let releaseNext: ((value: IteratorResult<StreamExecutionEmission<string>>) => void) | undefined;
+        const blockedNext = new Promise<IteratorResult<StreamExecutionEmission<string>>>((resolve) => {
+          releaseNext = resolve;
+        });
+        const response = await createStreamExecutionResponse({
+          upstream: {
+            status: 200,
+            headers: new Headers(),
+            bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+            cancel: async () => {
+              counts.cancel += 1;
+              if (index === 0) {
+                firstCancelStarted();
+                await firstCancelBarrier;
+              }
+            },
+          },
+          emissions: {
+            [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+              let emitted = false;
+              return {
+                next: async () => {
+                  if (!emitted) {
+                    emitted = true;
+                    return { done: false, value: { kind: "wire", bytes: new TextEncoder().encode("open") } };
+                  }
+                  if (index === 0) {
+                    return await blockedNext;
+                  }
+                  return { done: false, value: { kind: "terminal", value: "done" } };
+                },
+                return: async () => {
+                  counts.returned += 1;
+                  releaseNext?.({ done: true, value: undefined });
+                  return { done: true, value: undefined };
+                },
+              };
+            },
+          },
+          signal: scope.signal,
+          deliverySignal: scope.deliverySignal,
+          headers: { "Content-Type": "text/event-stream" },
+          onTerminal: () => { counts.terminal += 1; },
+          normalizeFailure: (error) => error,
+        });
+        return response;
+      },
+    };
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: "Q:\\tmp-ghc-gateway" }),
+      runtime,
+    }, [route]);
+    try {
+      const first = await gw.fetch(new Request("http://127.0.0.1:31400/v1/owned-cancel", { method: "POST" }));
+      const reader = first.body?.getReader();
+      expect(new TextDecoder().decode((await reader?.read())?.value)).toBe("open");
+      const cancelling = reader?.cancel();
+      await cancelStarted;
+
+      const blocked = await gw.fetch(new Request("http://127.0.0.1:31400/v1/owned-cancel", { method: "POST" }));
+      expect(blocked.status).toBe(503);
+      releaseFirstCancel();
+      await cancelling;
+
+      const after = await gw.fetch(new Request("http://127.0.0.1:31400/v1/owned-cancel", { method: "POST" }));
+      expect(after.status).toBe(200);
+      expect(await after.text()).toBe("open");
+      expect(counts).toEqual({ cancel: 2, returned: 2, terminal: 2 });
+      expect(deliveryListenerRemovals).toHaveLength(2);
+      for (const removals of deliveryListenerRemovals) {
+        expect(removals).toBeGreaterThanOrEqual(2);
+      }
+    } finally {
+      releaseFirstCancel();
+      await gw.close();
+    }
+  });
+
   it("holds the inference slot until the stream body ends", async () => {
     const writers: ReturnType<typeof createStreamResponseWriter>[] = [];
     const runtime = defaultRuntimeConfigSnapshot();
@@ -456,8 +680,8 @@ describe("stream route lifecycle", () => {
         status: failure.kind === "queue_full" ? 503 : 400,
         headers: { "Content-Type": "application/json; charset=utf-8" },
       }),
-      endpoint: async (_request, scope) => {
-        const writer = createStreamResponseWriter({ signal: scope.signal });
+      endpoint: async (_request, _scope) => {
+        const writer = createStreamResponseWriter({});
         writers.push(writer);
         return writer.response;
       },

--- a/tests/integration/gateway_stream_lifecycle.test.ts
+++ b/tests/integration/gateway_stream_lifecycle.test.ts
@@ -3,7 +3,13 @@ import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
 import { createGateway } from "../../src/gateway/create_gateway.js";
 import { createStreamResponseWriter } from "../../src/gateway/stream_response.js";
+import {
+  createStreamExecutionResponse,
+  getStreamExecutionHandle,
+  type StreamExecutionEmission,
+} from "../../src/gateway/stream_execution.js";
 import { armTimeout } from "../../src/gateway/timeouts.js";
+import type { UpstreamByteStream } from "../../src/copilot/upstream_types.js";
 import { defaultDelay } from "../../src/gateway/admission.js";
 import type { RouteRegistration } from "../../src/gateway/hono_app.js";
 import { createRequestAttempt } from "../../src/gateway/request_attempt.js";
@@ -15,12 +21,18 @@ describe("stream writer", () => {
     const writer = createStreamResponseWriter({ signal: abort.signal });
     expect(writer.committed).toBe(false);
 
+    const first = new Uint8Array([1, 2, 3]);
+    let enqueueSettled = false;
+    const accepted = writer.enqueue(first).then((value) => {
+      enqueueSettled = true;
+      return value;
+    });
+    await Promise.resolve();
+    expect(enqueueSettled).toBe(false);
     const reader = writer.response.body?.getReader();
     expect(reader).toBeDefined();
-    const first = new Uint8Array([1, 2, 3]);
-    const accepted = await writer.enqueue(first);
-    expect(accepted).toBe(true);
     const chunk = await reader?.read();
+    expect(await accepted).toBe(true);
     expect(writer.committed).toBe(true);
     expect(chunk?.value).toEqual(first);
 
@@ -28,6 +40,176 @@ describe("stream writer", () => {
     const rejected = await writer.enqueue(new Uint8Array([9]));
     expect(rejected).toBe(false);
     writer.close();
+  });
+});
+
+describe("Stream Execution owner", () => {
+  it("tracks semantic terminal and resource cleanup exactly once", async () => {
+    const counts = { cancel: 0, returned: 0, terminal: 0 };
+    const upstream: UpstreamByteStream = {
+      status: 200,
+      headers: new Headers(),
+      bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+      cancel: async () => { counts.cancel += 1; },
+    };
+    const emissions: AsyncIterable<StreamExecutionEmission<string>> = {
+      [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+        let index = 0;
+        return {
+          next: async () => index++ === 0
+            ? { done: false, value: { kind: "wire", bytes: new TextEncoder().encode("ok") } }
+            : { done: false, value: { kind: "terminal", value: "success" } },
+          return: async () => {
+            counts.returned += 1;
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+
+    const response = await createStreamExecutionResponse({
+      upstream,
+      emissions,
+      signal: new AbortController().signal,
+      deliverySignal: new AbortController().signal,
+      headers: { "Content-Type": "text/event-stream" },
+      onTerminal: () => { counts.terminal += 1; },
+      normalizeFailure: (error) => error,
+    });
+    const handle = getStreamExecutionHandle(response);
+    expect(handle).toBeDefined();
+    expect(await response.text()).toBe("ok");
+    await handle?.completion;
+
+    expect(handle?.state).toBe("completed");
+    expect(handle?.cause).toBe("semantic_success");
+    expect(counts).toEqual({ cancel: 1, returned: 1, terminal: 1 });
+  });
+
+  it("aborts a committed stream once and continues cleanup after cancellation rejects", async () => {
+    const counts = { cancel: 0, returned: 0, terminal: 0 };
+    const upstream: UpstreamByteStream = {
+      status: 200,
+      headers: new Headers(),
+      bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+      cancel: async () => {
+        counts.cancel += 1;
+        throw new Error("cancel failed");
+      },
+    };
+    const emissions: AsyncIterable<StreamExecutionEmission<string>> = {
+      [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+        let emitted = false;
+        return {
+          next: async () => {
+            if (!emitted) {
+              emitted = true;
+              return { done: false, value: { kind: "wire", bytes: new TextEncoder().encode("prefix") } };
+            }
+            throw new Error("parse failed");
+          },
+          return: async () => {
+            counts.returned += 1;
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+    const response = await createStreamExecutionResponse({
+      upstream,
+      emissions,
+      signal: new AbortController().signal,
+      deliverySignal: new AbortController().signal,
+      onTerminal: () => { counts.terminal += 1; },
+      normalizeFailure: (error) => error,
+      presentPostCommitFailure: (error) => new Error("stream error", { cause: error }),
+    });
+    const handle = getStreamExecutionHandle(response);
+    const reader = response.body?.getReader();
+    expect(new TextDecoder().decode((await reader?.read())?.value)).toBe("prefix");
+    await expect(reader?.read()).rejects.toThrow("stream error");
+    await handle?.completion;
+
+    expect(handle?.cause).toBe("postcommit_failure");
+    expect(counts).toEqual({ cancel: 1, returned: 1, terminal: 1 });
+  });
+
+  it("classifies response reader cancellation separately and tracks the stopped producer", async () => {
+    let releaseNext: ((value: IteratorResult<StreamExecutionEmission<string>>) => void) | undefined;
+    const blockedNext = new Promise<IteratorResult<StreamExecutionEmission<string>>>((resolve) => {
+      releaseNext = resolve;
+    });
+    const counts = { cancel: 0, returned: 0, terminal: 0 };
+    const upstream: UpstreamByteStream = {
+      status: 200,
+      headers: new Headers(),
+      bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+      cancel: async () => { counts.cancel += 1; },
+    };
+    const emissions: AsyncIterable<StreamExecutionEmission<string>> = {
+      [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+        let emitted = false;
+        return {
+          next: async () => {
+            if (!emitted) {
+              emitted = true;
+              return { done: false, value: { kind: "wire", bytes: new TextEncoder().encode("prefix") } };
+            }
+            return await blockedNext;
+          },
+          return: async () => {
+            counts.returned += 1;
+            releaseNext?.({ done: true, value: undefined });
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+    const response = await createStreamExecutionResponse({
+      upstream,
+      emissions,
+      signal: new AbortController().signal,
+      deliverySignal: new AbortController().signal,
+      onTerminal: () => { counts.terminal += 1; },
+      normalizeFailure: (error) => error,
+    });
+    const handle = getStreamExecutionHandle(response);
+    const reader = response.body?.getReader();
+    expect(new TextDecoder().decode((await reader?.read())?.value)).toBe("prefix");
+    await reader?.cancel();
+    await handle?.completion;
+
+    expect(handle?.cause).toBe("client_cancel");
+    expect(counts).toEqual({ cancel: 1, returned: 1, terminal: 1 });
+  });
+
+  it("classifies a signal aborted before registration and still completes cleanup", async () => {
+    const abort = new AbortController();
+    abort.abort();
+    let cancelled = 0;
+    const upstream: UpstreamByteStream = {
+      status: 200,
+      headers: new Headers(),
+      bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+      cancel: async () => { cancelled += 1; },
+    };
+    const emissions: AsyncIterable<StreamExecutionEmission<string>> = {
+      [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+        return {
+          next: async () => { throw new Error("producer must not start"); },
+        };
+      },
+    };
+
+    await expect(createStreamExecutionResponse({
+      upstream,
+      emissions,
+      signal: abort.signal,
+      deliverySignal: new AbortController().signal,
+      onTerminal: () => undefined,
+      normalizeFailure: (error) => error,
+    })).rejects.toMatchObject({ failure: { kind: "aborted" } });
+    expect(cancelled).toBe(1);
   });
 });
 
@@ -155,6 +337,79 @@ describe("stream route lifecycle", () => {
     } finally {
       await gw.close();
     }
+  });
+
+  it("waits for the claimed Stream Execution barrier before application close hooks", async () => {
+    let releaseCancel: (() => void) | undefined;
+    const cancelBarrier = new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    });
+    let closeSawCleanup = false;
+    let cleanupComplete = false;
+    const route: RouteRegistration = {
+      method: "POST",
+      path: "/v1/owned-cleanup-barrier",
+      admission: "inference",
+      body: "none",
+      presentFailure: () => new Response("{}"),
+      endpoint: async (_request, scope) => {
+        const upstream: UpstreamByteStream = {
+          status: 200,
+          headers: new Headers(),
+          bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+          cancel: async () => {
+            await cancelBarrier;
+            cleanupComplete = true;
+          },
+        };
+        let releaseNext: ((value: IteratorResult<StreamExecutionEmission<string>>) => void) | undefined;
+        const blockedNext = new Promise<IteratorResult<StreamExecutionEmission<string>>>((resolve) => {
+          releaseNext = resolve;
+        });
+        return await createStreamExecutionResponse({
+          upstream,
+          emissions: {
+            [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+              let emitted = false;
+              return {
+                next: async () => {
+                  if (!emitted) {
+                    emitted = true;
+                    return { done: false, value: { kind: "wire", bytes: new TextEncoder().encode("open") } };
+                  }
+                  return await blockedNext;
+                },
+                return: async () => {
+                  releaseNext?.({ done: true, value: undefined });
+                  return { done: true, value: undefined };
+                },
+              };
+            },
+          },
+          signal: scope.signal,
+          deliverySignal: scope.deliverySignal,
+          onTerminal: () => undefined,
+          normalizeFailure: (error) => error,
+        });
+      },
+    };
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: "Q:\\tmp-ghc-gateway" }),
+      runtime: defaultRuntimeConfigSnapshot(),
+    }, [route], {
+      onClose: () => {
+        closeSawCleanup = cleanupComplete;
+      },
+    });
+    const response = await gw.fetch(new Request("http://127.0.0.1:31400/v1/owned-cleanup-barrier", { method: "POST" }));
+    expect(response.body).not.toBeNull();
+    let closeSettled = false;
+    const closing = gw.close().then(() => { closeSettled = true; });
+    await Promise.resolve();
+    expect(closeSettled).toBe(false);
+    releaseCancel?.();
+    await closing;
+    expect(closeSawCleanup).toBe(true);
   });
 
   it("waits for response cancellation cleanup before application close hooks", async () => {

--- a/tests/integration/gateway_stream_lifecycle.test.ts
+++ b/tests/integration/gateway_stream_lifecycle.test.ts
@@ -43,6 +43,76 @@ describe("stream writer", () => {
 });
 
 describe("Stream Execution owner", () => {
+  it("does not produce past the host claim window without real body demand", async () => {
+    let nextCalls = 0;
+    let terminalCalls = 0;
+    const response = await createStreamExecutionResponse({
+      upstream: {
+        status: 200,
+        headers: new Headers(),
+        bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+        cancel: async () => undefined,
+      },
+      emissions: {
+        [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+          return {
+            next: async () => {
+              nextCalls += 1;
+              return nextCalls === 1
+                ? { done: false, value: { kind: "wire", bytes: new TextEncoder().encode("ok") } }
+                : { done: false, value: { kind: "terminal", value: "success" } };
+            },
+          };
+        },
+      },
+      signal: new AbortController().signal,
+      deliverySignal: new AbortController().signal,
+      onTerminal: () => { terminalCalls += 1; },
+      normalizeFailure: (error) => error,
+    });
+    const handle = getStreamExecutionHandle(response);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(nextCalls).toBe(1);
+    expect(terminalCalls).toBe(0);
+    expect(handle?.state).toBe("precommit");
+
+    await handle?.abort("shutdown");
+  });
+
+  it("runs a host finalizer exactly once when direct delivery completes before a late claim", async () => {
+    let finalized = 0;
+    const response = await createStreamExecutionResponse({
+      upstream: {
+        status: 200,
+        headers: new Headers(),
+        bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+        cancel: async () => undefined,
+      },
+      emissions: {
+        async *[Symbol.asyncIterator]() {
+          yield { kind: "wire", bytes: new TextEncoder().encode("ok") } as const;
+          yield { kind: "terminal", value: "success" } as const;
+        },
+      },
+      signal: new AbortController().signal,
+      deliverySignal: new AbortController().signal,
+      onTerminal: () => undefined,
+      normalizeFailure: (error) => error,
+    });
+    const handle = getStreamExecutionHandle(response);
+
+    expect(await response.text()).toBe("ok");
+    await handle?.completion;
+    expect(handle?.state).toBe("completed");
+
+    const delivery = handle?.claimDeliveryAdapter(() => { finalized += 1; });
+    expect(finalized).toBe(1);
+    delivery?.settle();
+    expect(finalized).toBe(1);
+  });
+
   it("keeps completion pending until claimed delivery settles and then runs its finalizer", async () => {
     const order: string[] = [];
     const upstream: UpstreamByteStream = {
@@ -557,6 +627,87 @@ describe("stream route lifecycle", () => {
     expect(response.body).not.toBeNull();
     await gw.close();
     expect(closeSawCleanup).toBe(true);
+  });
+
+  it("releases admission and listeners when direct delivery completes before the public route claims ownership", async () => {
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.admission.activeMax = 1;
+    runtime.admission.queueMax = 0;
+    const activeDeliveryListeners: Array<Set<EventListenerOrEventListenerObject>> = [];
+    let requestCount = 0;
+    const route: RouteRegistration = {
+      method: "POST",
+      path: "/v1/late-completion",
+      admission: "inference",
+      body: "none",
+      presentFailure: (failure) => new Response(JSON.stringify({ kind: failure.kind }), {
+        status: failure.kind === "queue_full" ? 503 : 400,
+      }),
+      endpoint: async (_request, scope) => {
+        const index = requestCount++;
+        const listeners = new Set<EventListenerOrEventListenerObject>();
+        activeDeliveryListeners[index] = listeners;
+        const addDeliveryListener = scope.deliverySignal.addEventListener.bind(scope.deliverySignal);
+        vi.spyOn(scope.deliverySignal, "addEventListener").mockImplementation((type, listener, options) => {
+          if (type === "abort") {
+            listeners.add(listener);
+          }
+          addDeliveryListener(type, listener, options);
+        });
+        const removeDeliveryListener = scope.deliverySignal.removeEventListener.bind(scope.deliverySignal);
+        vi.spyOn(scope.deliverySignal, "removeEventListener").mockImplementation((type, listener, options) => {
+          if (type === "abort") {
+            listeners.delete(listener);
+          }
+          removeDeliveryListener(type, listener, options);
+        });
+        const response = await createStreamExecutionResponse({
+          upstream: {
+            status: 200,
+            headers: new Headers(),
+            bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+            cancel: async () => undefined,
+          },
+          emissions: {
+            async *[Symbol.asyncIterator]() {
+              yield { kind: "wire", bytes: new TextEncoder().encode("delivered-directly") } as const;
+              yield { kind: "terminal", value: "done" } as const;
+            },
+          },
+          signal: scope.signal,
+          deliverySignal: scope.deliverySignal,
+          headers: { "Content-Type": "text/event-stream" },
+          onTerminal: () => undefined,
+          normalizeFailure: (error) => error,
+        });
+        const reader = response.body!.getReader();
+        const first = await reader.read();
+        expect(new TextDecoder().decode(first.value)).toBe("delivered-directly");
+        expect((await reader.read()).done).toBe(true);
+        reader.releaseLock();
+        await getStreamExecutionHandle(response)?.completion;
+        return response;
+      },
+    };
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: "Q:\\tmp-ghc-gateway" }),
+      runtime,
+    }, [route]);
+    try {
+      const first = await gw.fetch(new Request("http://127.0.0.1:31400/v1/late-completion", { method: "POST" }));
+      expect(first.status).toBe(200);
+      expect(await first.text()).toBe("");
+
+      const second = await gw.fetch(new Request("http://127.0.0.1:31400/v1/late-completion", { method: "POST" }));
+      expect(second.status).toBe(200);
+      expect(await second.text()).toBe("");
+      expect(activeDeliveryListeners).toHaveLength(2);
+      for (const listeners of activeDeliveryListeners) {
+        expect(listeners.size).toBe(0);
+      }
+    } finally {
+      await gw.close();
+    }
   });
 
   it("settles response cancellation through the owner before releasing admission", async () => {

--- a/tests/integration/responses_endpoint_stream.test.ts
+++ b/tests/integration/responses_endpoint_stream.test.ts
@@ -4,7 +4,15 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { AccountDirectory } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
-import { ScriptedCopilotBackend } from "../../src/copilot/backend.js";
+import {
+  ScriptedCopilotBackend,
+  type BoundCopilot,
+  type CopilotBackend,
+} from "../../src/copilot/backend.js";
+import type {
+  NativeResponsesUpstreamRequest,
+  UpstreamByteStream,
+} from "../../src/copilot/upstream_types.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
@@ -20,6 +28,7 @@ import type {
   ResponsesHistoryRecord,
   ResponsesReceiptRecord,
 } from "../../src/protocols/responses/history.js";
+import type { UsageUpdate } from "../../src/telemetry/recorder.js";
 
 const nowMs = (): number => 1_700_000_000_000;
 
@@ -29,7 +38,10 @@ class RecordingHistory implements ResponsesHistory {
   readonly checkpointStates: Array<"partial" | "complete"> = [];
   readonly receiptStates: Array<"route_only" | "partial" | "complete"> = [];
 
-  constructor(private readonly failAt?: "receipt" | "checkpoint") {}
+  constructor(
+    private readonly failAt?: "receipt" | "checkpoint",
+    private readonly beforeCheckpoint?: () => Promise<void>,
+  ) {}
 
   async resolve() {
     return { kind: "none" } as const;
@@ -52,6 +64,7 @@ class RecordingHistory implements ResponsesHistory {
     _ownership: Parameters<ResponsesHistory["recordCheckpoint"]>[1],
     checkpointState: "partial" | "complete",
   ): Promise<void> {
+    await this.beforeCheckpoint?.();
     if (this.failAt === "checkpoint") {
       throw new Error("synthetic checkpoint failure");
     }
@@ -61,8 +74,87 @@ class RecordingHistory implements ResponsesHistory {
 }
 
 describe("Responses endpoint stream integration", () => {
-  it("commits bridge stream checkpoints before completed bytes reach the caller", async () => {
+  it("owns native terminal cleanup and admission through the public response body", async () => {
+    const wire = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_native\",\"output\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":2,\"input_tokens_details\":{\"cached_tokens\":1}}}}\n\n";
+    const cancelStarted = deferred<void>();
+    const releaseCancel = deferred<void>();
+    const counts = { cancel: 0, returned: 0 };
+    const source = singleOwnedChunk(bytes(wire), () => {
+      counts.returned += 1;
+    });
+    let streams = 0;
+    const backend = withResponsesStream(
+      new ScriptedCopilotBackend({ responsesStream: [bytes(wire)] }),
+      async (request, fallback) => {
+        streams += 1;
+        if (streams > 1) {
+          return await fallback.openResponsesStream(request);
+        }
+        return {
+          status: 200,
+          headers: new Headers({ "content-type": "text/event-stream" }),
+          bytes: source,
+          cancel: async () => {
+            counts.cancel += 1;
+            cancelStarted.resolve();
+            await releaseCancel.promise;
+          },
+        };
+      },
+    );
     const history = new RecordingHistory();
+    const usageUpdates: UsageUpdate[] = [];
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.admission.activeMax = 1;
+    runtime.admission.queueMax = 0;
+    const opened = await streamGateway(history, backend, { runtime, usageUpdates });
+    try {
+      const response = await opened.gateway.fetch(responsesRequest("native"));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+      expect(response.headers.get("cache-control")).toBe("no-cache");
+      expect(response.headers.get("x-request-id")).toBe("req_stream");
+      expect(response.headers.get("x-ghcg-upstream-protocol")).toBe("responses");
+
+      const delivered = response.text();
+      await cancelStarted.promise;
+      expect(counts).toEqual({ cancel: 1, returned: 1 });
+      const held = await opened.gateway.fetch(responsesRequest("native"));
+      expect(held.status).toBe(503);
+      await held.arrayBuffer();
+
+      releaseCancel.resolve();
+      expect(await delivered).toBe(wire);
+      expect(counts).toEqual({ cancel: 1, returned: 1 });
+      expect(usageUpdates.filter((update) => update.outcome === "success")).toMatchObject([{
+        protocol: "openai_responses_native",
+        outcome: "success",
+        inputTokens: 5,
+        outputTokens: 2,
+        cacheTokens: 1,
+      }]);
+
+      const afterRelease = await opened.gateway.fetch(responsesRequest("native"));
+      expect(afterRelease.status).toBe(200);
+      expect(await afterRelease.text()).toBe(wire);
+      expect(usageUpdates.filter((update) => update.outcome === "success")).toHaveLength(2);
+    } finally {
+      releaseCancel.resolve();
+      await opened.close();
+    }
+  });
+
+  it("commits bridge stream checkpoints before completed bytes reach the caller", async () => {
+    const checkpointStarted = deferred<void>();
+    const releaseCheckpoint = deferred<void>();
+    let checkpointCalls = 0;
+    const history = new RecordingHistory(undefined, async () => {
+      checkpointCalls += 1;
+      if (checkpointCalls === 1) {
+        checkpointStarted.resolve();
+        await releaseCheckpoint.promise;
+      }
+    });
     const backend = new ScriptedCopilotBackend({
       chatStream: [
         bytes("data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\n"),
@@ -76,22 +168,121 @@ describe("Responses endpoint stream integration", () => {
       if (reader === undefined) {
         throw new Error("expected response body");
       }
-      let seenCompletedItem = false;
-      for (;;) {
+      let delivered = "";
+      const consumption = (async () => {
+        for (;;) {
+          const next = await reader.read();
+          if (next.done) {
+            return;
+          }
+          delivered += new TextDecoder().decode(next.value, { stream: true });
+        }
+      })();
+
+      await checkpointStarted.promise;
+      expect(history.records).toHaveLength(0);
+      expect(delivered).not.toContain("response.output_text.done");
+      expect(delivered).not.toContain("response.output_item.done");
+      expect(delivered).not.toContain("response.completed");
+
+      releaseCheckpoint.resolve();
+      await consumption;
+      expect(history.receiptStates).toEqual(["route_only"]);
+      expect(history.checkpointStates).toEqual(["complete"]);
+      expect(history.records).toHaveLength(1);
+      expect(delivered).toContain("response.output_item.done");
+      expect(delivered).toContain("response.completed");
+    } finally {
+      releaseCheckpoint.resolve();
+      await opened.close();
+    }
+  });
+
+  it("keeps only the route receipt when the client cancels before a checkpoint forms", async () => {
+    const history = new RecordingHistory();
+    let returned = 0;
+    const usageUpdates: UsageUpdate[] = [];
+    const backend = new ScriptedCopilotBackend({
+      chatStream: singleOwnedChunk(
+        bytes("data: {\"id\":\"chatcmpl_cancel\",\"choices\":[{\"delta\":{\"content\":\"unfinished\"},\"finish_reason\":null}]}\n\n"),
+        () => {
+          returned += 1;
+        },
+      ),
+    });
+    const opened = await streamGateway(history, backend, { usageUpdates });
+    try {
+      const response = await opened.gateway.fetch(responsesRequest());
+      expect(response.status).toBe(200);
+      const reader = response.body?.getReader();
+      if (reader === undefined) {
+        throw new Error("expected response body");
+      }
+      let delivered = "";
+      while (!delivered.includes("response.output_text.delta")) {
         const next = await reader.read();
         if (next.done) {
-          break;
+          throw new Error("stream ended before the text delta");
         }
-        const text = new TextDecoder().decode(next.value);
-        if (text.includes("response.output_item.done")) {
-          expect(history.records.length).toBeGreaterThan(0);
-          seenCompletedItem = true;
-          break;
-        }
+        delivered += new TextDecoder().decode(next.value, { stream: true });
       }
-      expect(seenCompletedItem).toBe(true);
-      expect(history.receipts).toHaveLength(1);
+      expect(history.receiptStates).toEqual(["route_only"]);
+      expect(history.checkpointStates).toEqual([]);
+      expect(history.records).toEqual([]);
+      expect(delivered).not.toContain("response.output_item.done");
+      expect(delivered).not.toContain("response.completed");
+
       await reader.cancel();
+      expect(returned).toBe(1);
+      expect(history.receiptStates).toEqual(["route_only"]);
+      expect(history.checkpointStates).toEqual([]);
+      expect(history.records).toEqual([]);
+      expect(usageUpdates).toHaveLength(1);
+      expect(usageUpdates).toMatchObject([{ protocol: "openai_responses_bridge", outcome: "aborted" }]);
+    } finally {
+      await opened.close();
+    }
+  });
+
+  it.each([
+    {
+      item: "text",
+      upstream: "data: {\"id\":\"chatcmpl_text_truncated\",\"choices\":[{\"delta\":{\"content\":\"unfinished\"},\"finish_reason\":null}]}\n\n",
+      progressEvent: "response.output_text.delta",
+    },
+    {
+      item: "tool",
+      upstream: "data: {\"id\":\"chatcmpl_tool_truncated\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"lookup\",\"arguments\":\"{\"}}]},\"finish_reason\":null}]}\n\n",
+      progressEvent: "response.function_call_arguments.delta",
+    },
+  ])("does not checkpoint an unfinished $item item when the upstream truncates", async ({ upstream, progressEvent }) => {
+    const history = new RecordingHistory();
+    const usageUpdates: UsageUpdate[] = [];
+    const backend = new ScriptedCopilotBackend({ chatStream: [bytes(upstream)] });
+    const opened = await streamGateway(history, backend, { usageUpdates });
+    try {
+      const response = await opened.gateway.fetch(responsesRequest());
+      expect(response.status).toBe(200);
+      const reader = response.body?.getReader();
+      let delivered = "";
+      await expect((async () => {
+        for (;;) {
+          const next = await reader?.read();
+          if (next?.done !== false) {
+            return;
+          }
+          delivered += new TextDecoder().decode(next.value, { stream: true });
+        }
+      })()).rejects.toThrow();
+
+      expect(delivered).toContain(progressEvent);
+      expect(delivered).not.toContain("response.output_item.done");
+      expect(delivered).not.toContain("response.completed");
+      expect(history.receiptStates).toEqual(["route_only"]);
+      expect(history.checkpointStates).toEqual([]);
+      expect(history.records).toEqual([]);
+      expect(usageUpdates).toHaveLength(1);
+      expect(usageUpdates).toMatchObject([{ protocol: "openai_responses_bridge", outcome: "upstream_error" }]);
     } finally {
       await opened.close();
     }
@@ -99,6 +290,7 @@ describe("Responses endpoint stream integration", () => {
 
   it("fails before exposing a converted response ID when its receipt cannot persist", async () => {
     const history = new RecordingHistory("receipt");
+    const usageUpdates: UsageUpdate[] = [];
     const backend = new ScriptedCopilotBackend({
       chatStream: [
         bytes("data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\n"),
@@ -106,13 +298,20 @@ describe("Responses endpoint stream integration", () => {
       ],
     });
 
-    const opened = await streamGateway(history, backend);
+    const opened = await streamGateway(history, backend, { usageUpdates });
     try {
       const response = await opened.gateway.fetch(responsesRequest());
       expect(response.status).toBe(500);
+      expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
+      expect(response.headers.get("x-request-id")).toBe("req_stream");
       const body = await response.text();
       expect(body).toContain("response continuation could not be saved");
       expect(body).not.toContain("chatcmpl_stream");
+      expect(body).not.toContain("resp_");
+      expect(history.receipts).toEqual([]);
+      expect(history.records).toEqual([]);
+      expect(usageUpdates).toHaveLength(1);
+      expect(usageUpdates).toMatchObject([{ protocol: "openai_responses_bridge", outcome: "internal_error" }]);
     } finally {
       await opened.close();
     }
@@ -150,16 +349,18 @@ describe("Responses endpoint stream integration", () => {
 
   it("does not expose a tool checkpoint event when checkpoint persistence fails", async () => {
     const history = new RecordingHistory("checkpoint");
+    const usageUpdates: UsageUpdate[] = [];
     const backend = new ScriptedCopilotBackend({
       chatStream: [
         bytes("data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"lookup\",\"arguments\":\"{}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n"),
         bytes("data: [DONE]\n\n"),
       ],
     });
-    const opened = await streamGateway(history, backend);
+    const opened = await streamGateway(history, backend, { usageUpdates });
     try {
       const response = await opened.gateway.fetch(responsesRequest());
       expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
       let delivered = "";
       await expect((async () => {
         const reader = response.body?.getReader();
@@ -173,7 +374,12 @@ describe("Responses endpoint stream integration", () => {
       })()).rejects.toThrow();
       expect(delivered).toContain("response.created");
       expect(delivered).not.toContain("response.output_item.done");
-      expect(history.receipts).toHaveLength(1);
+      expect(delivered).not.toContain("response.completed");
+      expect(history.receiptStates).toEqual(["route_only"]);
+      expect(history.records).toEqual([]);
+      expect(history.checkpointStates).toEqual([]);
+      expect(usageUpdates).toHaveLength(1);
+      expect(usageUpdates).toMatchObject([{ protocol: "openai_responses_bridge", outcome: "internal_error" }]);
     } finally {
       await opened.close();
     }
@@ -205,7 +411,11 @@ describe("Responses endpoint stream integration", () => {
 
 async function streamGateway(
   history: ResponsesHistory,
-  backend: ScriptedCopilotBackend,
+  backend: CopilotBackend,
+  options: {
+    readonly runtime?: ReturnType<typeof defaultRuntimeConfigSnapshot>;
+    readonly usageUpdates?: UsageUpdate[];
+  } = {},
 ): Promise<{ readonly gateway: Awaited<ReturnType<typeof createGateway>>; close(): Promise<void> }> {
   const dir = await mkdtemp(path.join(tmpdir(), "ghc-gateway-responses-stream-"));
   const database = openDatabase({
@@ -243,7 +453,7 @@ async function streamGateway(
   });
   const gateway = await createGateway({
     startup: parseStartupConfig([], {}, { homedir: dir }),
-    runtime: defaultRuntimeConfigSnapshot(),
+    runtime: options.runtime ?? defaultRuntimeConfigSnapshot(),
   }, [createResponsesRoute({
     directory: accounts,
     catalog,
@@ -252,6 +462,9 @@ async function streamGateway(
     history,
     nowUnixSeconds: () => 1_700_000_000,
     createUuid: () => "00000000-0000-4000-8000-000000000001",
+    ...(options.usageUpdates === undefined
+      ? {}
+      : { usageRecorder: { recordUsage: (update: UsageUpdate) => options.usageUpdates?.push(update) } }),
   })], { createRequestId: () => "req_stream" });
   return {
     gateway,
@@ -272,4 +485,68 @@ function responsesRequest(model = "chat", stream = true): Request {
 
 function bytes(value: string): Uint8Array {
   return new TextEncoder().encode(value);
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function singleOwnedChunk(chunk: Uint8Array, onReturn: () => void): AsyncIterable<Uint8Array> {
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+      let emitted = false;
+      let returned = false;
+      const pending = deferred<IteratorResult<Uint8Array>>();
+      return {
+        async next() {
+          if (!emitted) {
+            emitted = true;
+            return { done: false, value: chunk };
+          }
+          return await pending.promise;
+        },
+        async return() {
+          if (!returned) {
+            returned = true;
+            onReturn();
+            pending.resolve({ done: true, value: undefined });
+          }
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+}
+
+function withResponsesStream(
+  backend: ScriptedCopilotBackend,
+  open: (
+    request: NativeResponsesUpstreamRequest,
+    fallback: BoundCopilot,
+  ) => Promise<UpstreamByteStream>,
+): CopilotBackend {
+  return {
+    async bind(account, signal) {
+      const bound = await backend.bind(account, signal);
+      return {
+        ...bound,
+        openResponsesStream: async (request) => await open(request, bound),
+      };
+    },
+    async close() {
+      await backend.close();
+    },
+    forceClose() {
+      backend.forceClose();
+    },
+  };
 }

--- a/tests/unit/request_attempt.test.ts
+++ b/tests/unit/request_attempt.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { GatewayFailureError } from "../../src/gateway/failures.js";
 import { createRequestAttempt } from "../../src/gateway/request_attempt.js";
-import {
-  cleanupOwnedStream,
-  createExchangeCancellation,
-  createOwnedStreamCleanup,
-  withByteIdleDeadlines,
-} from "../../src/gateway/stream_execution.js";
 import type { UsageUpdate } from "../../src/telemetry/recorder.js";
 
 describe("RequestAttempt", () => {
@@ -129,74 +123,5 @@ describe("RequestAttempt", () => {
     attempt.failure(second);
     expect(updates).toHaveLength(1);
     expect(updates).toMatchObject([{ outcome }]);
-  });
-});
-
-describe("owned stream cleanup", () => {
-  it("cancels the exchange before bounded iterator cleanup", async () => {
-    const order: string[] = [];
-    const upstream = {
-      status: 200,
-      headers: new Headers(),
-      bytes: { async *[Symbol.asyncIterator]() {} },
-      cancel: async () => {
-        order.push("cancel");
-        await new Promise<void>(() => undefined);
-      },
-    };
-    const iterator: AsyncIterator<unknown> = {
-      next: async () => ({ done: true, value: undefined }),
-      return: async () => {
-        order.push("return");
-        await new Promise<void>(() => undefined);
-        return { done: true, value: undefined };
-      },
-    };
-    const started = Date.now();
-    await cleanupOwnedStream(upstream, iterator, 10);
-    expect(order).toEqual(["cancel", "return"]);
-    expect(Date.now() - started).toBeLessThan(200);
-  });
-
-  it("shares one exchange cancellation across deadline and outer cleanup", async () => {
-    let cancels = 0;
-    let returns = 0;
-    const source: AsyncIterable<Uint8Array> = {
-      [Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
-        let first = true;
-        return {
-          next: async () => {
-            if (first) {
-              first = false;
-              return { done: false, value: new Uint8Array([1]) };
-            }
-            await new Promise<void>(() => undefined);
-            return { done: true, value: undefined };
-          },
-          return: async () => {
-            returns += 1;
-            return { done: true, value: undefined };
-          },
-        };
-      },
-    };
-    const upstream = {
-      status: 200,
-      headers: new Headers(),
-      bytes: source,
-      cancel: async () => {
-        cancels += 1;
-      },
-    };
-    const cancelExchange = createExchangeCancellation(upstream, 10);
-    const timed = withByteIdleDeadlines(source, new AbortController().signal, 10, 1, cancelExchange);
-    const iterator = timed[Symbol.asyncIterator]();
-    const cleanup = createOwnedStreamCleanup(upstream, iterator, 10, cancelExchange);
-    expect((await iterator.next()).done).toBe(false);
-    await expect(iterator.next()).rejects.toMatchObject({
-      failure: { kind: "upstream_timeout" },
-    });
-    await cleanup();
-    expect({ cancels, returns }).toEqual({ cancels: 1, returns: 1 });
   });
 });


### PR DESCRIPTION
## Summary

- centralize stream commit, terminal arbitration, producer tracking, and bounded cleanup in one Stream Execution owner
- include outer delivery and Hono attempt/admission/inflight finalization in the completion barrier
- preserve protocol-owned status, headers, wire ordering, terminal presentation, and Responses checkpoint-before-wire behavior
- handle presemantic keepalives, cancellation/abort/shutdown races, demandless and late delivery claims, and honest terminal outcomes independent of close/abort presentation
- add public-seam Chat, Messages, native/converted Responses lifecycle and history evidence

## Validation

- Issue-targeted matrix: 361 passed
- final full `npm test`: 1113 passed, 6 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run fixtures:verify` (53 entries)
- `git diff --check`
- final Standards review: no findings
- final Spec review: no findings

Official SDK suites, live inference, capture, e2e, bench, and pack were not run locally. Fixture and golden bytes were unchanged.

Closes #179
