### PR TITLE
Serialize daemon lifecycle operations by data directory

### DIFF
--- a/src/cli/control_client.ts
+++ b/src/cli/control_client.ts
@@ -439,7 +439,7 @@ export async function authenticatedControlRequest(
   let response: Response;
   const timeout = controlTimeout(context.signal, context.timeoutMs ?? 30_000);
   try {
-    response = await Promise.race([fetchImpl(`http://127.0.0.1:${endpoint.port}${pathPart}`, {
+    response = await fetchImpl(`http://127.0.0.1:${endpoint.port}${pathPart}`, {
       method,
       headers: {
         "content-type": "application/json",
@@ -448,7 +448,7 @@ export async function authenticatedControlRequest(
       },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
       signal: timeout.signal,
-    }), timeout.promise]);
+    });
   } catch (_error: unknown) {
     timeout.clear();
     if (timeout.timedOut()) {
@@ -461,7 +461,7 @@ export async function authenticatedControlRequest(
   }
   let payload: unknown;
   try {
-    payload = await Promise.race([response.json(), timeout.promise]).catch(() => null) as unknown;
+    payload = await response.json().catch(() => null) as unknown;
   } finally {
     timeout.clear();
   }
@@ -492,7 +492,6 @@ const readControlEndpoint = readDaemonIdentity;
 
 function controlTimeout(parent: AbortSignal | undefined, ms: number): {
   readonly signal: AbortSignal;
-  readonly promise: Promise<never>;
   readonly clear: () => void;
   readonly timedOut: () => boolean;
   readonly parentAborted: () => boolean;
@@ -500,18 +499,12 @@ function controlTimeout(parent: AbortSignal | undefined, ms: number): {
   const controller = new AbortController();
   const signal = parent === undefined ? controller.signal : AbortSignal.any([parent, controller.signal]);
   let timedOut = false;
-  let rejectTimeout: (error: unknown) => void = () => undefined;
-  const promise = new Promise<never>((_resolve, reject) => {
-    rejectTimeout = reject;
-  });
   const timer = setTimeout(() => {
     timedOut = true;
-    controller.abort();
-    rejectTimeout(new CliError("timeout"));
+    controller.abort(new CliError("timeout"));
   }, ms);
   return {
     signal,
-    promise,
     clear: () => clearTimeout(timer),
     timedOut: () => timedOut,
     parentAborted: () => parent?.aborted === true,

--- a/src/daemon/controller.ts
+++ b/src/daemon/controller.ts
@@ -13,12 +13,22 @@ const STOP_TIMEOUT_MS = 10_000;
 const FORCE_STOP_TIMEOUT_MS = 10_000;
 const FORCE_SETTLE_TIMEOUT_MS = 10_000;
 const RESTART_SETTLE_TIMEOUT_MS = 5_000;
+const DEPENDENCY_TIMEOUT_MS = 30_000;
 const STATUS_PATH = "/__ghcg/control/v1/status";
 const STOP_PATH = "/__ghcg/control/v1/stop";
 
+export interface LifecycleDependencyContext {
+  readonly signal: AbortSignal;
+  readonly deadlineMs: number;
+}
+
 export interface DaemonIdentityFileAccess {
-  read(dataDir: string): Promise<DaemonIdentity | null>;
-  remove(dataDir: string, expected: Readonly<DaemonIdentity>): Promise<boolean>;
+  read(dataDir: string, context: Readonly<LifecycleDependencyContext>): Promise<DaemonIdentity | null>;
+  remove(
+    dataDir: string,
+    expected: Readonly<DaemonIdentity>,
+    context: Readonly<LifecycleDependencyContext>,
+  ): Promise<boolean>;
 }
 
 export interface SpawnedDaemon {
@@ -40,12 +50,21 @@ export type DaemonControlRequest = (
 
 export interface DaemonControllerDependencies {
   readonly identityFile: DaemonIdentityFileAccess;
-  readonly processIdentity: (pid: number) => Promise<string | null>;
-  readonly spawn: (startup: Readonly<StartupConfig>) => Promise<SpawnedDaemon>;
+  readonly processIdentity: (
+    pid: number,
+    context: Readonly<LifecycleDependencyContext>,
+  ) => Promise<string | null>;
+  readonly spawn: (
+    startup: Readonly<StartupConfig>,
+    context: Readonly<LifecycleDependencyContext>,
+  ) => Promise<SpawnedDaemon>;
   readonly delay: (ms: number, signal?: AbortSignal) => Promise<void>;
   readonly nowMs: () => number;
   readonly controlRequest: DaemonControlRequest;
-  readonly terminate: (identity: Readonly<ProcessIdentityReference>) => Promise<void>;
+  readonly terminate: (
+    identity: Readonly<ProcessIdentityReference>,
+    context: Readonly<LifecycleDependencyContext>,
+  ) => Promise<void>;
   readonly lifecycleCoordinator?: LifecycleCoordinatorAccess;
 }
 
@@ -89,7 +108,7 @@ export class DaemonController {
     let identity: DaemonIdentity | null;
     try {
       identity = await this.runBeforeDeadline(
-        () => this.dependencies.identityFile.read(resolvedDataDir),
+        (dependencyContext) => this.dependencies.identityFile.read(resolvedDataDir, dependencyContext),
         context.deadlineMs,
         context.signal,
       );
@@ -107,7 +126,15 @@ export class DaemonController {
     }
     if (processState.kind === "dead") {
       context.signal?.throwIfAborted();
-      const removed = await this.dependencies.identityFile.remove(resolvedDataDir, identity);
+      const removed = await this.runBeforeDeadline(
+        (dependencyContext) => this.dependencies.identityFile.remove(
+          resolvedDataDir,
+          identity,
+          dependencyContext,
+        ),
+        context.deadlineMs,
+        context.signal,
+      );
       return {
         result: identityResult(removed ? "stale" : "conflict", identity, resolvedDataDir),
         identity,
@@ -116,11 +143,9 @@ export class DaemonController {
 
     try {
       const response = await this.runBeforeDeadline(
-        () => this.dependencies.controlRequest(identity, "GET", STATUS_PATH, {
-          ...(context.signal === undefined ? {} : { signal: context.signal }),
-          ...(context.deadlineMs === undefined
-            ? {}
-            : { timeoutMs: remainingMs(context.deadlineMs, this.dependencies.nowMs()) }),
+        (dependencyContext) => this.dependencies.controlRequest(identity, "GET", STATUS_PATH, {
+          signal: dependencyContext.signal,
+          timeoutMs: remainingMs(dependencyContext.deadlineMs, this.dependencies.nowMs()),
         }),
         context.deadlineMs,
         context.signal,
@@ -174,20 +199,30 @@ export class DaemonController {
     if (this.dependencies.nowMs() >= deadline) {
       return identityResult("unreachable", await this.readIdentityOrNull(startup.dataDir), resolvedDataDir);
     }
-    const child = await this.dependencies.spawn(startup);
+    const child = await this.runBeforeDeadline(
+      (dependencyContext) => this.dependencies.spawn(startup, dependencyContext),
+      deadline,
+      undefined,
+      true,
+    );
     let spawned: ProcessIdentityReference | null = null;
     try {
       spawned = await this.captureSpawnedIdentity(child.pid);
       context.signal?.throwIfAborted();
       while (this.dependencies.nowMs() < deadline) {
-        await this.runBeforeDeadline(
-          () => this.dependencies.delay(
-            Math.min(POLL_INTERVAL_MS, remainingMs(deadline, this.dependencies.nowMs())),
+        try {
+          await this.runBeforeDeadline(
+            (dependencyContext) => this.dependencies.delay(
+              Math.min(POLL_INTERVAL_MS, remainingMs(deadline, this.dependencies.nowMs())),
+              dependencyContext.signal,
+            ),
+            deadline,
             context.signal,
-          ),
-          deadline,
-          context.signal,
-        );
+          );
+        } catch (error: unknown) {
+          if (isDeadlineTimeout(error)) break;
+          throw error;
+        }
         const timeoutMs = remainingMs(deadline, this.dependencies.nowMs());
         if (timeoutMs === 0) {
           break;
@@ -205,10 +240,10 @@ export class DaemonController {
         }
       }
 
-      await this.cleanupFailedStart(startup.dataDir, spawned);
+      await this.cleanupFailedStart(startup.dataDir, child.pid, spawned);
       return identityResult("unreachable", await this.readIdentityOrNull(startup.dataDir), resolvedDataDir);
     } catch (error: unknown) {
-      await this.cleanupFailedStart(startup.dataDir, spawned);
+      await this.cleanupFailedStart(startup.dataDir, child.pid, spawned);
       rethrowCancellation(error, context.signal);
       throw error;
     } finally {
@@ -259,9 +294,14 @@ export class DaemonController {
     const stopRequestDeadline = this.dependencies.nowMs() + STOP_TIMEOUT_MS;
     try {
       context.signal?.throwIfAborted();
-      const response = await this.dependencies.controlRequest(identity, "POST", STOP_PATH, {
-        timeoutMs: remainingMs(stopRequestDeadline, this.dependencies.nowMs()),
-      });
+      const response = await this.runBeforeDeadline(
+        (dependencyContext) => this.dependencies.controlRequest(identity, "POST", STOP_PATH, {
+          signal: dependencyContext.signal,
+          timeoutMs: remainingMs(dependencyContext.deadlineMs, this.dependencies.nowMs()),
+        }),
+        stopRequestDeadline,
+        undefined,
+      );
       if (this.dependencies.nowMs() > stopRequestDeadline) throw new CliError("timeout");
       if (!validControlResponse(response, identity, false)) {
         return identityResult("conflict", identity, resolvedDataDir);
@@ -279,7 +319,7 @@ export class DaemonController {
       const delayMs = remaining <= POLL_INTERVAL_MS ? 0 : POLL_INTERVAL_MS;
       if (delayMs > 0) {
         await this.runBeforeDeadline(
-          () => this.dependencies.delay(delayMs),
+          (dependencyContext) => this.dependencies.delay(delayMs, dependencyContext.signal),
           graceDeadline,
           undefined,
         );
@@ -294,7 +334,7 @@ export class DaemonController {
         throw error;
       }
       if (processState.kind === "dead") {
-        await this.dependencies.identityFile.remove(resolvedDataDir, identity);
+        await this.removeIdentityBeforeDeadline(resolvedDataDir, identity, graceDeadline);
         return emptyResult("stopped", resolvedDataDir);
       }
       if (processState.kind !== "same") {
@@ -306,9 +346,25 @@ export class DaemonController {
     }
 
     const forceDeadline = this.dependencies.nowMs() + FORCE_STOP_TIMEOUT_MS;
-    await this.dependencies.terminate(identity);
-    let afterTerminate = await this.waitForTermination(identity, undefined, forceDeadline);
-    if (afterTerminate.kind === "same") {
+    let terminationError: unknown;
+    try {
+      await this.runBeforeDeadline(
+        (dependencyContext) => this.dependencies.terminate(identity, dependencyContext),
+        forceDeadline,
+        undefined,
+        true,
+      );
+    } catch (error: unknown) {
+      terminationError = error;
+    }
+    let afterTerminate = await this.waitForTermination(
+      identity,
+      undefined,
+      terminationError === undefined
+        ? forceDeadline
+        : this.dependencies.nowMs() + FORCE_SETTLE_TIMEOUT_MS,
+    );
+    if (terminationError === undefined && afterTerminate.kind === "same") {
       afterTerminate = await this.waitForTermination(
         identity,
         undefined,
@@ -316,12 +372,17 @@ export class DaemonController {
       );
     }
     if (afterTerminate.kind === "dead") {
-      await this.dependencies.identityFile.remove(resolvedDataDir, identity);
+      await this.removeIdentityBeforeDeadline(
+        resolvedDataDir,
+        identity,
+        this.dependencies.nowMs() + FORCE_STOP_TIMEOUT_MS,
+      );
       return emptyResult("stopped", resolvedDataDir);
     }
     if (afterTerminate.kind === "same" && await this.readIdentityOrNull(resolvedDataDir) === null) {
       return emptyResult("stopped", resolvedDataDir);
     }
+    if (terminationError !== undefined && afterTerminate.kind === "same") throw terminationError;
     return identityResult(afterTerminate.kind === "same" ? "unreachable" : "conflict", identity, resolvedDataDir);
   }
 
@@ -339,8 +400,12 @@ export class DaemonController {
       if (stopped.state === "unreachable") {
         const deadline = this.dependencies.nowMs() + RESTART_SETTLE_TIMEOUT_MS;
         while (this.dependencies.nowMs() < deadline) {
-          await this.dependencies.delay(POLL_INTERVAL_MS, signal);
-          stopped = (await this.inspectWithinLane(startup.dataDir, withinContext)).result;
+          await this.runBeforeDeadline(
+            (dependencyContext) => this.dependencies.delay(POLL_INTERVAL_MS, dependencyContext.signal),
+            deadline,
+            signal,
+          );
+          stopped = (await this.inspectWithinLane(startup.dataDir, { ...withinContext, deadlineMs: deadline })).result;
           if (stopped.state !== "unreachable") break;
         }
       }
@@ -349,17 +414,29 @@ export class DaemonController {
     });
   }
 
-  private async captureSpawnedIdentity(pid: number): Promise<ProcessIdentityReference | null> {
+  private async captureSpawnedIdentity(
+    pid: number,
+    retryNull = false,
+  ): Promise<ProcessIdentityReference | null> {
     const deadline = this.dependencies.nowMs() + FORCE_STOP_TIMEOUT_MS;
     for (;;) {
       try {
-        const captured = await this.dependencies.processIdentity(pid);
-        return captured === null ? null : { pid, processStartIdentity: captured };
+        const captured = await this.runBeforeDeadline(
+          (dependencyContext) => this.dependencies.processIdentity(pid, dependencyContext),
+          deadline,
+          undefined,
+        );
+        if (captured !== null) return { pid, processStartIdentity: captured };
+        if (!retryNull) return null;
       } catch (_error: unknown) {
-        if (this.dependencies.nowMs() >= deadline) return null;
+        // A transient probe failure is retried within the reconciliation deadline.
       }
+      if (this.dependencies.nowMs() >= deadline) return null;
       await this.runBeforeDeadline(
-        () => this.dependencies.delay(Math.min(POLL_INTERVAL_MS, remainingMs(deadline, this.dependencies.nowMs()))),
+        (dependencyContext) => this.dependencies.delay(
+          Math.min(POLL_INTERVAL_MS, remainingMs(deadline, this.dependencies.nowMs())),
+          dependencyContext.signal,
+        ),
         deadline,
         undefined,
       );
@@ -368,19 +445,33 @@ export class DaemonController {
 
   private async cleanupFailedStart(
     dataDir: string,
-    spawned: Readonly<ProcessIdentityReference> | null,
+    pid: number,
+    initiallyCaptured: Readonly<ProcessIdentityReference> | null,
   ): Promise<void> {
-    if (spawned === null) {
-      return;
-    }
+    const spawned = initiallyCaptured ?? await this.captureSpawnedIdentity(pid, true);
+    if (spawned === null) return;
     const forceDeadline = this.dependencies.nowMs() + FORCE_STOP_TIMEOUT_MS;
     const fresh = await this.readProcessIdentity(spawned, undefined, forceDeadline);
     if (fresh.kind !== "same") {
       await this.removeSpawnedIdentityIfOwned(dataDir, spawned);
       return;
     }
-    await this.dependencies.terminate(spawned);
-    const afterTerminate = await this.waitForTermination(spawned, undefined, forceDeadline);
+    let terminationFailed = false;
+    try {
+      await this.runBeforeDeadline(
+        (dependencyContext) => this.dependencies.terminate(spawned, dependencyContext),
+        forceDeadline,
+        undefined,
+        true,
+      );
+    } catch (_error: unknown) {
+      terminationFailed = true;
+    }
+    const afterTerminate = await this.waitForTermination(
+      spawned,
+      undefined,
+      terminationFailed ? this.dependencies.nowMs() + FORCE_SETTLE_TIMEOUT_MS : forceDeadline,
+    );
     if (afterTerminate.kind === "dead") {
       await this.removeSpawnedIdentityIfOwned(dataDir, spawned);
     }
@@ -394,7 +485,11 @@ export class DaemonController {
     if (identity !== null
       && identity.pid === spawned.pid
       && identity.processStartIdentity === spawned.processStartIdentity) {
-      await this.dependencies.identityFile.remove(path.resolve(dataDir), identity);
+      await this.removeIdentityBeforeDeadline(
+        path.resolve(dataDir),
+        identity,
+        this.dependencies.nowMs() + FORCE_STOP_TIMEOUT_MS,
+      );
     }
   }
 
@@ -417,7 +512,10 @@ export class DaemonController {
         return state;
       }
       await this.runBeforeDeadline(
-        () => this.dependencies.delay(Math.min(POLL_INTERVAL_MS, remaining), signal),
+        (dependencyContext) => this.dependencies.delay(
+          Math.min(POLL_INTERVAL_MS, remaining),
+          dependencyContext.signal,
+        ),
         deadline,
         signal,
       );
@@ -429,10 +527,26 @@ export class DaemonController {
 
   private async readIdentityOrNull(dataDir: string): Promise<DaemonIdentity | null> {
     try {
-      return await this.dependencies.identityFile.read(path.resolve(dataDir));
+      return await this.runBeforeDeadline(
+        (dependencyContext) => this.dependencies.identityFile.read(path.resolve(dataDir), dependencyContext),
+        this.dependencies.nowMs() + FORCE_STOP_TIMEOUT_MS,
+        undefined,
+      );
     } catch (_error: unknown) {
       throw new CliError("security_error");
     }
+  }
+
+  private async removeIdentityBeforeDeadline(
+    dataDir: string,
+    identity: Readonly<DaemonIdentity>,
+    deadline: number,
+  ): Promise<boolean> {
+    return await this.runBeforeDeadline(
+      (dependencyContext) => this.dependencies.identityFile.remove(dataDir, identity, dependencyContext),
+      deadline,
+      undefined,
+    );
   }
 
   private async readProcessIdentity(
@@ -443,7 +557,7 @@ export class DaemonController {
     signal?.throwIfAborted();
     try {
       const actual = await this.runBeforeDeadline(
-        () => this.dependencies.processIdentity(identity.pid),
+        (dependencyContext) => this.dependencies.processIdentity(identity.pid, dependencyContext),
         deadline,
         signal,
       );
@@ -458,18 +572,21 @@ export class DaemonController {
   }
 
   private async runBeforeDeadline<T>(
-    work: () => Promise<T>,
+    work: (context: Readonly<LifecycleDependencyContext>) => Promise<T>,
     deadline: number | undefined,
     signal: AbortSignal | undefined,
+    acceptCompletedSideEffect = false,
   ): Promise<T> {
     signal?.throwIfAborted();
-    if (deadline === undefined) {
-      return await work();
-    }
-    const result = await withDeadline(work, remainingMs(deadline, this.dependencies.nowMs()), signal);
-    if (this.dependencies.nowMs() > deadline) {
-      throw new CliError("timeout");
-    }
+    const effectiveDeadline = deadline ?? this.dependencies.nowMs() + DEPENDENCY_TIMEOUT_MS;
+    const result = await withCooperativeDeadline(
+      work,
+      effectiveDeadline,
+      remainingMs(effectiveDeadline, this.dependencies.nowMs()),
+      signal,
+      acceptCompletedSideEffect,
+    );
+    if (!acceptCompletedSideEffect && this.dependencies.nowMs() > effectiveDeadline) throw new CliError("timeout");
     return result;
   }
 }
@@ -533,25 +650,27 @@ function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-async function withDeadline<T>(work: () => Promise<T>, timeoutMs: number, parent?: AbortSignal): Promise<T> {
-  if (timeoutMs <= 0) {
-    throw new CliError("timeout");
-  }
+async function withCooperativeDeadline<T>(
+  work: (context: Readonly<LifecycleDependencyContext>) => Promise<T>,
+  deadlineMs: number,
+  timeoutMs: number,
+  parent?: AbortSignal,
+  acceptCompletedSideEffect = false,
+): Promise<T> {
+  if (timeoutMs <= 0) throw new CliError("timeout");
   const timeout = new AbortController();
   const timer = setTimeout(() => timeout.abort(new CliError("timeout")), timeoutMs);
   const signal = parent === undefined ? timeout.signal : AbortSignal.any([parent, timeout.signal]);
-  let removeAbort = (): void => undefined;
   try {
-    return await Promise.race([
-      work(),
-      new Promise<never>((_resolve, reject) => {
-        const abort = (): void => reject(signal.reason);
-        signal.addEventListener("abort", abort, { once: true });
-        removeAbort = () => signal.removeEventListener("abort", abort);
-      }),
-    ]);
+    const result = await work({ signal, deadlineMs });
+    if (parent?.aborted === true) parent.throwIfAborted();
+    if (!acceptCompletedSideEffect && timeout.signal.aborted) throw new CliError("timeout");
+    return result;
+  } catch (error: unknown) {
+    if (parent?.aborted === true) parent.throwIfAborted();
+    if (timeout.signal.aborted) throw new CliError("timeout");
+    throw error;
   } finally {
     clearTimeout(timer);
-    removeAbort();
   }
 }

--- a/src/daemon/controller.ts
+++ b/src/daemon/controller.ts
@@ -17,6 +17,12 @@ const DEPENDENCY_TIMEOUT_MS = 30_000;
 const STATUS_PATH = "/__ghcg/control/v1/status";
 const STOP_PATH = "/__ghcg/control/v1/stop";
 
+/**
+ * A lifecycle dependency must acknowledge abort before settling: after signal
+ * abort, it may settle only once its side effect is quiescent or ownership of
+ * every created resource has been returned to the controller for reconciliation.
+ * Rejecting while an unowned side effect can still commit violates this contract.
+ */
 export interface LifecycleDependencyContext {
   readonly signal: AbortSignal;
   readonly deadlineMs: number;

--- a/src/daemon/controller.ts
+++ b/src/daemon/controller.ts
@@ -2,6 +2,10 @@ import path from "node:path";
 import { CliError, type CliLifecycleResult } from "../cli/control_client.js";
 import type { StartupConfig } from "../config/startup_config.js";
 import type { DaemonIdentity } from "./identity_file.js";
+import {
+  sharedInProcessLifecycleCoordinator,
+  type LifecycleCoordinatorAccess,
+} from "./lifecycle_coordinator.js";
 
 const POLL_INTERVAL_MS = 100;
 const START_TIMEOUT_MS = 30_000;
@@ -42,6 +46,7 @@ export interface DaemonControllerDependencies {
   readonly nowMs: () => number;
   readonly controlRequest: DaemonControlRequest;
   readonly terminate: (identity: Readonly<ProcessIdentityReference>) => Promise<void>;
+  readonly lifecycleCoordinator?: LifecycleCoordinatorAccess;
 }
 
 export interface ProcessIdentityReference {
@@ -63,15 +68,19 @@ interface InspectionContext extends DaemonLifecycleContext {
 }
 
 export class DaemonController {
-  private readonly starts = new Map<string, Promise<CliLifecycleResult>>();
+  private readonly coordinator: LifecycleCoordinatorAccess;
 
-  constructor(private readonly dependencies: Readonly<DaemonControllerDependencies>) {}
-
-  async status(dataDir: string, context: Readonly<DaemonLifecycleContext> = {}): Promise<CliLifecycleResult> {
-    return (await this.inspect(dataDir, context)).result;
+  constructor(private readonly dependencies: Readonly<DaemonControllerDependencies>) {
+    this.coordinator = dependencies.lifecycleCoordinator ?? sharedInProcessLifecycleCoordinator;
   }
 
-  private async inspect(
+  async status(dataDir: string, context: Readonly<DaemonLifecycleContext> = {}): Promise<CliLifecycleResult> {
+    return await this.coordinator.run(dataDir, context, async (signal) => (
+      await this.inspectWithinLane(dataDir, { ...(signal === undefined ? {} : { signal }) })
+    ).result);
+  }
+
+  private async inspectWithinLane(
     dataDir: string,
     context: Readonly<InspectionContext>,
   ): Promise<DaemonInspection> {
@@ -97,11 +106,8 @@ export class DaemonController {
       return { result: identityResult("conflict", identity, resolvedDataDir), identity };
     }
     if (processState.kind === "dead") {
-      const removed = await this.runBeforeDeadline(
-        () => this.dependencies.identityFile.remove(resolvedDataDir, identity),
-        context.deadlineMs,
-        context.signal,
-      );
+      context.signal?.throwIfAborted();
+      const removed = await this.dependencies.identityFile.remove(resolvedDataDir, identity);
       return {
         result: identityResult(removed ? "stale" : "conflict", identity, resolvedDataDir),
         identity,
@@ -136,21 +142,13 @@ export class DaemonController {
     startup: Readonly<StartupConfig>,
     context: Readonly<DaemonLifecycleContext> = {},
   ): Promise<CliLifecycleResult> {
-    const key = path.resolve(startup.dataDir);
-    const active = this.starts.get(key);
-    if (active !== undefined) {
-      return await active;
-    }
-    const work = this.startOnce(startup, context).finally(() => {
-      if (this.starts.get(key) === work) {
-        this.starts.delete(key);
-      }
-    });
-    this.starts.set(key, work);
-    return await work;
+    return await this.coordinator.run(startup.dataDir, context, async (signal) => await this.startWithinLane(
+      startup,
+      { ...(signal === undefined ? {} : { signal }) },
+    ));
   }
 
-  private async startOnce(
+  private async startWithinLane(
     startup: Readonly<StartupConfig>,
     context: Readonly<DaemonLifecycleContext>,
   ): Promise<CliLifecycleResult> {
@@ -158,7 +156,7 @@ export class DaemonController {
     const deadline = this.dependencies.nowMs() + START_TIMEOUT_MS;
     let existing: CliLifecycleResult;
     try {
-      existing = (await this.inspect(startup.dataDir, {
+      existing = (await this.inspectWithinLane(startup.dataDir, {
         ...context,
         deadlineMs: deadline,
       })).result;
@@ -176,31 +174,12 @@ export class DaemonController {
     if (this.dependencies.nowMs() >= deadline) {
       return identityResult("unreachable", await this.readIdentityOrNull(startup.dataDir), resolvedDataDir);
     }
-    const child = await this.runBeforeDeadline(
-      () => this.dependencies.spawn(startup),
-      deadline,
-      context.signal,
-    );
+    const child = await this.dependencies.spawn(startup);
     let spawned: ProcessIdentityReference | null = null;
     try {
+      spawned = await this.captureSpawnedIdentity(child.pid);
+      context.signal?.throwIfAborted();
       while (this.dependencies.nowMs() < deadline) {
-        if (spawned === null) {
-          try {
-            const captured = await this.runBeforeDeadline(
-              () => this.dependencies.processIdentity(child.pid),
-              deadline,
-              context.signal,
-            );
-            if (captured !== null) {
-              spawned = { pid: child.pid, processStartIdentity: captured };
-            }
-          } catch (error: unknown) {
-            if (isDeadlineTimeout(error)) {
-              break;
-            }
-            rethrowCancellation(error, context.signal);
-          }
-        }
         await this.runBeforeDeadline(
           () => this.dependencies.delay(
             Math.min(POLL_INTERVAL_MS, remainingMs(deadline, this.dependencies.nowMs())),
@@ -214,7 +193,7 @@ export class DaemonController {
           break;
         }
         try {
-          const inspection = await this.inspect(startup.dataDir, { ...context, deadlineMs: deadline });
+          const inspection = await this.inspectWithinLane(startup.dataDir, { ...context, deadlineMs: deadline });
           if (inspection.result.state === "running") {
             return inspection.result;
           }
@@ -241,11 +220,21 @@ export class DaemonController {
     dataDir: string,
     context: Readonly<DaemonLifecycleContext> = {},
   ): Promise<CliLifecycleResult> {
+    return await this.coordinator.run(dataDir, context, async (signal) => await this.stopWithinLane(
+      dataDir,
+      { ...(signal === undefined ? {} : { signal }) },
+    ));
+  }
+
+  private async stopWithinLane(
+    dataDir: string,
+    context: Readonly<DaemonLifecycleContext>,
+  ): Promise<CliLifecycleResult> {
     const resolvedDataDir = path.resolve(dataDir);
     const inspectionDeadline = this.dependencies.nowMs() + STOP_TIMEOUT_MS;
     let inspection: DaemonInspection;
     try {
-      inspection = await this.inspect(resolvedDataDir, { ...context, deadlineMs: inspectionDeadline });
+      inspection = await this.inspectWithinLane(resolvedDataDir, { ...context, deadlineMs: inspectionDeadline });
     } catch (error: unknown) {
       if (isDeadlineTimeout(error)) {
         return identityResult("unreachable", await this.readIdentityOrNull(resolvedDataDir), resolvedDataDir);
@@ -269,14 +258,11 @@ export class DaemonController {
 
     const stopRequestDeadline = this.dependencies.nowMs() + STOP_TIMEOUT_MS;
     try {
-      const response = await this.runBeforeDeadline(
-        () => this.dependencies.controlRequest(identity, "POST", STOP_PATH, {
-          ...(context.signal === undefined ? {} : { signal: context.signal }),
-          timeoutMs: remainingMs(stopRequestDeadline, this.dependencies.nowMs()),
-        }),
-        stopRequestDeadline,
-        context.signal,
-      );
+      context.signal?.throwIfAborted();
+      const response = await this.dependencies.controlRequest(identity, "POST", STOP_PATH, {
+        timeoutMs: remainingMs(stopRequestDeadline, this.dependencies.nowMs()),
+      });
+      if (this.dependencies.nowMs() > stopRequestDeadline) throw new CliError("timeout");
       if (!validControlResponse(response, identity, false)) {
         return identityResult("conflict", identity, resolvedDataDir);
       }
@@ -293,14 +279,14 @@ export class DaemonController {
       const delayMs = remaining <= POLL_INTERVAL_MS ? 0 : POLL_INTERVAL_MS;
       if (delayMs > 0) {
         await this.runBeforeDeadline(
-          () => this.dependencies.delay(delayMs, context.signal),
+          () => this.dependencies.delay(delayMs),
           graceDeadline,
-          context.signal,
+          undefined,
         );
       }
       let processState: { readonly kind: "same" | "different" | "dead" | "unknown" };
       try {
-        processState = await this.readProcessIdentity(identity, context.signal, graceDeadline);
+        processState = await this.readProcessIdentity(identity, undefined, graceDeadline);
       } catch (error: unknown) {
         if (isDeadlineTimeout(error)) {
           break;
@@ -308,11 +294,7 @@ export class DaemonController {
         throw error;
       }
       if (processState.kind === "dead") {
-        await this.runBeforeDeadline(
-          () => this.dependencies.identityFile.remove(resolvedDataDir, identity),
-          graceDeadline,
-          context.signal,
-        );
+        await this.dependencies.identityFile.remove(resolvedDataDir, identity);
         return emptyResult("stopped", resolvedDataDir);
       }
       if (processState.kind !== "same") {
@@ -324,11 +306,7 @@ export class DaemonController {
     }
 
     const forceDeadline = this.dependencies.nowMs() + FORCE_STOP_TIMEOUT_MS;
-    await this.runBeforeDeadline(
-      () => this.dependencies.terminate(identity),
-      forceDeadline,
-      undefined,
-    );
+    await this.dependencies.terminate(identity);
     let afterTerminate = await this.waitForTermination(identity, undefined, forceDeadline);
     if (afterTerminate.kind === "same") {
       afterTerminate = await this.waitForTermination(
@@ -351,23 +329,41 @@ export class DaemonController {
     startup: Readonly<StartupConfig>,
     context: Readonly<DaemonLifecycleContext> = {},
   ): Promise<CliLifecycleResult> {
-    const inspection = await this.inspect(startup.dataDir, context);
-    const effectiveStartup = inspection.identity === null
-      ? startup
-      : { ...startup, port: inspection.identity.port };
-    let stopped = await this.stop(startup.dataDir, context);
-    if (stopped.state === "unreachable") {
-      const deadline = this.dependencies.nowMs() + RESTART_SETTLE_TIMEOUT_MS;
-      while (this.dependencies.nowMs() < deadline) {
-        await this.dependencies.delay(POLL_INTERVAL_MS, context.signal);
-        stopped = await this.status(startup.dataDir, context);
-        if (stopped.state !== "unreachable") break;
+    return await this.coordinator.run(startup.dataDir, context, async (signal) => {
+      const withinContext = { ...(signal === undefined ? {} : { signal }) };
+      const inspection = await this.inspectWithinLane(startup.dataDir, withinContext);
+      const effectiveStartup = inspection.identity === null
+        ? startup
+        : { ...startup, port: inspection.identity.port };
+      let stopped = await this.stopWithinLane(startup.dataDir, withinContext);
+      if (stopped.state === "unreachable") {
+        const deadline = this.dependencies.nowMs() + RESTART_SETTLE_TIMEOUT_MS;
+        while (this.dependencies.nowMs() < deadline) {
+          await this.dependencies.delay(POLL_INTERVAL_MS, signal);
+          stopped = (await this.inspectWithinLane(startup.dataDir, withinContext)).result;
+          if (stopped.state !== "unreachable") break;
+        }
       }
+      if (stopped.state !== "stopped" && stopped.state !== "stale") return stopped;
+      return await this.startWithinLane(effectiveStartup, withinContext);
+    });
+  }
+
+  private async captureSpawnedIdentity(pid: number): Promise<ProcessIdentityReference | null> {
+    const deadline = this.dependencies.nowMs() + FORCE_STOP_TIMEOUT_MS;
+    for (;;) {
+      try {
+        const captured = await this.dependencies.processIdentity(pid);
+        return captured === null ? null : { pid, processStartIdentity: captured };
+      } catch (_error: unknown) {
+        if (this.dependencies.nowMs() >= deadline) return null;
+      }
+      await this.runBeforeDeadline(
+        () => this.dependencies.delay(Math.min(POLL_INTERVAL_MS, remainingMs(deadline, this.dependencies.nowMs()))),
+        deadline,
+        undefined,
+      );
     }
-    if (stopped.state !== "stopped" && stopped.state !== "stale") {
-      return stopped;
-    }
-    return await this.start(effectiveStartup, context);
   }
 
   private async cleanupFailedStart(
@@ -383,11 +379,7 @@ export class DaemonController {
       await this.removeSpawnedIdentityIfOwned(dataDir, spawned);
       return;
     }
-    await this.runBeforeDeadline(
-      () => this.dependencies.terminate(spawned),
-      forceDeadline,
-      undefined,
-    );
+    await this.dependencies.terminate(spawned);
     const afterTerminate = await this.waitForTermination(spawned, undefined, forceDeadline);
     if (afterTerminate.kind === "dead") {
       await this.removeSpawnedIdentityIfOwned(dataDir, spawned);
@@ -412,7 +404,11 @@ export class DaemonController {
     deadline: number,
   ): Promise<{ readonly kind: "same" | "different" | "dead" | "unknown" }> {
     for (;;) {
-      const state = await this.readProcessIdentity(identity, signal, deadline);
+      const state = await this.readProcessIdentity(
+        identity,
+        signal,
+        this.dependencies.nowMs() >= deadline ? undefined : deadline,
+      );
       if (state.kind !== "same") {
         return state;
       }
@@ -544,14 +540,18 @@ async function withDeadline<T>(work: () => Promise<T>, timeoutMs: number, parent
   const timeout = new AbortController();
   const timer = setTimeout(() => timeout.abort(new CliError("timeout")), timeoutMs);
   const signal = parent === undefined ? timeout.signal : AbortSignal.any([parent, timeout.signal]);
+  let removeAbort = (): void => undefined;
   try {
     return await Promise.race([
       work(),
       new Promise<never>((_resolve, reject) => {
-        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        const abort = (): void => reject(signal.reason);
+        signal.addEventListener("abort", abort, { once: true });
+        removeAbort = () => signal.removeEventListener("abort", abort);
       }),
     ]);
   } finally {
     clearTimeout(timer);
+    removeAbort();
   }
 }

--- a/src/daemon/identity_file.ts
+++ b/src/daemon/identity_file.ts
@@ -12,7 +12,11 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { captureProcessStartIdentity } from "./process_identity.js";
+import {
+  captureProcessStartIdentity,
+  isCanonicalProcessStartIdentity,
+  type ProcessIdentityContext,
+} from "./process_identity.js";
 import {
   DaemonIdentityFileError,
   ProtectedFileSystem,
@@ -41,7 +45,10 @@ export interface DaemonIdentityLease {
 export interface DaemonIdentityFileOptions {
   readonly platform?: NodeJS.Platform;
   readonly runCommand?: (file: string, args: readonly string[]) => string;
-  readonly processIdentity?: (pid: number) => Promise<string | null>;
+  readonly processIdentity?: (
+    pid: number,
+    context?: Readonly<ProcessIdentityContext>,
+  ) => Promise<string | null>;
 }
 
 interface DaemonLockOwner {
@@ -69,14 +76,18 @@ export class DaemonIdentityFile {
   readonly path: string;
   private readonly lockPath: string;
   private readonly protectedFiles: ProtectedFileSystem;
-  private readonly processIdentity: (pid: number) => Promise<string | null>;
+  private readonly processIdentity: (
+    pid: number,
+    context?: Readonly<ProcessIdentityContext>,
+  ) => Promise<string | null>;
 
   constructor(directory: string, options: DaemonIdentityFileOptions = {}) {
     this.directory = path.resolve(directory);
     this.path = path.join(this.directory, "daemon.json");
     this.lockPath = path.join(this.directory, "daemon.lock");
     this.protectedFiles = new ProtectedFileSystem(this.directory, options);
-    this.processIdentity = options.processIdentity ?? captureProcessStartIdentity;
+    this.processIdentity = options.processIdentity
+      ?? (async (pid, context) => await captureProcessStartIdentity(pid, undefined, context));
   }
 
   read(): DaemonIdentity | null {
@@ -133,7 +144,11 @@ export class DaemonIdentityFile {
     };
   }
 
-  async remove(expected: Readonly<DaemonIdentity>): Promise<boolean> {
+  async remove(
+    expected: Readonly<DaemonIdentity>,
+    context: Readonly<ProcessIdentityContext> = {},
+  ): Promise<boolean> {
+    context.signal?.throwIfAborted();
     this.ensureProtectedDirectory();
     if (!pathExists(this.path)) {
       return false;
@@ -145,13 +160,14 @@ export class DaemonIdentityFile {
     if (pathExists(this.lockPath)) {
       const owner = this.readLockOwner();
       if (owner.pid !== expected.pid || owner.processStartIdentity !== expected.processStartIdentity
-        || !await this.proveLockOwnerDead(owner)) {
+        || !await this.proveLockOwnerDead(owner, context)) {
         return false;
       }
       if (!this.removeLockIfUnchanged(owner)) {
         return false;
       }
     }
+    context.signal?.throwIfAborted();
     return this.cleanupOwned(expected);
   }
 
@@ -193,10 +209,13 @@ export class DaemonIdentityFile {
     }
   }
 
-  private async proveLockOwnerDead(owner: Readonly<DaemonLockOwner>): Promise<boolean> {
+  private async proveLockOwnerDead(
+    owner: Readonly<DaemonLockOwner>,
+    context: Readonly<ProcessIdentityContext> = {},
+  ): Promise<boolean> {
     let actual: string | null;
     try {
-      actual = await this.processIdentity(owner.pid);
+      actual = await this.processIdentity(owner.pid, context);
     } catch (error: unknown) {
       throw new DaemonIdentityFileError("lease_conflict", "unable to verify daemon identity lease owner", { cause: error });
     }
@@ -311,7 +330,7 @@ export function decodeDaemonIdentity(text: string): DaemonIdentity {
     || parsed.version !== 1
     || typeof parsed.managed !== "boolean"
     || !isPositiveSafeInteger(parsed.pid)
-    || !isCanonicalProcessIdentity(parsed.processStartIdentity)
+    || !isCanonicalProcessStartIdentity(parsed.processStartIdentity)
     || !isNonemptyString(parsed.instanceNonce)
     || !isNonemptyString(parsed.controlToken)
     || !isPort(parsed.port)
@@ -340,7 +359,7 @@ function decodeLockOwner(text: string): DaemonLockOwner {
   if (!isRecord(parsed) || !hasExactKeys(parsed, LOCK_KEYS)
     || parsed.version !== 1
     || !isPositiveSafeInteger(parsed.pid)
-    || !isCanonicalProcessIdentity(parsed.processStartIdentity)
+    || !isCanonicalProcessStartIdentity(parsed.processStartIdentity)
     || !isNonemptyString(parsed.leaseToken)) {
     throw new DaemonIdentityFileError("invalid_identity", "invalid daemon lock schema");
   }
@@ -355,22 +374,6 @@ function decodeLockOwner(text: string): DaemonLockOwner {
 function hasExactKeys(value: Readonly<Record<string, unknown>>, expected: readonly string[]): boolean {
   const keys = Object.keys(value).sort();
   return keys.length === expected.length && [...expected].sort().every((key, index) => keys[index] === key);
-}
-
-function isCanonicalProcessIdentity(value: unknown): value is string {
-  if (typeof value !== "string") {
-    return false;
-  }
-  if (/^linux:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:(0|[1-9]\d*)$/u.test(value)
-    || /^windows:(0|[1-9]\d{0,19})$/u.test(value)) {
-    return true;
-  }
-  const macOs = /^macos:(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)$/u.exec(value);
-  if (macOs?.[1] === undefined) {
-    return false;
-  }
-  const milliseconds = Date.parse(macOs[1]);
-  return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString().replace(".000Z", "Z") === macOs[1];
 }
 
 function isCanonicalTimestamp(value: unknown): value is string {

--- a/src/daemon/identity_file.ts
+++ b/src/daemon/identity_file.ts
@@ -1,23 +1,25 @@
-import { execFileSync } from "node:child_process";
 import {
-  chmodSync,
   closeSync,
   constants,
   fstatSync,
   fsyncSync,
   linkSync,
   lstatSync,
-  mkdirSync,
   openSync,
-  readSync,
   unlinkSync,
   writeSync,
   type Stats,
 } from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { InvalidWindowsIdentityError, WindowsAcl, windowsCommandPath } from "../security/windows_acl.js";
 import { captureProcessStartIdentity } from "./process_identity.js";
+import {
+  DaemonIdentityFileError,
+  ProtectedFileSystem,
+} from "./protected_file.js";
+
+export { DaemonIdentityFileError } from "./protected_file.js";
+export type { DaemonIdentityFileErrorCode } from "./protected_file.js";
 
 export interface DaemonIdentity {
   readonly version: 1;
@@ -28,25 +30,6 @@ export interface DaemonIdentity {
   readonly controlToken: string;
   readonly port: number;
   readonly createdAt: string;
-}
-
-export type DaemonIdentityFileErrorCode =
-  | "invalid_identity"
-  | "lease_conflict"
-  | "unsafe_path"
-  | "unsafe_owner"
-  | "unsafe_permissions"
-  | "io_error";
-
-export class DaemonIdentityFileError extends Error {
-  constructor(
-    readonly code: DaemonIdentityFileErrorCode,
-    message: string,
-    options?: ErrorOptions,
-  ) {
-    super(message, options);
-    this.name = "DaemonIdentityFileError";
-  }
 }
 
 export interface DaemonIdentityLease {
@@ -85,18 +68,14 @@ export class DaemonIdentityFile {
   readonly directory: string;
   readonly path: string;
   private readonly lockPath: string;
-  private readonly platform: NodeJS.Platform;
-  private readonly runCommand: (file: string, args: readonly string[]) => string;
-  private readonly windowsAcl: WindowsAcl;
+  private readonly protectedFiles: ProtectedFileSystem;
   private readonly processIdentity: (pid: number) => Promise<string | null>;
 
   constructor(directory: string, options: DaemonIdentityFileOptions = {}) {
     this.directory = path.resolve(directory);
     this.path = path.join(this.directory, "daemon.json");
     this.lockPath = path.join(this.directory, "daemon.lock");
-    this.platform = options.platform ?? process.platform;
-    this.runCommand = options.runCommand ?? defaultRunCommand;
-    this.windowsAcl = new WindowsAcl(this.runCommand);
+    this.protectedFiles = new ProtectedFileSystem(this.directory, options);
     this.processIdentity = options.processIdentity ?? captureProcessStartIdentity;
   }
 
@@ -301,133 +280,23 @@ export class DaemonIdentityFile {
   }
 
   private ensureProtectedDirectory(): void {
-    let created = false;
-    if (!pathExists(this.directory)) {
-      mkdirSync(this.directory, { recursive: true, mode: 0o700 });
-      created = true;
-    }
-    const stat = lstatSync(this.directory);
-    if (!stat.isDirectory() || stat.isSymbolicLink() || this.isWindowsReparsePoint(this.directory)) {
-      throw new DaemonIdentityFileError("unsafe_path", "daemon directory must be a regular directory");
-    }
-    this.assertOwner(stat);
-    if (this.platform === "win32") {
-      if (created) {
-        this.restrictWindowsAcl(this.directory, true);
-      }
-      this.assertWindowsAcl(this.directory);
-    } else if ((stat.mode & 0o777) !== 0o700) {
-      throw new DaemonIdentityFileError("unsafe_permissions", "daemon directory permissions must be 0700");
-    }
+    this.protectedFiles.ensureProtectedDirectory();
   }
 
   private readProtectedFile(filePath: string): string {
-    const before = this.assertProtectedRegularFile(filePath);
-    const noFollowFlag = (constants as Readonly<Record<string, number>>)["O_NOFOLLOW"] ?? 0;
-    const noFollow = constants.O_RDONLY | noFollowFlag;
-    let fd: number;
-    try {
-      fd = openSync(filePath, noFollow);
-    } catch (error: unknown) {
-      throw new DaemonIdentityFileError("unsafe_path", "unable to safely open daemon file", { cause: error });
-    }
-    try {
-      const opened = fstatSync(fd);
-      if (!opened.isFile() || !sameFile(before, opened) || opened.size > MAX_IDENTITY_BYTES) {
-        throw new DaemonIdentityFileError("unsafe_path", "daemon file changed during validation");
-      }
-      const buffer = Buffer.alloc(opened.size);
-      let offset = 0;
-      while (offset < buffer.length) {
-        const count = readSync(fd, buffer, offset, buffer.length - offset, offset);
-        if (count === 0) {
-          break;
-        }
-        offset += count;
-      }
-      if (offset !== buffer.length) {
-        throw new DaemonIdentityFileError("io_error", "unable to read complete daemon file");
-      }
-      return buffer.toString("utf8");
-    } finally {
-      closeSync(fd);
-    }
+    return this.protectedFiles.readProtectedFile(filePath, MAX_IDENTITY_BYTES);
   }
 
   private assertProtectedRegularFile(filePath: string): Stats {
-    const stat = lstatSync(filePath);
-    if (!stat.isFile() || stat.isSymbolicLink() || this.isWindowsReparsePoint(filePath)) {
-      throw new DaemonIdentityFileError("unsafe_path", "daemon path must be a regular file");
-    }
-    this.assertOwner(stat);
-    if (this.platform === "win32") {
-      this.assertWindowsAcl(filePath);
-    } else if ((stat.mode & 0o777) !== 0o600) {
-      throw new DaemonIdentityFileError("unsafe_permissions", "daemon file permissions must be 0600");
-    }
-    return stat;
-  }
-
-  private assertOwner(stat: Stats): void {
-    if (this.platform !== "win32" && typeof process.getuid === "function" && stat.uid !== process.getuid()) {
-      throw new DaemonIdentityFileError("unsafe_owner", "daemon path must be owned by the current user");
-    }
+    return this.protectedFiles.assertProtectedRegularFile(filePath);
   }
 
   private protectFile(filePath: string): void {
-    if (this.platform === "win32") {
-      this.restrictWindowsAcl(filePath, false);
-      return;
-    }
-    chmodSync(filePath, 0o600);
-  }
-
-  private isWindowsReparsePoint(target: string): boolean {
-    if (this.platform !== "win32") {
-      return false;
-    }
-    const script = `$item = Get-Item -LiteralPath '${powerShellLiteral(target)}' -Force; if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { 'true' } else { 'false' }`;
-    return this.runCommand("powershell.exe", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script]).trim() === "true";
-  }
-
-  private restrictWindowsAcl(target: string, directory: boolean): void {
-    const current = this.currentWindowsIdentity();
-    this.windowsAcl.restrict(target, directory, { setOwner: true, currentIdentity: current });
-  }
-
-  private assertWindowsAcl(target: string): void {
-    const current = this.currentWindowsIdentity();
-    const owner = windowsOwner(target, this.runCommand);
-    if (!this.windowsAcl.isCurrentIdentity(owner, current)) {
-      throw new DaemonIdentityFileError("unsafe_owner", "daemon path must be owned by the current user");
-    }
-    const identities = this.windowsAcl.identities(target);
-    if (identities.length !== 1 || !this.windowsAcl.isCurrentIdentity(identities[0] ?? "", current)) {
-      throw new DaemonIdentityFileError("unsafe_permissions", "daemon ACL must be restricted to the current user");
-    }
-  }
-
-  private currentWindowsIdentity() {
-    try {
-      return this.windowsAcl.currentIdentity();
-    } catch (error: unknown) {
-      if (error instanceof InvalidWindowsIdentityError) {
-        throw new DaemonIdentityFileError("unsafe_owner", "unable to resolve current Windows identity");
-      }
-      throw error;
-    }
+    this.protectedFiles.protectFile(filePath);
   }
 
   private flushDirectory(): void {
-    if (this.platform === "win32") {
-      return;
-    }
-    const fd = openSync(this.directory, constants.O_RDONLY);
-    try {
-      fsyncSync(fd);
-    } finally {
-      closeSync(fd);
-    }
+    this.protectedFiles.flushDirectory();
   }
 }
 
@@ -578,31 +447,4 @@ function isNotFound(error: unknown): boolean {
 
 function isAlreadyExists(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
-}
-
-function defaultRunCommand(file: string, args: readonly string[]): string {
-  const resolved = process.platform === "win32" && (file === "whoami" || file === "icacls")
-    ? windowsCommandPath(file)
-    : file;
-  return execFileSync(resolved, [...args], { encoding: "utf8", windowsHide: true });
-}
-
-function windowsOwner(
-  target: string,
-  runCommand: (file: string, args: readonly string[]) => string,
-): string {
-  const securityModule = "$env:windir\\system32\\WindowsPowerShell\\v1.0\\Modules"
-    + "\\Microsoft.PowerShell.Security\\Microsoft.PowerShell.Security.psd1";
-  const script = `Import-Module "${securityModule}"; (Get-Acl -LiteralPath '${powerShellLiteral(target)}').Owner`;
-  const owner = runCommand("powershell.exe", [
-    "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script,
-  ]).trim();
-  if (owner.length === 0) {
-    throw new DaemonIdentityFileError("unsafe_owner", "unable to resolve daemon path owner");
-  }
-  return owner;
-}
-
-function powerShellLiteral(value: string): string {
-  return value.replaceAll("'", "''");
 }

--- a/src/daemon/lifecycle_coordinator.ts
+++ b/src/daemon/lifecycle_coordinator.ts
@@ -1,0 +1,145 @@
+import path from "node:path";
+import { CliError } from "../cli/control_client.js";
+import { DaemonIdentityFileError } from "./identity_file.js";
+import type { DaemonOperationLeaseAccess, DaemonOperationLeaseHandle } from "./operation_lease.js";
+
+export interface LifecycleOperationContext {
+  readonly signal?: AbortSignal;
+}
+
+export interface LifecycleCoordinatorAccess {
+  run<T>(
+    dataDir: string,
+    context: Readonly<LifecycleOperationContext>,
+    operation: (signal: AbortSignal | undefined) => Promise<T>,
+  ): Promise<T>;
+}
+
+interface QueueNode {
+  readonly signal: AbortSignal | undefined;
+  readonly operation: (signal: AbortSignal | undefined) => Promise<unknown>;
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (error: unknown) => void;
+  started: boolean;
+  settled: boolean;
+  removeAbortListener(): void;
+}
+
+interface DirectoryLane {
+  readonly key: string;
+  readonly queue: QueueNode[];
+  draining: boolean;
+}
+
+export class LifecycleCoordinator implements LifecycleCoordinatorAccess {
+  private readonly lanes = new Map<string, DirectoryLane>();
+
+  constructor(private readonly leases: Readonly<DaemonOperationLeaseAccess>) {}
+
+  async run<T>(
+    dataDir: string,
+    context: Readonly<LifecycleOperationContext>,
+    operation: (signal: AbortSignal | undefined) => Promise<T>,
+  ): Promise<T> {
+    const signal = context.signal;
+    if (signal?.aborted === true) throw new CliError("interrupted");
+    const key = path.resolve(dataDir);
+    const lane = this.lanes.get(key) ?? { key, queue: [], draining: false };
+    this.lanes.set(key, lane);
+
+    return await new Promise<T>((resolve, reject) => {
+      const node: QueueNode = {
+        signal,
+        operation,
+        resolve: (value) => resolve(value as T),
+        reject,
+        started: false,
+        settled: false,
+        removeAbortListener: () => undefined,
+      };
+      const abort = (): void => {
+        if (node.started || node.settled) return;
+        node.settled = true;
+        node.removeAbortListener();
+        const index = lane.queue.indexOf(node);
+        if (index >= 0) lane.queue.splice(index, 1);
+        reject(new CliError("interrupted"));
+      };
+      if (signal !== undefined) {
+        signal.addEventListener("abort", abort, { once: true });
+        node.removeAbortListener = () => signal.removeEventListener("abort", abort);
+      }
+      lane.queue.push(node);
+      if (!lane.draining) void this.drain(lane);
+    });
+  }
+
+  private async drain(lane: DirectoryLane): Promise<void> {
+    lane.draining = true;
+    try {
+      for (;;) {
+        const node = lane.queue.shift();
+        if (node === undefined) return;
+        if (node.settled) continue;
+        node.started = true;
+        node.removeAbortListener();
+        let lease: DaemonOperationLeaseHandle | undefined;
+        try {
+          if (node.signal?.aborted === true) throw new CliError("interrupted");
+          lease = await this.leases.acquire(lane.key, {
+            ...(node.signal === undefined ? {} : { signal: node.signal }),
+          });
+          if (signalIsAborted(node.signal)) throw new CliError("interrupted");
+          const result = await node.operation(node.signal);
+          if (signalIsAborted(node.signal)) throw new CliError("interrupted");
+          lease.release();
+          lease = undefined;
+          node.resolve(result);
+        } catch (error: unknown) {
+          try {
+            lease?.release();
+          } catch (releaseError: unknown) {
+            node.reject(normalizeCoordinatorError(releaseError, node.signal));
+            node.settled = true;
+            continue;
+          }
+          node.reject(normalizeCoordinatorError(error, node.signal));
+        } finally {
+          node.settled = true;
+        }
+      }
+    } finally {
+      lane.draining = false;
+      if (lane.queue.length === 0 && this.lanes.get(lane.key) === lane) {
+        this.lanes.delete(lane.key);
+      } else if (lane.queue.length > 0) {
+        void this.drain(lane);
+      }
+    }
+  }
+}
+
+export const sharedInProcessLifecycleCoordinator: LifecycleCoordinatorAccess = new LifecycleCoordinator({
+  acquire: async () => ({ release() {} }),
+});
+
+function signalIsAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
+function normalizeCoordinatorError(error: unknown, signal: AbortSignal | undefined): unknown {
+  if (signal?.aborted === true) return new CliError("interrupted");
+  if (error instanceof CliError) return error;
+  if (error instanceof DaemonIdentityFileError) {
+    const cause = error.cause;
+    if (isPermissionError(cause)) return new CliError("permission_denied");
+    return new CliError("security_error");
+  }
+  if (isPermissionError(error)) return new CliError("permission_denied");
+  return error;
+}
+
+function isPermissionError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error
+    && (error.code === "EACCES" || error.code === "EPERM");
+}

--- a/src/daemon/lifecycle_coordinator.ts
+++ b/src/daemon/lifecycle_coordinator.ts
@@ -3,6 +3,8 @@ import { CliError } from "../cli/control_client.js";
 import { DaemonIdentityFileError } from "./identity_file.js";
 import type { DaemonOperationLeaseAccess, DaemonOperationLeaseHandle } from "./operation_lease.js";
 
+export const MAX_PENDING_LIFECYCLE_OPERATIONS_PER_DIRECTORY = 64;
+
 export interface LifecycleOperationContext {
   readonly signal?: AbortSignal;
 }
@@ -46,6 +48,9 @@ export class LifecycleCoordinator implements LifecycleCoordinatorAccess {
     const key = path.resolve(dataDir);
     const lane = this.lanes.get(key) ?? { key, queue: [], draining: false };
     this.lanes.set(key, lane);
+    if (lane.queue.length >= MAX_PENDING_LIFECYCLE_OPERATIONS_PER_DIRECTORY) {
+      throw new CliError("unavailable");
+    }
 
     return await new Promise<T>((resolve, reject) => {
       const node: QueueNode = {

--- a/src/daemon/operation_lease.ts
+++ b/src/daemon/operation_lease.ts
@@ -1,5 +1,16 @@
 import { randomUUID } from "node:crypto";
-import { closeSync, constants, fsyncSync, openSync, renameSync, unlinkSync, writeSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  fsyncSync,
+  linkSync,
+  openSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+  type Stats,
+} from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import {
@@ -16,6 +27,8 @@ import {
 const OPERATION_DATABASE = "daemon.operation.db";
 const OPERATION_OWNER = "daemon.operation.owner.json";
 const OPERATION_OWNER_TEMP = ".daemon.operation.owner.json.tmp";
+const OPERATION_DATABASE_INIT_PREFIX = ".daemon.operation.db.init-";
+const MAX_DATABASE_INIT_TEMPS = 16;
 const MAX_OWNER_BYTES = 4 * 1024;
 const POLL_INTERVAL_MS = 50;
 const SQLITE_BUSY = 5;
@@ -37,6 +50,13 @@ export interface DaemonOperationLeaseAccess {
 
 export interface DaemonOperationLeaseFileOptions extends ProtectedFileOptions {
   readonly pid?: number;
+  readonly write?: (
+    fd: number,
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    position: number | null,
+  ) => number;
   readonly processStartIdentity?: (context?: Readonly<ProcessIdentityContext>) => Promise<string | null>;
   readonly processIdentity?: (
     pid: number,
@@ -44,6 +64,7 @@ export interface DaemonOperationLeaseFileOptions extends ProtectedFileOptions {
   ) => Promise<string | null>;
   readonly createToken?: () => string;
   readonly delay?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  readonly onInitializationPhase?: (phase: "database_prepared" | "database_published") => void;
   readonly onPhase?: (phase: "os_locked" | "held_published" | "released_published" | "database_closing") => void;
 }
 
@@ -65,8 +86,10 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
     context?: Readonly<ProcessIdentityContext>,
   ) => Promise<string | null>;
   private readonly createToken: () => string;
+  private readonly write: NonNullable<DaemonOperationLeaseFileOptions["write"]>;
   private readonly delay: (ms: number, signal?: AbortSignal) => Promise<void>;
   private readonly protectedOptions: ProtectedFileOptions;
+  private readonly onInitializationPhase: NonNullable<DaemonOperationLeaseFileOptions["onInitializationPhase"]>;
   private readonly onPhase: NonNullable<DaemonOperationLeaseFileOptions["onPhase"]>;
 
   constructor(options: Readonly<DaemonOperationLeaseFileOptions> = {}) {
@@ -76,7 +99,10 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
     this.processIdentity = options.processIdentity
       ?? (async (pid, context) => await captureProcessStartIdentity(pid, undefined, context));
     this.createToken = options.createToken ?? randomUUID;
+    this.write = options.write ?? ((fd, buffer, offset, length, position) =>
+      writeSync(fd, buffer, offset, length, position));
     this.delay = options.delay ?? abortableDelay;
+    this.onInitializationPhase = options.onInitializationPhase ?? (() => undefined);
     this.onPhase = options.onPhase ?? (() => undefined);
     this.protectedOptions = {
       ...(options.platform === undefined ? {} : { platform: options.platform }),
@@ -103,7 +129,7 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
     const databasePath = path.join(files.directory, OPERATION_DATABASE);
     const ownerPath = path.join(files.directory, OPERATION_OWNER);
     const tempPath = path.join(files.directory, OPERATION_OWNER_TEMP);
-    this.ensureDatabase(files, databasePath);
+    await this.ensureDatabase(files, databasePath, processStartIdentity);
 
     for (;;) {
       signal?.throwIfAborted();
@@ -125,6 +151,7 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
         this.onPhase("os_locked");
         signal?.throwIfAborted();
         this.assertDatabaseAssets(files, databasePath);
+        await this.cleanupDatabaseInitTemps(files, databasePath, signal);
         this.cleanupOwnerTemp(files, tempPath);
         await this.verifyPreviousOwner(files, ownerPath, signal);
         this.publishOwner(files, ownerPath, tempPath, held);
@@ -137,24 +164,105 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
     }
   }
 
-  private ensureDatabase(files: ProtectedFileSystem, databasePath: string): void {
-    if (!files.pathExists(databasePath)) {
-      let fd: number | undefined;
+  private async ensureDatabase(
+    files: ProtectedFileSystem,
+    databasePath: string,
+    processStartIdentity: string,
+  ): Promise<void> {
+    if (files.pathExists(databasePath)) {
+      files.assertProtectedRegularFile(databasePath);
+      return;
+    }
+
+    const initPath = path.join(
+      files.directory,
+      `${OPERATION_DATABASE_INIT_PREFIX}${this.pid}-${Buffer.from(processStartIdentity).toString("base64url")}-${randomUUID()}`,
+    );
+    let fd: number | undefined;
+    try {
+      fd = openSync(initPath, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR, 0o600);
+      writeAllSync(fd, emptyDatabaseImage(), this.write);
+      fsyncSync(fd);
+      files.protectFile(initPath);
+      files.assertProtectedRegularFile(initPath);
+      closeSync(fd);
+      fd = undefined;
+      this.validateDatabase(files, initPath);
+      this.onInitializationPhase("database_prepared");
       try {
-        fd = openSync(databasePath, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR, 0o600);
-        writeSync(fd, emptyDatabaseImage());
-        fsyncSync(fd);
-        closeSync(fd);
-        fd = undefined;
-        files.protectFile(databasePath);
-        files.assertProtectedRegularFile(databasePath);
+        linkSync(initPath, databasePath);
         files.flushDirectory();
+        this.onInitializationPhase("database_published");
       } catch (error: unknown) {
-        if (fd !== undefined) closeSync(fd);
-        if (!isAlreadyExists(error)) throw normalizeAcquireError(error);
+        if (!isAlreadyExists(error)) throw error;
       }
+      files.assertProtectedRegularFile(databasePath);
+      files.unlink(initPath);
+    } catch (error: unknown) {
+      if (fd !== undefined) closeSync(fd);
+      this.cleanupOwnDatabaseInitTemp(files, initPath);
+      throw normalizeAcquireError(error);
+    }
+  }
+
+  private validateDatabase(files: ProtectedFileSystem, databasePath: string): void {
+    files.assertProtectedRegularFile(databasePath);
+    let database: DatabaseSync | undefined;
+    try {
+      database = new DatabaseSync(databasePath, { readOnly: true });
+      const rows = database.prepare("PRAGMA quick_check").all() as Array<Record<string, unknown>>;
+      if (rows.length !== 1 || Object.values(rows[0] ?? {})[0] !== "ok") {
+        throw new Error("SQLite quick check failed");
+      }
+    } catch (error: unknown) {
+      throw new DaemonIdentityFileError("unsafe_path", "invalid daemon operation database", { cause: error });
+    } finally {
+      database?.close();
     }
     files.assertProtectedRegularFile(databasePath);
+  }
+
+  private cleanupOwnDatabaseInitTemp(files: ProtectedFileSystem, initPath: string): void {
+    if (!files.pathExists(initPath)) return;
+    try {
+      files.assertProtectedRegularFile(initPath);
+      files.unlink(initPath);
+    } catch {
+      // Preserve the original sanitized failure. A later holder validates initialization temps.
+    }
+  }
+
+  private async cleanupDatabaseInitTemps(
+    files: ProtectedFileSystem,
+    databasePath: string,
+    signal: AbortSignal | undefined,
+  ): Promise<void> {
+    const names = readdirSync(files.directory)
+      .filter((name) => name.startsWith(OPERATION_DATABASE_INIT_PREFIX));
+    if (names.length > MAX_DATABASE_INIT_TEMPS) {
+      throw new DaemonIdentityFileError("unsafe_path", "too many daemon operation database initialization files");
+    }
+    const databaseStat = files.assertProtectedRegularFile(databasePath);
+    for (const name of names) {
+      signal?.throwIfAborted();
+      const initOwner = decodeDatabaseInitName(name);
+      const initPath = path.join(files.directory, name);
+      const initStat = files.assertProtectedRegularFile(initPath);
+      if (sameFile(databaseStat, initStat)) {
+        files.unlink(initPath);
+        continue;
+      }
+      this.validateDatabase(files, initPath);
+
+      let actual: string | null;
+      try {
+        actual = await this.processIdentity(initOwner.pid, { ...(signal === undefined ? {} : { signal }) });
+      } catch (error: unknown) {
+        throw new DaemonIdentityFileError("unsafe_owner", "unable to verify database initializer", { cause: error });
+      }
+      if (actual === initOwner.processStartIdentity) continue;
+      files.unlink(initPath);
+    }
   }
 
   private assertDatabaseAssets(files: ProtectedFileSystem, databasePath: string): void {
@@ -227,7 +335,7 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
     let fd: number | undefined;
     try {
       fd = openSync(tempPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
-      writeSync(fd, `${JSON.stringify(owner)}\n`, 0, "utf8");
+      writeAllSync(fd, Buffer.from(`${JSON.stringify(owner)}\n`, "utf8"), this.write);
       fsyncSync(fd);
       closeSync(fd);
       fd = undefined;
@@ -319,6 +427,38 @@ function sameOwner(left: Readonly<OperationOwner>, right: Readonly<OperationOwne
     && left.pid === right.pid
     && left.processStartIdentity === right.processStartIdentity
     && left.leaseToken === right.leaseToken;
+}
+
+function decodeDatabaseInitName(name: string): { readonly pid: number; readonly processStartIdentity: string } {
+  const match = /^\.daemon\.operation\.db\.init-([1-9]\d*)-([A-Za-z0-9_-]+)-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u.exec(name);
+  const pid = Number(match?.[1]);
+  const encodedIdentity = match?.[2] ?? "";
+  const processStartIdentity = Buffer.from(encodedIdentity, "base64url").toString("utf8");
+  if (!Number.isSafeInteger(pid) || pid <= 0
+    || Buffer.from(processStartIdentity, "utf8").toString("base64url") !== encodedIdentity
+    || !isCanonicalProcessStartIdentity(processStartIdentity)) {
+    throw new DaemonIdentityFileError("unsafe_path", "invalid daemon operation database initialization file");
+  }
+  return { pid, processStartIdentity };
+}
+
+function sameFile(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function writeAllSync(
+  fd: number,
+  buffer: Uint8Array,
+  write: NonNullable<DaemonOperationLeaseFileOptions["write"]>,
+): void {
+  let offset = 0;
+  while (offset < buffer.byteLength) {
+    const written = write(fd, buffer, offset, buffer.byteLength - offset, offset);
+    if (!Number.isSafeInteger(written) || written <= 0 || written > buffer.byteLength - offset) {
+      throw new Error("unable to write complete daemon file");
+    }
+    offset += written;
+  }
 }
 
 let databaseImage: Buffer | undefined;

--- a/src/daemon/operation_lease.ts
+++ b/src/daemon/operation_lease.ts
@@ -1,0 +1,258 @@
+import { randomUUID } from "node:crypto";
+import { closeSync, fstatSync } from "node:fs";
+import path from "node:path";
+import { captureProcessStartIdentity } from "./process_identity.js";
+import {
+  DaemonIdentityFileError,
+  ProtectedFileSystem,
+  sameProtectedFile,
+  type ProtectedFileOptions,
+} from "./protected_file.js";
+
+const OPERATION_FILE = "daemon.operation.lock";
+const MAX_OWNER_BYTES = 4 * 1024;
+const POLL_INTERVAL_MS = 50;
+const OWNER_KEYS = ["version", "pid", "processStartIdentity", "leaseToken"] as const;
+
+export interface DaemonOperationLeaseHandle {
+  release(): void;
+}
+
+export interface DaemonOperationLeaseContext {
+  readonly signal?: AbortSignal;
+}
+
+export interface DaemonOperationLeaseAccess {
+  acquire(dataDir: string, context?: Readonly<DaemonOperationLeaseContext>): Promise<DaemonOperationLeaseHandle>;
+}
+
+export interface DaemonOperationLeaseFileOptions extends ProtectedFileOptions {
+  readonly pid?: number;
+  readonly processStartIdentity?: () => Promise<string | null>;
+  readonly processIdentity?: (pid: number) => Promise<string | null>;
+  readonly createToken?: () => string;
+  readonly delay?: (ms: number, signal?: AbortSignal) => Promise<void>;
+}
+
+interface OperationOwner {
+  readonly version: 1;
+  readonly pid: number;
+  readonly processStartIdentity: string;
+  readonly leaseToken: string;
+}
+
+export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
+  private readonly pid: number;
+  private readonly processStartIdentity: () => Promise<string | null>;
+  private readonly processIdentity: (pid: number) => Promise<string | null>;
+  private readonly createToken: () => string;
+  private readonly delay: (ms: number, signal?: AbortSignal) => Promise<void>;
+  private readonly protectedOptions: ProtectedFileOptions;
+
+  constructor(options: Readonly<DaemonOperationLeaseFileOptions> = {}) {
+    this.pid = options.pid ?? process.pid;
+    this.processStartIdentity = options.processStartIdentity
+      ?? (async () => await captureProcessStartIdentity(this.pid));
+    this.processIdentity = options.processIdentity ?? captureProcessStartIdentity;
+    this.createToken = options.createToken ?? randomUUID;
+    this.delay = options.delay ?? abortableDelay;
+    this.protectedOptions = {
+      ...(options.platform === undefined ? {} : { platform: options.platform }),
+      ...(options.runCommand === undefined ? {} : { runCommand: options.runCommand }),
+    };
+  }
+
+  async acquire(
+    dataDir: string,
+    context: Readonly<DaemonOperationLeaseContext> = {},
+  ): Promise<DaemonOperationLeaseHandle> {
+    const signal = context.signal;
+    signal?.throwIfAborted();
+    const processStartIdentity = await this.captureOwnerIdentity();
+    const owner: OperationOwner = {
+      version: 1,
+      pid: this.pid,
+      processStartIdentity,
+      leaseToken: this.createToken(),
+    };
+    const files = new ProtectedFileSystem(dataDir, this.protectedOptions);
+    files.ensureProtectedDirectory();
+    const operationPath = path.join(files.directory, OPERATION_FILE);
+
+    for (;;) {
+      signal?.throwIfAborted();
+      let fd: number;
+      try {
+        fd = files.createExclusiveFile(operationPath, `${JSON.stringify(owner)}\n`);
+      } catch (error: unknown) {
+        if (!isAlreadyExists(error)) throw normalizeAcquireError(error);
+        try {
+          await this.waitForOrRecoverOwner(files, operationPath, signal);
+        } catch (ownerError: unknown) {
+          if (!isNotFound(ownerError) && files.pathExists(operationPath)) {
+            throw normalizeAcquireError(ownerError);
+          }
+        }
+        continue;
+      }
+      return this.ownedLease(files, operationPath, fd, owner);
+    }
+  }
+
+  private async captureOwnerIdentity(): Promise<string> {
+    let identity: string | null;
+    try {
+      identity = await this.processStartIdentity();
+    } catch (error: unknown) {
+      throw new DaemonIdentityFileError("unsafe_owner", "unable to verify operation lease owner", { cause: error });
+    }
+    if (identity === null || !isCanonicalProcessIdentity(identity)) {
+      throw new DaemonIdentityFileError("unsafe_owner", "unable to verify operation lease owner");
+    }
+    return identity;
+  }
+
+  private async waitForOrRecoverOwner(
+    files: ProtectedFileSystem,
+    operationPath: string,
+    signal: AbortSignal | undefined,
+  ): Promise<void> {
+    const before = files.assertProtectedRegularFile(operationPath);
+    const owner = decodeOperationOwner(files.readProtectedFile(operationPath, MAX_OWNER_BYTES));
+    const after = files.assertProtectedRegularFile(operationPath);
+    if (!sameProtectedFile(before, after)) return;
+
+    let actual: string | null;
+    try {
+      actual = await this.processIdentity(owner.pid);
+    } catch (error: unknown) {
+      throw new DaemonIdentityFileError("unsafe_owner", "unable to verify operation lease owner", { cause: error });
+    }
+    if (actual === null) {
+      const finalBefore = files.assertProtectedRegularFile(operationPath);
+      const finalOwner = decodeOperationOwner(files.readProtectedFile(operationPath, MAX_OWNER_BYTES));
+      const finalAfter = files.assertProtectedRegularFile(operationPath);
+      const unchanged = sameProtectedFile(after, finalBefore)
+        && sameProtectedFile(finalBefore, finalAfter)
+        && sameOwner(owner, finalOwner);
+      if (unchanged) files.unlink(operationPath);
+      return;
+    }
+    if (actual !== owner.processStartIdentity) {
+      throw new DaemonIdentityFileError("unsafe_owner", "operation lease owner identity changed");
+    }
+    await this.delay(POLL_INTERVAL_MS, signal);
+  }
+
+  private ownedLease(
+    files: ProtectedFileSystem,
+    operationPath: string,
+    fd: number,
+    owner: Readonly<OperationOwner>,
+  ): DaemonOperationLeaseHandle {
+    let released = false;
+    return {
+      release: (): void => {
+        if (released) return;
+        released = true;
+        try {
+          const held = fstatSync(fd);
+          if (files.pathExists(operationPath)) {
+            const pathStat = files.assertProtectedRegularFile(operationPath);
+            const current = decodeOperationOwner(files.readProtectedFile(operationPath, MAX_OWNER_BYTES));
+            const finalStat = files.assertProtectedRegularFile(operationPath);
+            if (sameProtectedFile(held, pathStat)
+              && sameProtectedFile(pathStat, finalStat)
+              && sameOwner(current, owner)) {
+              files.unlink(operationPath);
+            }
+          }
+        } finally {
+          closeSync(fd);
+        }
+      },
+    };
+  }
+}
+
+export function decodeOperationOwner(text: string): OperationOwner {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch (error: unknown) {
+    throw new DaemonIdentityFileError("invalid_identity", "invalid daemon operation lease JSON", { cause: error });
+  }
+  if (!isRecord(parsed) || !hasExactKeys(parsed, OWNER_KEYS)
+    || parsed.version !== 1
+    || !isPositiveSafeInteger(parsed.pid)
+    || !isCanonicalProcessIdentity(parsed.processStartIdentity)
+    || typeof parsed.leaseToken !== "string" || parsed.leaseToken.length === 0) {
+    throw new DaemonIdentityFileError("invalid_identity", "invalid daemon operation lease schema");
+  }
+  return {
+    version: 1,
+    pid: parsed.pid,
+    processStartIdentity: parsed.processStartIdentity,
+    leaseToken: parsed.leaseToken,
+  };
+}
+
+function sameOwner(left: Readonly<OperationOwner>, right: Readonly<OperationOwner>): boolean {
+  return left.version === right.version
+    && left.pid === right.pid
+    && left.processStartIdentity === right.processStartIdentity
+    && left.leaseToken === right.leaseToken;
+}
+
+function normalizeAcquireError(error: unknown): unknown {
+  if (error instanceof DaemonIdentityFileError) return error;
+  return new DaemonIdentityFileError("io_error", "unable to acquire daemon operation lease", { cause: error });
+}
+
+function hasExactKeys(value: Readonly<Record<string, unknown>>, expected: readonly string[]): boolean {
+  const keys = Object.keys(value).sort();
+  return keys.length === expected.length && [...expected].sort().every((key, index) => keys[index] === key);
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isCanonicalProcessIdentity(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  if (/^linux:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:(0|[1-9]\d*)$/u.test(value)
+    || /^windows:(0|[1-9]\d{0,19})$/u.test(value)) return true;
+  const macOs = /^macos:(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)$/u.exec(value);
+  if (macOs?.[1] === undefined) return false;
+  const milliseconds = Date.parse(macOs[1]);
+  return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString().replace(".000Z", "Z") === macOs[1];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+async function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => signal?.removeEventListener("abort", abort);
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const abort = (): void => {
+      clearTimeout(timer);
+      cleanup();
+      reject(signal?.reason ?? new DOMException("aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}

--- a/src/daemon/operation_lease.ts
+++ b/src/daemon/operation_lease.ts
@@ -64,7 +64,9 @@ export interface DaemonOperationLeaseFileOptions extends ProtectedFileOptions {
   ) => Promise<string | null>;
   readonly createToken?: () => string;
   readonly delay?: (ms: number, signal?: AbortSignal) => Promise<void>;
-  readonly onInitializationPhase?: (phase: "database_prepared" | "database_published") => void;
+  readonly onInitializationPhase?: (
+    phase: "database_prepared" | "database_published",
+  ) => void | Promise<void>;
   readonly onPhase?: (phase: "os_locked" | "held_published" | "released_published" | "database_closing") => void;
 }
 
@@ -179,6 +181,7 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
       `${OPERATION_DATABASE_INIT_PREFIX}${this.pid}-${Buffer.from(processStartIdentity).toString("base64url")}-${randomUUID()}`,
     );
     let fd: number | undefined;
+    let publishedOwnDatabase = false;
     try {
       fd = openSync(initPath, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR, 0o600);
       writeAllSync(fd, emptyDatabaseImage(), this.write);
@@ -188,16 +191,23 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
       closeSync(fd);
       fd = undefined;
       this.validateDatabase(files, initPath);
-      this.onInitializationPhase("database_prepared");
+      const prepared = this.onInitializationPhase("database_prepared");
+      if (prepared !== undefined) await prepared;
       try {
         linkSync(initPath, databasePath);
         files.flushDirectory();
-        this.onInitializationPhase("database_published");
+        publishedOwnDatabase = true;
+        const published = this.onInitializationPhase("database_published");
+        if (published !== undefined) await published;
       } catch (error: unknown) {
         if (!isAlreadyExists(error)) throw error;
       }
       files.assertProtectedRegularFile(databasePath);
-      files.unlink(initPath);
+      if (publishedOwnDatabase) {
+        this.cleanupPublishedOwnDatabaseInitTemp(files, initPath);
+      } else {
+        files.unlink(initPath);
+      }
     } catch (error: unknown) {
       if (fd !== undefined) closeSync(fd);
       this.cleanupOwnDatabaseInitTemp(files, initPath);
@@ -220,6 +230,16 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
       database?.close();
     }
     files.assertProtectedRegularFile(databasePath);
+  }
+
+  private cleanupPublishedOwnDatabaseInitTemp(files: ProtectedFileSystem, initPath: string): void {
+    try {
+      unlinkSync(initPath);
+    } catch (error: unknown) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    files.flushDirectory();
   }
 
   private cleanupOwnDatabaseInitTemp(files: ProtectedFileSystem, initPath: string): void {
@@ -511,6 +531,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isAlreadyExists(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 }
 
 async function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {

--- a/src/daemon/operation_lease.ts
+++ b/src/daemon/operation_lease.ts
@@ -1,6 +1,7 @@
-import { createHash, randomUUID } from "node:crypto";
-import { closeSync, fstatSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { closeSync, constants, fsyncSync, openSync, renameSync, unlinkSync, writeSync } from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import {
   captureProcessStartIdentity,
   isCanonicalProcessStartIdentity,
@@ -9,14 +10,18 @@ import {
 import {
   DaemonIdentityFileError,
   ProtectedFileSystem,
-  sameProtectedFile,
   type ProtectedFileOptions,
 } from "./protected_file.js";
 
-const OPERATION_FILE = "daemon.operation.lock";
+const OPERATION_DATABASE = "daemon.operation.db";
+const OPERATION_OWNER = "daemon.operation.owner.json";
+const OPERATION_OWNER_TEMP = ".daemon.operation.owner.json.tmp";
 const MAX_OWNER_BYTES = 4 * 1024;
 const POLL_INTERVAL_MS = 50;
-const OWNER_KEYS = ["version", "pid", "processStartIdentity", "leaseToken"] as const;
+const SQLITE_BUSY = 5;
+const SQLITE_LOCKED = 6;
+const OWNER_KEYS = ["version", "state", "pid", "processStartIdentity", "leaseToken"] as const;
+const SIDECAR_SUFFIXES = ["-journal", "-wal", "-shm"] as const;
 
 export interface DaemonOperationLeaseHandle {
   release(): void;
@@ -39,10 +44,12 @@ export interface DaemonOperationLeaseFileOptions extends ProtectedFileOptions {
   ) => Promise<string | null>;
   readonly createToken?: () => string;
   readonly delay?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  readonly onPhase?: (phase: "os_locked" | "held_published" | "released_published" | "database_closing") => void;
 }
 
-interface OperationOwner {
+export interface OperationOwner {
   readonly version: 1;
+  readonly state: "held" | "released";
   readonly pid: number;
   readonly processStartIdentity: string;
   readonly leaseToken: string;
@@ -60,6 +67,7 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
   private readonly createToken: () => string;
   private readonly delay: (ms: number, signal?: AbortSignal) => Promise<void>;
   private readonly protectedOptions: ProtectedFileOptions;
+  private readonly onPhase: NonNullable<DaemonOperationLeaseFileOptions["onPhase"]>;
 
   constructor(options: Readonly<DaemonOperationLeaseFileOptions> = {}) {
     this.pid = options.pid ?? process.pid;
@@ -69,6 +77,7 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
       ?? (async (pid, context) => await captureProcessStartIdentity(pid, undefined, context));
     this.createToken = options.createToken ?? randomUUID;
     this.delay = options.delay ?? abortableDelay;
+    this.onPhase = options.onPhase ?? (() => undefined);
     this.protectedOptions = {
       ...(options.platform === undefined ? {} : { platform: options.platform }),
       ...(options.runCommand === undefined ? {} : { runCommand: options.runCommand }),
@@ -82,37 +91,114 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
     const signal = context.signal;
     signal?.throwIfAborted();
     const processStartIdentity = await this.captureOwnerIdentity(signal);
-    const owner: OperationOwner = {
+    const held: OperationOwner = {
       version: 1,
+      state: "held",
       pid: this.pid,
       processStartIdentity,
       leaseToken: this.createToken(),
     };
     const files = new ProtectedFileSystem(dataDir, this.protectedOptions);
     files.ensureProtectedDirectory();
-    const operationPath = path.join(files.directory, OPERATION_FILE);
+    const databasePath = path.join(files.directory, OPERATION_DATABASE);
+    const ownerPath = path.join(files.directory, OPERATION_OWNER);
+    const tempPath = path.join(files.directory, OPERATION_OWNER_TEMP);
+    this.ensureDatabase(files, databasePath);
 
     for (;;) {
       signal?.throwIfAborted();
-      let fd: number;
+      this.assertDatabaseAssets(files, databasePath);
+      let database: DatabaseSync | undefined;
       try {
-        fd = files.createExclusiveFile(operationPath, `${JSON.stringify(owner)}\n`);
+        database = new DatabaseSync(databasePath, { timeout: 0 });
+        database.exec("BEGIN EXCLUSIVE");
       } catch (error: unknown) {
-        if (!isAlreadyExists(error)) throw normalizeAcquireError(error);
-        try {
-          await this.waitForOrRecoverOwner(files, operationPath, signal);
-        } catch (ownerError: unknown) {
-          if (!isNotFound(ownerError) && files.pathExists(operationPath)) {
-            throw normalizeAcquireError(ownerError);
-          }
+        database?.close();
+        if (isSqliteBusy(error)) {
+          await this.delay(POLL_INTERVAL_MS, signal);
+          continue;
         }
-        continue;
+        throw normalizeAcquireError(error);
       }
-      return this.ownedLease(files, operationPath, fd, owner);
+
+      try {
+        this.onPhase("os_locked");
+        signal?.throwIfAborted();
+        this.assertDatabaseAssets(files, databasePath);
+        this.cleanupOwnerTemp(files, tempPath);
+        await this.verifyPreviousOwner(files, ownerPath, signal);
+        this.publishOwner(files, ownerPath, tempPath, held);
+        this.onPhase("held_published");
+        return this.ownedLease(files, database, ownerPath, tempPath, held);
+      } catch (error: unknown) {
+        closeDatabase(database);
+        throw normalizeAcquireError(error);
+      }
     }
   }
 
-  private async captureOwnerIdentity(signal: AbortSignal | undefined): Promise<string> {
+  private ensureDatabase(files: ProtectedFileSystem, databasePath: string): void {
+    if (!files.pathExists(databasePath)) {
+      let fd: number | undefined;
+      try {
+        fd = openSync(databasePath, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR, 0o600);
+        writeSync(fd, emptyDatabaseImage());
+        fsyncSync(fd);
+        closeSync(fd);
+        fd = undefined;
+        files.protectFile(databasePath);
+        files.assertProtectedRegularFile(databasePath);
+        files.flushDirectory();
+      } catch (error: unknown) {
+        if (fd !== undefined) closeSync(fd);
+        if (!isAlreadyExists(error)) throw normalizeAcquireError(error);
+      }
+    }
+    files.assertProtectedRegularFile(databasePath);
+  }
+
+  private assertDatabaseAssets(files: ProtectedFileSystem, databasePath: string): void {
+    files.ensureProtectedDirectory();
+    files.assertProtectedRegularFile(databasePath);
+    for (const suffix of SIDECAR_SUFFIXES) {
+      const sidecar = databasePath + suffix;
+      if (files.pathExists(sidecar)) {
+        files.assertProtectedRegularFile(sidecar);
+        throw new DaemonIdentityFileError("unsafe_path", "unexpected daemon operation database sidecar");
+      }
+    }
+  }
+
+  private cleanupOwnerTemp(files: ProtectedFileSystem, tempPath: string): void {
+    if (!files.pathExists(tempPath)) return;
+    files.assertProtectedRegularFile(tempPath);
+    unlinkSync(tempPath);
+    files.flushDirectory();
+  }
+
+  private async verifyPreviousOwner(
+    files: ProtectedFileSystem,
+    ownerPath: string,
+    signal: AbortSignal | undefined,
+  ): Promise<void> {
+    if (!files.pathExists(ownerPath)) return;
+    const previous = this.readOwner(files, ownerPath);
+    if (previous.state === "released") return;
+
+    let actual: string | null;
+    try {
+      actual = await this.processIdentity(previous.pid, { ...(signal === undefined ? {} : { signal }) });
+    } catch (error: unknown) {
+      throw new DaemonIdentityFileError("unsafe_owner", "unable to verify operation lease owner", { cause: error });
+    }
+    if (actual === null) return;
+    if (actual === previous.processStartIdentity) {
+      throw new DaemonIdentityFileError("unsafe_owner", "operation lease owner is still active");
+    }
+    throw new DaemonIdentityFileError("unsafe_owner", "operation lease owner identity changed");
+  }
+
+  private captureOwnerIdentity = async (signal: AbortSignal | undefined): Promise<string> => {
     let identity: string | null;
     try {
       identity = await this.processStartIdentity({ ...(signal === undefined ? {} : { signal }) });
@@ -123,105 +209,81 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
       throw new DaemonIdentityFileError("unsafe_owner", "unable to verify operation lease owner");
     }
     return identity;
+  };
+
+  private readOwner(files: ProtectedFileSystem, ownerPath: string): OperationOwner {
+    files.assertProtectedRegularFile(ownerPath);
+    const owner = decodeOperationOwner(files.readProtectedFile(ownerPath, MAX_OWNER_BYTES));
+    files.assertProtectedRegularFile(ownerPath);
+    return owner;
   }
 
-  private async waitForOrRecoverOwner(
+  private publishOwner(
     files: ProtectedFileSystem,
-    operationPath: string,
-    signal: AbortSignal | undefined,
-  ): Promise<void> {
-    const before = files.assertProtectedRegularFile(operationPath);
-    const owner = decodeOperationOwner(files.readProtectedFile(operationPath, MAX_OWNER_BYTES));
-    const after = files.assertProtectedRegularFile(operationPath);
-    if (!sameProtectedFile(before, after)) return;
-
-    let actual: string | null;
-    try {
-      actual = await this.processIdentity(owner.pid, { ...(signal === undefined ? {} : { signal }) });
-    } catch (error: unknown) {
-      throw new DaemonIdentityFileError("unsafe_owner", "unable to verify operation lease owner", { cause: error });
-    }
-    if (actual === null) {
-      await this.recoverDeadOwner(files, operationPath, after, owner, signal);
-      return;
-    }
-    if (actual !== owner.processStartIdentity) {
-      throw new DaemonIdentityFileError("unsafe_owner", "operation lease owner identity changed");
-    }
-    await this.delay(POLL_INTERVAL_MS, signal);
-  }
-
-  private async recoverDeadOwner(
-    files: ProtectedFileSystem,
-    operationPath: string,
-    observedFile: ReturnType<ProtectedFileSystem["assertProtectedRegularFile"]>,
+    ownerPath: string,
+    tempPath: string,
     owner: Readonly<OperationOwner>,
-    signal: AbortSignal | undefined,
-  ): Promise<void> {
-    const claimPath = path.join(
-      files.directory,
-      `.daemon.operation.recovery.${createHash("sha256").update(owner.leaseToken).digest("hex")}.lock`,
-    );
+  ): void {
+    let fd: number | undefined;
     try {
-      files.createHardLink(operationPath, claimPath);
+      fd = openSync(tempPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+      writeSync(fd, `${JSON.stringify(owner)}\n`, 0, "utf8");
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = undefined;
+      files.protectFile(tempPath);
+      files.assertProtectedRegularFile(tempPath);
+      renameSync(tempPath, ownerPath);
+      files.flushDirectory();
+      const published = this.readOwner(files, ownerPath);
+      if (!sameOwner(published, owner)) {
+        throw new DaemonIdentityFileError("unsafe_owner", "daemon operation owner changed during publication");
+      }
     } catch (error: unknown) {
-      if (isAlreadyExists(error) || isNotFound(error)) {
-        await this.delay(POLL_INTERVAL_MS, signal);
-        return;
+      if (fd !== undefined) closeSync(fd);
+      if (files.pathExists(tempPath)) {
+        try {
+          files.assertProtectedRegularFile(tempPath);
+          unlinkSync(tempPath);
+          files.flushDirectory();
+        } catch {
+          // Preserve the original sanitized failure. A later acquisition validates the temp file.
+        }
       }
       throw error;
-    }
-
-    try {
-      const claimedFile = files.assertProtectedRegularFile(claimPath);
-      const claimedOwner = decodeOperationOwner(files.readProtectedFile(claimPath, MAX_OWNER_BYTES));
-      const claimedAfter = files.assertProtectedRegularFile(claimPath);
-      if (!sameProtectedFile(observedFile, claimedFile)
-        || !sameProtectedFile(claimedFile, claimedAfter)
-        || !sameOwner(owner, claimedOwner)) {
-        return;
-      }
-
-      const currentFile = files.assertProtectedRegularFile(operationPath);
-      const currentOwner = decodeOperationOwner(files.readProtectedFile(operationPath, MAX_OWNER_BYTES));
-      const currentAfter = files.assertProtectedRegularFile(operationPath);
-      if (sameProtectedFile(claimedFile, currentFile)
-        && sameProtectedFile(currentFile, currentAfter)
-        && sameOwner(owner, currentOwner)) {
-        files.unlink(operationPath);
-      }
-    } finally {
-      files.unlinkIfExists(claimPath);
-      files.flushDirectory();
     }
   }
 
   private ownedLease(
     files: ProtectedFileSystem,
-    operationPath: string,
-    fd: number,
-    owner: Readonly<OperationOwner>,
+    database: DatabaseSync,
+    ownerPath: string,
+    tempPath: string,
+    held: Readonly<OperationOwner>,
   ): DaemonOperationLeaseHandle {
     let released = false;
     return {
       release: (): void => {
         if (released) return;
         released = true;
+        let publicationError: unknown;
         try {
-          const held = fstatSync(fd);
-          if (files.pathExists(operationPath)) {
-            const pathStat = files.assertProtectedRegularFile(operationPath);
-            const current = decodeOperationOwner(files.readProtectedFile(operationPath, MAX_OWNER_BYTES));
-            const finalStat = files.assertProtectedRegularFile(operationPath);
-            if (sameProtectedFile(held, pathStat)
-              && sameProtectedFile(pathStat, finalStat)
-              && sameOwner(current, owner)) {
-              files.unlink(operationPath);
-            }
+          const current = this.readOwner(files, ownerPath);
+          if (!sameOwner(current, held) || current.state !== "held") {
+            throw new DaemonIdentityFileError("unsafe_owner", "daemon operation ownership changed before release");
           }
+          this.publishOwner(files, ownerPath, tempPath, { ...held, state: "released" });
+          this.onPhase("released_published");
+        } catch (error: unknown) {
+          publicationError = error;
         } finally {
-          closeSync(fd);
+          try {
+            this.onPhase("database_closing");
+          } finally {
+            closeDatabase(database);
+          }
         }
+        if (publicationError !== undefined) throw normalizeAcquireError(publicationError);
       },
     };
   }
@@ -232,17 +294,19 @@ export function decodeOperationOwner(text: string): OperationOwner {
   try {
     parsed = JSON.parse(text) as unknown;
   } catch (error: unknown) {
-    throw new DaemonIdentityFileError("invalid_identity", "invalid daemon operation lease JSON", { cause: error });
+    throw new DaemonIdentityFileError("invalid_identity", "invalid daemon operation owner JSON", { cause: error });
   }
   if (!isRecord(parsed) || !hasExactKeys(parsed, OWNER_KEYS)
     || parsed.version !== 1
+    || (parsed.state !== "held" && parsed.state !== "released")
     || !isPositiveSafeInteger(parsed.pid)
     || !isCanonicalProcessStartIdentity(parsed.processStartIdentity)
-    || typeof parsed.leaseToken !== "string" || parsed.leaseToken.length === 0) {
-    throw new DaemonIdentityFileError("invalid_identity", "invalid daemon operation lease schema");
+    || typeof parsed.leaseToken !== "string" || parsed.leaseToken.length === 0 || parsed.leaseToken.length > 256) {
+    throw new DaemonIdentityFileError("invalid_identity", "invalid daemon operation owner schema");
   }
   return {
     version: 1,
+    state: parsed.state,
     pid: parsed.pid,
     processStartIdentity: parsed.processStartIdentity,
     leaseToken: parsed.leaseToken,
@@ -251,9 +315,40 @@ export function decodeOperationOwner(text: string): OperationOwner {
 
 function sameOwner(left: Readonly<OperationOwner>, right: Readonly<OperationOwner>): boolean {
   return left.version === right.version
+    && left.state === right.state
     && left.pid === right.pid
     && left.processStartIdentity === right.processStartIdentity
     && left.leaseToken === right.leaseToken;
+}
+
+let databaseImage: Buffer | undefined;
+
+function emptyDatabaseImage(): Buffer {
+  if (databaseImage !== undefined) return databaseImage;
+  const memory = new DatabaseSync(":memory:");
+  try {
+    databaseImage = Buffer.from((memory as unknown as { serialize(): Uint8Array }).serialize());
+    return databaseImage;
+  } finally {
+    memory.close();
+  }
+}
+
+function closeDatabase(database: DatabaseSync): void {
+  try {
+    database.exec("ROLLBACK");
+  } catch {
+    // close() also releases the OS lock if SQLite already rolled the transaction back.
+  } finally {
+    database.close();
+  }
+}
+
+function isSqliteBusy(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("errcode" in error)) return false;
+  const code = error.errcode;
+  return typeof code === "number"
+    && ((code & 0xff) === SQLITE_BUSY || (code & 0xff) === SQLITE_LOCKED);
 }
 
 function normalizeAcquireError(error: unknown): unknown {
@@ -276,10 +371,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isAlreadyExists(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
-}
-
-function isNotFound(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 }
 
 async function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {

--- a/src/daemon/operation_lease.ts
+++ b/src/daemon/operation_lease.ts
@@ -1,7 +1,11 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { closeSync, fstatSync } from "node:fs";
 import path from "node:path";
-import { captureProcessStartIdentity } from "./process_identity.js";
+import {
+  captureProcessStartIdentity,
+  isCanonicalProcessStartIdentity,
+  type ProcessIdentityContext,
+} from "./process_identity.js";
 import {
   DaemonIdentityFileError,
   ProtectedFileSystem,
@@ -28,8 +32,11 @@ export interface DaemonOperationLeaseAccess {
 
 export interface DaemonOperationLeaseFileOptions extends ProtectedFileOptions {
   readonly pid?: number;
-  readonly processStartIdentity?: () => Promise<string | null>;
-  readonly processIdentity?: (pid: number) => Promise<string | null>;
+  readonly processStartIdentity?: (context?: Readonly<ProcessIdentityContext>) => Promise<string | null>;
+  readonly processIdentity?: (
+    pid: number,
+    context?: Readonly<ProcessIdentityContext>,
+  ) => Promise<string | null>;
   readonly createToken?: () => string;
   readonly delay?: (ms: number, signal?: AbortSignal) => Promise<void>;
 }
@@ -43,8 +50,13 @@ interface OperationOwner {
 
 export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
   private readonly pid: number;
-  private readonly processStartIdentity: () => Promise<string | null>;
-  private readonly processIdentity: (pid: number) => Promise<string | null>;
+  private readonly processStartIdentity: (
+    context?: Readonly<ProcessIdentityContext>,
+  ) => Promise<string | null>;
+  private readonly processIdentity: (
+    pid: number,
+    context?: Readonly<ProcessIdentityContext>,
+  ) => Promise<string | null>;
   private readonly createToken: () => string;
   private readonly delay: (ms: number, signal?: AbortSignal) => Promise<void>;
   private readonly protectedOptions: ProtectedFileOptions;
@@ -52,8 +64,9 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
   constructor(options: Readonly<DaemonOperationLeaseFileOptions> = {}) {
     this.pid = options.pid ?? process.pid;
     this.processStartIdentity = options.processStartIdentity
-      ?? (async () => await captureProcessStartIdentity(this.pid));
-    this.processIdentity = options.processIdentity ?? captureProcessStartIdentity;
+      ?? (async (context) => await captureProcessStartIdentity(this.pid, undefined, context));
+    this.processIdentity = options.processIdentity
+      ?? (async (pid, context) => await captureProcessStartIdentity(pid, undefined, context));
     this.createToken = options.createToken ?? randomUUID;
     this.delay = options.delay ?? abortableDelay;
     this.protectedOptions = {
@@ -68,7 +81,7 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
   ): Promise<DaemonOperationLeaseHandle> {
     const signal = context.signal;
     signal?.throwIfAborted();
-    const processStartIdentity = await this.captureOwnerIdentity();
+    const processStartIdentity = await this.captureOwnerIdentity(signal);
     const owner: OperationOwner = {
       version: 1,
       pid: this.pid,
@@ -99,14 +112,14 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
     }
   }
 
-  private async captureOwnerIdentity(): Promise<string> {
+  private async captureOwnerIdentity(signal: AbortSignal | undefined): Promise<string> {
     let identity: string | null;
     try {
-      identity = await this.processStartIdentity();
+      identity = await this.processStartIdentity({ ...(signal === undefined ? {} : { signal }) });
     } catch (error: unknown) {
       throw new DaemonIdentityFileError("unsafe_owner", "unable to verify operation lease owner", { cause: error });
     }
-    if (identity === null || !isCanonicalProcessIdentity(identity)) {
+    if (identity === null || !isCanonicalProcessStartIdentity(identity)) {
       throw new DaemonIdentityFileError("unsafe_owner", "unable to verify operation lease owner");
     }
     return identity;
@@ -124,24 +137,63 @@ export class DaemonOperationLeaseFile implements DaemonOperationLeaseAccess {
 
     let actual: string | null;
     try {
-      actual = await this.processIdentity(owner.pid);
+      actual = await this.processIdentity(owner.pid, { ...(signal === undefined ? {} : { signal }) });
     } catch (error: unknown) {
       throw new DaemonIdentityFileError("unsafe_owner", "unable to verify operation lease owner", { cause: error });
     }
     if (actual === null) {
-      const finalBefore = files.assertProtectedRegularFile(operationPath);
-      const finalOwner = decodeOperationOwner(files.readProtectedFile(operationPath, MAX_OWNER_BYTES));
-      const finalAfter = files.assertProtectedRegularFile(operationPath);
-      const unchanged = sameProtectedFile(after, finalBefore)
-        && sameProtectedFile(finalBefore, finalAfter)
-        && sameOwner(owner, finalOwner);
-      if (unchanged) files.unlink(operationPath);
+      await this.recoverDeadOwner(files, operationPath, after, owner, signal);
       return;
     }
     if (actual !== owner.processStartIdentity) {
       throw new DaemonIdentityFileError("unsafe_owner", "operation lease owner identity changed");
     }
     await this.delay(POLL_INTERVAL_MS, signal);
+  }
+
+  private async recoverDeadOwner(
+    files: ProtectedFileSystem,
+    operationPath: string,
+    observedFile: ReturnType<ProtectedFileSystem["assertProtectedRegularFile"]>,
+    owner: Readonly<OperationOwner>,
+    signal: AbortSignal | undefined,
+  ): Promise<void> {
+    const claimPath = path.join(
+      files.directory,
+      `.daemon.operation.recovery.${createHash("sha256").update(owner.leaseToken).digest("hex")}.lock`,
+    );
+    try {
+      files.createHardLink(operationPath, claimPath);
+    } catch (error: unknown) {
+      if (isAlreadyExists(error) || isNotFound(error)) {
+        await this.delay(POLL_INTERVAL_MS, signal);
+        return;
+      }
+      throw error;
+    }
+
+    try {
+      const claimedFile = files.assertProtectedRegularFile(claimPath);
+      const claimedOwner = decodeOperationOwner(files.readProtectedFile(claimPath, MAX_OWNER_BYTES));
+      const claimedAfter = files.assertProtectedRegularFile(claimPath);
+      if (!sameProtectedFile(observedFile, claimedFile)
+        || !sameProtectedFile(claimedFile, claimedAfter)
+        || !sameOwner(owner, claimedOwner)) {
+        return;
+      }
+
+      const currentFile = files.assertProtectedRegularFile(operationPath);
+      const currentOwner = decodeOperationOwner(files.readProtectedFile(operationPath, MAX_OWNER_BYTES));
+      const currentAfter = files.assertProtectedRegularFile(operationPath);
+      if (sameProtectedFile(claimedFile, currentFile)
+        && sameProtectedFile(currentFile, currentAfter)
+        && sameOwner(owner, currentOwner)) {
+        files.unlink(operationPath);
+      }
+    } finally {
+      files.unlinkIfExists(claimPath);
+      files.flushDirectory();
+    }
   }
 
   private ownedLease(
@@ -185,7 +237,7 @@ export function decodeOperationOwner(text: string): OperationOwner {
   if (!isRecord(parsed) || !hasExactKeys(parsed, OWNER_KEYS)
     || parsed.version !== 1
     || !isPositiveSafeInteger(parsed.pid)
-    || !isCanonicalProcessIdentity(parsed.processStartIdentity)
+    || !isCanonicalProcessStartIdentity(parsed.processStartIdentity)
     || typeof parsed.leaseToken !== "string" || parsed.leaseToken.length === 0) {
     throw new DaemonIdentityFileError("invalid_identity", "invalid daemon operation lease schema");
   }
@@ -216,16 +268,6 @@ function hasExactKeys(value: Readonly<Record<string, unknown>>, expected: readon
 
 function isPositiveSafeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
-}
-
-function isCanonicalProcessIdentity(value: unknown): value is string {
-  if (typeof value !== "string") return false;
-  if (/^linux:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:(0|[1-9]\d*)$/u.test(value)
-    || /^windows:(0|[1-9]\d{0,19})$/u.test(value)) return true;
-  const macOs = /^macos:(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)$/u.exec(value);
-  if (macOs?.[1] === undefined) return false;
-  const milliseconds = Date.parse(macOs[1]);
-  return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString().replace(".000Z", "Z") === macOs[1];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/daemon/process_identity.ts
+++ b/src/daemon/process_identity.ts
@@ -3,13 +3,29 @@ import { readFile } from "node:fs/promises";
 
 export type ProcessStartIdentity = string;
 
+export function isCanonicalProcessStartIdentity(value: unknown): value is ProcessStartIdentity {
+  if (typeof value !== "string") return false;
+  if (/^linux:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:(0|[1-9]\d*)$/u.test(value)
+    || /^windows:(0|[1-9]\d{0,19})$/u.test(value)) return true;
+  const macOs = /^macos:(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)$/u.exec(value);
+  if (macOs?.[1] === undefined) return false;
+  const milliseconds = Date.parse(macOs[1]);
+  return Number.isFinite(milliseconds)
+    && new Date(milliseconds).toISOString().replace(".000Z", "Z") === macOs[1];
+}
+
+export interface ProcessIdentityContext {
+  readonly signal?: AbortSignal;
+}
+
 export interface ProcessIdentityDependencies {
   readonly platform: NodeJS.Platform;
-  readonly readFile: (path: string) => Promise<string>;
+  readonly readFile: (path: string, context?: Readonly<ProcessIdentityContext>) => Promise<string>;
   readonly runCommand: (
     file: string,
     args: readonly string[],
     env: Readonly<Record<string, string>>,
+    context?: Readonly<ProcessIdentityContext>,
   ) => Promise<string>;
 }
 
@@ -22,7 +38,10 @@ export class ProcessIdentityError extends Error {
 
 const DEFAULT_DEPENDENCIES: ProcessIdentityDependencies = {
   platform: process.platform,
-  readFile: async (filePath) => await readFile(filePath, "utf8"),
+  readFile: async (filePath, context) => await readFile(filePath, {
+    encoding: "utf8",
+    ...(context?.signal === undefined ? {} : { signal: context.signal }),
+  }),
   runCommand: runCommand,
 };
 const PROCESS_IDENTITY_TIMEOUT_MS = 5_000;
@@ -30,15 +49,16 @@ const PROCESS_IDENTITY_TIMEOUT_MS = 5_000;
 export async function captureProcessStartIdentity(
   pid: number,
   dependencies: ProcessIdentityDependencies = DEFAULT_DEPENDENCIES,
+  context: Readonly<ProcessIdentityContext> = {},
 ): Promise<ProcessStartIdentity | null> {
   assertPid(pid);
   switch (dependencies.platform) {
   case "linux":
-    return await captureLinuxIdentity(pid, dependencies);
+    return await captureLinuxIdentity(pid, dependencies, context);
   case "win32":
-    return await captureWindowsIdentity(pid, dependencies);
+    return await captureWindowsIdentity(pid, dependencies, context);
   case "darwin":
-    return await captureMacOsIdentity(pid, dependencies);
+    return await captureMacOsIdentity(pid, dependencies, context);
   default:
     throw new ProcessIdentityError("process identity is unsupported on this platform");
   }
@@ -57,8 +77,10 @@ export async function terminateProcessIfMatching(
   pid: number,
   expected: ProcessStartIdentity,
   dependencies: ProcessIdentityDependencies = DEFAULT_DEPENDENCIES,
+  context: Readonly<ProcessIdentityContext> = {},
 ): Promise<boolean> {
   assertPid(pid);
+  if (!isCanonicalProcessStartIdentity(expected)) return false;
   if (dependencies.platform === "win32") {
     const filetime = /^windows:(\d{1,20})$/u.exec(expected)?.[1];
     if (filetime === undefined) {
@@ -77,6 +99,7 @@ export async function terminateProcessIfMatching(
         "powershell.exe",
         ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
         {},
+        context,
       );
       return true;
     } catch (error: unknown) {
@@ -102,7 +125,7 @@ export async function terminateProcessIfMatching(
       "[ \"$boot\" = \"$expected_boot\" ] && [ \"$ticks\" = \"$expected_ticks\" ] || exit 4",
       "kill -KILL \"$pid\"",
     ].join("; ");
-    return await runVerifiedTermination("sh", ["-c", script], dependencies);
+    return await runVerifiedTermination("sh", ["-c", script], dependencies, context);
   }
   if (dependencies.platform === "darwin") {
     const timestamp = /^macos:(.+)$/u.exec(expected)?.[1];
@@ -117,7 +140,7 @@ export async function terminateProcessIfMatching(
       "[ \"$actual_epoch\" = \"$expected\" ] || exit 4",
       "kill -KILL \"$pid\"",
     ].join("; ");
-    return await runVerifiedTermination("sh", ["-c", script], dependencies);
+    return await runVerifiedTermination("sh", ["-c", script], dependencies, context);
   }
   return false;
 }
@@ -126,9 +149,10 @@ async function runVerifiedTermination(
   file: string,
   args: readonly string[],
   dependencies: ProcessIdentityDependencies,
+  context: Readonly<ProcessIdentityContext>,
 ): Promise<boolean> {
   try {
-    await dependencies.runCommand(file, args, {});
+    await dependencies.runCommand(file, args, {}, context);
     return true;
   } catch (error: unknown) {
     if (commandExitCode(error) === 3 || commandExitCode(error) === 4) {
@@ -162,10 +186,11 @@ export function parseLinuxProcStatStartTicks(stat: string, expectedPid: number):
 async function captureLinuxIdentity(
   pid: number,
   dependencies: ProcessIdentityDependencies,
+  context: Readonly<ProcessIdentityContext>,
 ): Promise<ProcessStartIdentity | null> {
   let stat: string;
   try {
-    stat = await dependencies.readFile(`/proc/${pid}/stat`);
+    stat = await dependencies.readFile(`/proc/${pid}/stat`, context);
   } catch (error: unknown) {
     if (isNotFound(error)) {
       return null;
@@ -175,7 +200,7 @@ async function captureLinuxIdentity(
 
   let bootId: string;
   try {
-    bootId = (await dependencies.readFile("/proc/sys/kernel/random/boot_id")).trim().toLowerCase();
+    bootId = (await dependencies.readFile("/proc/sys/kernel/random/boot_id", context)).trim().toLowerCase();
   } catch (error: unknown) {
     throw new ProcessIdentityError("unable to read Linux boot identity", { cause: error });
   }
@@ -188,6 +213,7 @@ async function captureLinuxIdentity(
 async function captureWindowsIdentity(
   pid: number,
   dependencies: ProcessIdentityDependencies,
+  context: Readonly<ProcessIdentityContext>,
 ): Promise<ProcessStartIdentity | null> {
   const script = [
     `$process = Get-Process -Id ${pid} -ErrorAction SilentlyContinue`,
@@ -200,6 +226,7 @@ async function captureWindowsIdentity(
       "powershell.exe",
       ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
       {},
+      context,
     );
   } catch (error: unknown) {
     if (commandExitCode(error) === 3) {
@@ -217,6 +244,7 @@ async function captureWindowsIdentity(
 async function captureMacOsIdentity(
   pid: number,
   dependencies: ProcessIdentityDependencies,
+  context: Readonly<ProcessIdentityContext>,
 ): Promise<ProcessStartIdentity | null> {
   let output: string;
   try {
@@ -224,6 +252,7 @@ async function captureMacOsIdentity(
       "ps",
       ["-o", "lstart=", "-p", String(pid)],
       { LC_ALL: "C", TZ: "UTC" },
+      context,
     );
   } catch (error: unknown) {
     if (commandExitCode(error) === 1) {
@@ -264,6 +293,7 @@ async function runCommand(
   file: string,
   args: readonly string[],
   env: Readonly<Record<string, string>>,
+  context: Readonly<ProcessIdentityContext> = {},
 ): Promise<string> {
   return await new Promise<string>((resolve, reject) => {
     execFile(file, [...args], {
@@ -271,6 +301,7 @@ async function runCommand(
       env: { ...process.env, ...env },
       windowsHide: true,
       timeout: PROCESS_IDENTITY_TIMEOUT_MS,
+      ...(context.signal === undefined ? {} : { signal: context.signal }),
     }, (error, stdout) => {
       if (error !== null) {
         reject(error);

--- a/src/daemon/protected_file.ts
+++ b/src/daemon/protected_file.ts
@@ -6,7 +6,6 @@ import {
   fstatSync,
   fsyncSync,
   lstatSync,
-  linkSync,
   mkdirSync,
   openSync,
   readSync,
@@ -51,7 +50,7 @@ export class ProtectedFileSystem {
     this.directory = path.resolve(directory);
     this.platform = options.platform ?? process.platform;
     this.runCommand = options.runCommand ?? defaultRunCommand;
-    this.windowsAcl = new WindowsAcl(this.runCommand);
+    this.windowsAcl = new WindowsAcl(this.runCommand, { cacheIdentity: true });
   }
 
   ensureProtectedDirectory(): void {
@@ -146,11 +145,6 @@ export class ProtectedFileSystem {
     }
   }
 
-  createHardLink(existingPath: string, newPath: string): void {
-    linkSync(existingPath, newPath);
-    this.flushDirectory();
-  }
-
   unlink(filePath: string): void {
     unlinkSync(filePath);
     this.flushDirectory();
@@ -223,10 +217,6 @@ export class ProtectedFileSystem {
   }
 }
 
-export function sameProtectedFile(left: Stats, right: Stats): boolean {
-  return sameFile(left, right);
-}
-
 function sameFile(left: Stats, right: Stats): boolean {
   return left.dev === right.dev && left.ino === right.ino;
 }
@@ -234,6 +224,9 @@ function sameFile(left: Stats, right: Stats): boolean {
 function isNotFound(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 }
+
+const WINDOWS_SECURITY_COMMAND_TIMEOUT_MS = 5_000;
+const WINDOWS_SECURITY_COMMAND_MAX_BUFFER_BYTES = 1024 * 1024;
 
 function defaultRunCommand(file: string, args: readonly string[]): string {
   const resolved = process.platform === "win32" && (file === "whoami" || file === "icacls")
@@ -243,6 +236,8 @@ function defaultRunCommand(file: string, args: readonly string[]): string {
     encoding: "utf8",
     windowsHide: true,
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: WINDOWS_SECURITY_COMMAND_TIMEOUT_MS,
+    maxBuffer: WINDOWS_SECURITY_COMMAND_MAX_BUFFER_BYTES,
   });
 }
 

--- a/src/daemon/protected_file.ts
+++ b/src/daemon/protected_file.ts
@@ -6,6 +6,7 @@ import {
   fstatSync,
   fsyncSync,
   lstatSync,
+  linkSync,
   mkdirSync,
   openSync,
   readSync,
@@ -143,6 +144,11 @@ export class ProtectedFileSystem {
       if (isNotFound(error)) return false;
       throw error;
     }
+  }
+
+  createHardLink(existingPath: string, newPath: string): void {
+    linkSync(existingPath, newPath);
+    this.flushDirectory();
   }
 
   unlink(filePath: string): void {

--- a/src/daemon/protected_file.ts
+++ b/src/daemon/protected_file.ts
@@ -1,0 +1,256 @@
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  unlinkSync,
+  writeSync,
+  type Stats,
+} from "node:fs";
+import path from "node:path";
+import { InvalidWindowsIdentityError, WindowsAcl, windowsCommandPath } from "../security/windows_acl.js";
+
+export type DaemonIdentityFileErrorCode =
+  | "invalid_identity"
+  | "lease_conflict"
+  | "unsafe_path"
+  | "unsafe_owner"
+  | "unsafe_permissions"
+  | "io_error";
+
+export class DaemonIdentityFileError extends Error {
+  constructor(
+    readonly code: DaemonIdentityFileErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "DaemonIdentityFileError";
+  }
+}
+
+export interface ProtectedFileOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly runCommand?: (file: string, args: readonly string[]) => string;
+}
+
+export class ProtectedFileSystem {
+  readonly directory: string;
+  private readonly platform: NodeJS.Platform;
+  private readonly runCommand: (file: string, args: readonly string[]) => string;
+  private readonly windowsAcl: WindowsAcl;
+
+  constructor(directory: string, options: Readonly<ProtectedFileOptions> = {}) {
+    this.directory = path.resolve(directory);
+    this.platform = options.platform ?? process.platform;
+    this.runCommand = options.runCommand ?? defaultRunCommand;
+    this.windowsAcl = new WindowsAcl(this.runCommand);
+  }
+
+  ensureProtectedDirectory(): void {
+    let created = false;
+    if (!this.pathExists(this.directory)) {
+      mkdirSync(this.directory, { recursive: true, mode: 0o700 });
+      created = true;
+    }
+    const stat = lstatSync(this.directory);
+    if (!stat.isDirectory() || stat.isSymbolicLink() || this.isWindowsReparsePoint(this.directory)) {
+      throw new DaemonIdentityFileError("unsafe_path", "daemon directory must be a regular directory");
+    }
+    this.assertOwner(stat);
+    if (this.platform === "win32") {
+      if (created) this.restrictWindowsAcl(this.directory, true);
+      this.assertWindowsAcl(this.directory);
+    } else if ((stat.mode & 0o777) !== 0o700) {
+      throw new DaemonIdentityFileError("unsafe_permissions", "daemon directory permissions must be 0700");
+    }
+  }
+
+  createExclusiveFile(filePath: string, contents: string): number {
+    const fd = openSync(filePath, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR, 0o600);
+    try {
+      writeSync(fd, contents, 0, "utf8");
+      fsyncSync(fd);
+      this.protectFile(filePath);
+      this.assertProtectedRegularFile(filePath);
+      return fd;
+    } catch (error: unknown) {
+      const held = fstatSync(fd);
+      closeSync(fd);
+      if (this.pathExists(filePath)) {
+        const current = lstatSync(filePath);
+        if (sameFile(held, current)) this.unlinkIfExists(filePath);
+      }
+      throw error;
+    }
+  }
+
+  readProtectedFile(filePath: string, maximumBytes = 64 * 1024): string {
+    const before = this.assertProtectedRegularFile(filePath);
+    const noFollowFlag = (constants as Readonly<Record<string, number>>)["O_NOFOLLOW"] ?? 0;
+    let fd: number;
+    try {
+      fd = openSync(filePath, constants.O_RDONLY | noFollowFlag);
+    } catch (error: unknown) {
+      throw new DaemonIdentityFileError("unsafe_path", "unable to safely open daemon file", { cause: error });
+    }
+    try {
+      const opened = fstatSync(fd);
+      if (!opened.isFile() || !sameFile(before, opened) || opened.size > maximumBytes) {
+        throw new DaemonIdentityFileError("unsafe_path", "daemon file changed during validation");
+      }
+      const buffer = Buffer.alloc(opened.size);
+      let offset = 0;
+      while (offset < buffer.length) {
+        const count = readSync(fd, buffer, offset, buffer.length - offset, offset);
+        if (count === 0) break;
+        offset += count;
+      }
+      if (offset !== buffer.length) {
+        throw new DaemonIdentityFileError("io_error", "unable to read complete daemon file");
+      }
+      return buffer.toString("utf8");
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  assertProtectedRegularFile(filePath: string): Stats {
+    const stat = lstatSync(filePath);
+    if (!stat.isFile() || stat.isSymbolicLink() || this.isWindowsReparsePoint(filePath)) {
+      throw new DaemonIdentityFileError("unsafe_path", "daemon path must be a regular file");
+    }
+    this.assertOwner(stat);
+    if (this.platform === "win32") {
+      this.assertWindowsAcl(filePath);
+    } else if ((stat.mode & 0o777) !== 0o600) {
+      throw new DaemonIdentityFileError("unsafe_permissions", "daemon file permissions must be 0600");
+    }
+    return stat;
+  }
+
+  pathExists(target: string): boolean {
+    try {
+      lstatSync(target);
+      return true;
+    } catch (error: unknown) {
+      if (isNotFound(error)) return false;
+      throw error;
+    }
+  }
+
+  unlink(filePath: string): void {
+    unlinkSync(filePath);
+    this.flushDirectory();
+  }
+
+  unlinkIfExists(filePath: string): void {
+    try {
+      unlinkSync(filePath);
+    } catch (error: unknown) {
+      if (!isNotFound(error)) throw error;
+    }
+  }
+
+  flushDirectory(): void {
+    if (this.platform === "win32") return;
+    const fd = openSync(this.directory, constants.O_RDONLY);
+    try {
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  private assertOwner(stat: Stats): void {
+    if (this.platform !== "win32" && typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+      throw new DaemonIdentityFileError("unsafe_owner", "daemon path must be owned by the current user");
+    }
+  }
+
+  protectFile(filePath: string): void {
+    if (this.platform === "win32") {
+      this.restrictWindowsAcl(filePath, false);
+    } else {
+      chmodSync(filePath, 0o600);
+    }
+  }
+
+  private isWindowsReparsePoint(target: string): boolean {
+    if (this.platform !== "win32") return false;
+    const script = `$item = Get-Item -LiteralPath '${powerShellLiteral(target)}' -Force; if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { 'true' } else { 'false' }`;
+    return this.runCommand("powershell.exe", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script]).trim() === "true";
+  }
+
+  private restrictWindowsAcl(target: string, directory: boolean): void {
+    const current = this.currentWindowsIdentity();
+    this.windowsAcl.restrict(target, directory, { setOwner: true, currentIdentity: current });
+  }
+
+  private assertWindowsAcl(target: string): void {
+    const current = this.currentWindowsIdentity();
+    const owner = windowsOwner(target, this.runCommand);
+    if (!this.windowsAcl.isCurrentIdentity(owner, current)) {
+      throw new DaemonIdentityFileError("unsafe_owner", "daemon path must be owned by the current user");
+    }
+    const identities = this.windowsAcl.identities(target);
+    if (identities.length !== 1 || !this.windowsAcl.isCurrentIdentity(identities[0] ?? "", current)) {
+      throw new DaemonIdentityFileError("unsafe_permissions", "daemon ACL must be restricted to the current user");
+    }
+  }
+
+  private currentWindowsIdentity() {
+    try {
+      return this.windowsAcl.currentIdentity();
+    } catch (error: unknown) {
+      if (error instanceof InvalidWindowsIdentityError) {
+        throw new DaemonIdentityFileError("unsafe_owner", "unable to resolve current Windows identity");
+      }
+      throw error;
+    }
+  }
+}
+
+export function sameProtectedFile(left: Stats, right: Stats): boolean {
+  return sameFile(left, right);
+}
+
+function sameFile(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function defaultRunCommand(file: string, args: readonly string[]): string {
+  const resolved = process.platform === "win32" && (file === "whoami" || file === "icacls")
+    ? windowsCommandPath(file)
+    : file;
+  return execFileSync(resolved, [...args], {
+    encoding: "utf8",
+    windowsHide: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function windowsOwner(target: string, runCommand: (file: string, args: readonly string[]) => string): string {
+  const securityModule = "$env:windir\\system32\\WindowsPowerShell\\v1.0\\Modules"
+    + "\\Microsoft.PowerShell.Security\\Microsoft.PowerShell.Security.psd1";
+  const script = `Import-Module "${securityModule}"; (Get-Acl -LiteralPath '${powerShellLiteral(target)}').Owner`;
+  const owner = runCommand("powershell.exe", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script]).trim();
+  if (owner.length === 0) {
+    throw new DaemonIdentityFileError("unsafe_owner", "unable to resolve daemon path owner");
+  }
+  return owner;
+}
+
+function powerShellLiteral(value: string): string {
+  return value.replaceAll("'", "''");
+}

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,7 +7,7 @@ import type { StartupConfig } from "../config/startup_config.js";
 import type { HostedGateway } from "../gateway/create_gateway.js";
 import { GRACEFUL_SHUTDOWN_MS } from "../gateway/create_gateway.js";
 import { assertSupportedRuntime } from "../runtime_support.js";
-import { DaemonController } from "./controller.js";
+import { DaemonController, type LifecycleDependencyContext, type SpawnedDaemon } from "./controller.js";
 import {
   DaemonIdentityFile,
   DaemonIdentityFileError,
@@ -76,48 +76,13 @@ export function createProductionDaemonController(
       },
     },
     processIdentity: async (pid, context) => await captureProcessStartIdentity(pid, undefined, context),
-    spawn: async (startup, context) => {
-      context?.signal.throwIfAborted();
-      const child = spawn(execPath, [
-        childEntry,
-        "--data-dir", startup.dataDir,
-        "--port", String(startup.port),
-        "--log-level", startup.logLevel,
-      ], {
-        detached: true,
-        stdio: "ignore",
-        windowsHide: true,
-        env,
-      });
-      await new Promise<void>((resolve, reject) => {
-        const cleanup = (): void => {
-          child.off("error", onError);
-          child.off("spawn", onSpawn);
-          context.signal.removeEventListener("abort", onAbort);
-        };
-        const onError = (error: Error): void => {
-          cleanup();
-          reject(error);
-        };
-        const onSpawn = (): void => {
-          cleanup();
-          resolve();
-        };
-        const onAbort = (): void => {
-          cleanup();
-          if (child.pid === undefined) reject(context.signal.reason);
-          else resolve();
-        };
-        child.once("error", onError);
-        child.once("spawn", onSpawn);
-        context.signal.addEventListener("abort", onAbort, { once: true });
-        if (context.signal.aborted) onAbort();
-      });
-      if (child.pid === undefined) {
-        throw new Error("daemon child has no process id");
-      }
-      return { pid: child.pid, unref: () => child.unref() };
-    },
+    spawn: async (startup, context) => await spawnDaemonProcess(
+      execPath,
+      childEntry,
+      env,
+      startup,
+      context,
+    ),
     delay,
     nowMs: Date.now,
     controlRequest: async (identity, method, requestPath, context = {}) => await authenticatedControlRequest(
@@ -131,6 +96,56 @@ export function createProductionDaemonController(
       await terminateProcessIfMatching(identity.pid, identity.processStartIdentity, undefined, context);
     },
   });
+}
+
+type SpawnDaemonChild = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => ChildProcess;
+
+export async function spawnDaemonProcess(
+  execPath: string,
+  childEntry: string,
+  env: NodeJS.ProcessEnv,
+  startup: Readonly<StartupConfig>,
+  context: Readonly<LifecycleDependencyContext>,
+  spawnChild: SpawnDaemonChild = spawn,
+): Promise<SpawnedDaemon> {
+  context.signal.throwIfAborted();
+  const child = spawnChild(execPath, [
+    childEntry,
+    "--data-dir", startup.dataDir,
+    "--port", String(startup.port),
+    "--log-level", startup.logLevel,
+  ], {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+    env,
+    signal: context.signal,
+  });
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      child.off("error", onError);
+      child.off("spawn", onSpawn);
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      // Once a PID exists, ownership must return to the controller even if
+      // AbortSignal caused child_process to report an error.
+      if (child.pid === undefined) reject(error);
+      else resolve();
+    };
+    const onSpawn = (): void => {
+      cleanup();
+      resolve();
+    };
+    child.once("error", onError);
+    child.once("spawn", onSpawn);
+  });
+  if (child.pid === undefined) throw new Error("daemon child has no process id");
+  return { pid: child.pid, unref: () => child.unref() };
 }
 
 export interface RunDaemonRuntimeOptions {

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -62,11 +62,22 @@ export function createProductionDaemonController(
   return new DaemonController({
     lifecycleCoordinator: productionLifecycleCoordinator,
     identityFile: {
-      read: async (dataDir) => new DaemonIdentityFile(dataDir).read(),
-      remove: async (dataDir, expected) => new DaemonIdentityFile(dataDir).remove(expected),
+      read: async (dataDir, context) => {
+        context?.signal.throwIfAborted();
+        const identity = new DaemonIdentityFile(dataDir).read();
+        context?.signal.throwIfAborted();
+        return identity;
+      },
+      remove: async (dataDir, expected, context) => {
+        context?.signal.throwIfAborted();
+        const removed = await new DaemonIdentityFile(dataDir).remove(expected, context);
+        context?.signal.throwIfAborted();
+        return removed;
+      },
     },
-    processIdentity: captureProcessStartIdentity,
-    spawn: async (startup) => {
+    processIdentity: async (pid, context) => await captureProcessStartIdentity(pid, undefined, context),
+    spawn: async (startup, context) => {
+      context?.signal.throwIfAborted();
       const child = spawn(execPath, [
         childEntry,
         "--data-dir", startup.dataDir,
@@ -79,8 +90,28 @@ export function createProductionDaemonController(
         env,
       });
       await new Promise<void>((resolve, reject) => {
-        child.once("error", reject);
-        child.once("spawn", resolve);
+        const cleanup = (): void => {
+          child.off("error", onError);
+          child.off("spawn", onSpawn);
+          context.signal.removeEventListener("abort", onAbort);
+        };
+        const onError = (error: Error): void => {
+          cleanup();
+          reject(error);
+        };
+        const onSpawn = (): void => {
+          cleanup();
+          resolve();
+        };
+        const onAbort = (): void => {
+          cleanup();
+          if (child.pid === undefined) reject(context.signal.reason);
+          else resolve();
+        };
+        child.once("error", onError);
+        child.once("spawn", onSpawn);
+        context.signal.addEventListener("abort", onAbort, { once: true });
+        if (context.signal.aborted) onAbort();
       });
       if (child.pid === undefined) {
         throw new Error("daemon child has no process id");
@@ -96,8 +127,8 @@ export function createProductionDaemonController(
       undefined,
       context,
     ),
-    terminate: async (identity) => {
-      await terminateProcessIfMatching(identity.pid, identity.processStartIdentity);
+    terminate: async (identity, context) => {
+      await terminateProcessIfMatching(identity.pid, identity.processStartIdentity, undefined, context);
     },
   });
 }

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -14,8 +14,12 @@ import {
   type DaemonIdentity,
   type DaemonIdentityLease,
 } from "./identity_file.js";
+import { LifecycleCoordinator } from "./lifecycle_coordinator.js";
 import { JsonlLogger, StderrLogger, type DaemonLogger } from "./logger.js";
+import { DaemonOperationLeaseFile } from "./operation_lease.js";
 import { captureProcessStartIdentity, terminateProcessIfMatching } from "./process_identity.js";
+
+const productionLifecycleCoordinator = new LifecycleCoordinator(new DaemonOperationLeaseFile());
 
 export interface DaemonRuntimeComposition {
   readonly startup: StartupConfig;
@@ -56,6 +60,7 @@ export function createProductionDaemonController(
   const childEntry = options.childEntry ?? fileURLToPath(new URL("./child.js", import.meta.url));
   const execPath = options.execPath ?? process.execPath;
   return new DaemonController({
+    lifecycleCoordinator: productionLifecycleCoordinator,
     identityFile: {
       read: async (dataDir) => new DaemonIdentityFile(dataDir).read(),
       remove: async (dataDir, expected) => new DaemonIdentityFile(dataDir).remove(expected),

--- a/tests/fixtures/daemon_operation_contender.ts
+++ b/tests/fixtures/daemon_operation_contender.ts
@@ -1,0 +1,29 @@
+import { appendFileSync, writeSync } from "node:fs";
+import { access } from "node:fs/promises";
+import { DaemonOperationLeaseFile } from "../../src/daemon/operation_lease.js";
+
+const dataDir = process.argv[2];
+const gatePath = process.argv[3];
+const eventsPath = process.argv[4];
+const contender = process.argv[5];
+if (dataDir === undefined || gatePath === undefined || eventsPath === undefined || contender === undefined) {
+  process.exitCode = 2;
+} else {
+  writeSync(1, "ready\n");
+  while (!await exists(gatePath)) await new Promise((resolve) => setTimeout(resolve, 10));
+  const lease = await new DaemonOperationLeaseFile().acquire(dataDir);
+  appendFileSync(eventsPath, `start:${contender}\n`, "utf8");
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  appendFileSync(eventsPath, `end:${contender}\n`, "utf8");
+  lease.release();
+  writeSync(1, "done\n");
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/fixtures/daemon_operation_crash.ts
+++ b/tests/fixtures/daemon_operation_crash.ts
@@ -3,16 +3,23 @@ import { DaemonOperationLeaseFile } from "../../src/daemon/operation_lease.js";
 
 const dataDir = process.argv[2];
 const crashPhase = process.argv[3];
-if (dataDir === undefined || (crashPhase !== "os_locked" && crashPhase !== "released_published")) {
+if (dataDir === undefined || ![
+  "database_prepared",
+  "database_published",
+  "os_locked",
+  "released_published",
+].includes(crashPhase ?? "")) {
   process.exitCode = 2;
 } else {
+  const crash = (phase: string): void => {
+    if (phase === crashPhase) {
+      writeSync(1, `${phase}\n`);
+      process.exit(23);
+    }
+  };
   const lease = await new DaemonOperationLeaseFile({
-    onPhase: (phase) => {
-      if (phase === crashPhase) {
-        writeSync(1, `${phase}\n`);
-        process.exit(23);
-      }
-    },
+    onInitializationPhase: crash,
+    onPhase: crash,
   }).acquire(dataDir);
   lease.release();
   process.exitCode = 3;

--- a/tests/fixtures/daemon_operation_crash.ts
+++ b/tests/fixtures/daemon_operation_crash.ts
@@ -1,0 +1,19 @@
+import { writeSync } from "node:fs";
+import { DaemonOperationLeaseFile } from "../../src/daemon/operation_lease.js";
+
+const dataDir = process.argv[2];
+const crashPhase = process.argv[3];
+if (dataDir === undefined || (crashPhase !== "os_locked" && crashPhase !== "released_published")) {
+  process.exitCode = 2;
+} else {
+  const lease = await new DaemonOperationLeaseFile({
+    onPhase: (phase) => {
+      if (phase === crashPhase) {
+        writeSync(1, `${phase}\n`);
+        process.exit(23);
+      }
+    },
+  }).acquire(dataDir);
+  lease.release();
+  process.exitCode = 3;
+}

--- a/tests/integration/daemon_lifecycle.test.ts
+++ b/tests/integration/daemon_lifecycle.test.ts
@@ -78,7 +78,7 @@ describe("DaemonController lifecycle", () => {
       port: FIRST.port,
     });
     expect(fixture.spawn).toHaveBeenCalledOnce();
-    expect(fixture.spawn).toHaveBeenCalledWith(STARTUP);
+    expect(fixture.spawn).toHaveBeenCalledWith(STARTUP, expect.objectContaining({ deadlineMs: 30_000 }));
     expect(fixture.child.unref).toHaveBeenCalledOnce();
     expect(fixture.events).toEqual(["spawn", "delay:100", "control:GET:status", "unref"]);
     expect(fixture.terminate).not.toHaveBeenCalled();
@@ -126,7 +126,7 @@ describe("DaemonController lifecycle", () => {
     expect(fixture.terminate).toHaveBeenCalledWith({
       pid: FIRST.pid,
       processStartIdentity: FIRST.processStartIdentity,
-    });
+    }, expect.objectContaining({ signal: expect.any(AbortSignal) }));
     expect(fixture.child.unref).toHaveBeenCalledOnce();
   });
 
@@ -146,7 +146,7 @@ describe("DaemonController lifecycle", () => {
     expect(fixture.terminate).toHaveBeenCalledWith({
       pid: FIRST.pid,
       processStartIdentity: FIRST.processStartIdentity,
-    });
+    }, expect.objectContaining({ signal: expect.any(AbortSignal) }));
     expect(fixture.removed).toEqual([FIRST]);
     expect(fixture.child.unref).toHaveBeenCalledOnce();
   });
@@ -161,7 +161,7 @@ describe("DaemonController lifecycle", () => {
     expect(fixture.terminate).toHaveBeenCalledWith({
       pid: FIRST.pid,
       processStartIdentity: FIRST.processStartIdentity,
-    });
+    }, expect.objectContaining({ signal: expect.any(AbortSignal) }));
   });
 
   it("retries the spawned child identity probe before failed-start cleanup", async () => {
@@ -178,6 +178,51 @@ describe("DaemonController lifecycle", () => {
     await expect(fixture.controller.start(STARTUP)).resolves.toMatchObject({ state: "unreachable" });
     expect(reads).toBeGreaterThan(1);
     expect(fixture.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("retries a null initial child identity probe during failed-start reconciliation", async () => {
+    const fixture = harness();
+    fixture.processes.set(FIRST.pid, FIRST.processStartIdentity);
+    let reads = 0;
+    fixture.processIdentityOverride = async (pid) => {
+      reads += 1;
+      if (reads === 1) return null;
+      return fixture.processes.get(pid) ?? null;
+    };
+    fixture.onTerminate = () => fixture.processes.delete(FIRST.pid);
+
+    await expect(fixture.controller.start(STARTUP)).resolves.toMatchObject({ state: "unreachable" });
+    expect(reads).toBeGreaterThan(1);
+    expect(fixture.terminate).toHaveBeenCalledWith({
+      pid: FIRST.pid,
+      processStartIdentity: FIRST.processStartIdentity,
+    }, expect.objectContaining({ signal: expect.any(AbortSignal) }));
+  });
+
+  it("recaptures a null initial child identity before cleanup after readiness cancellation", async () => {
+    const fixture = harness();
+    const abort = new AbortController();
+    const blocked = deferred();
+    fixture.processes.set(FIRST.pid, FIRST.processStartIdentity);
+    let reads = 0;
+    fixture.processIdentityOverride = async (pid) => {
+      reads += 1;
+      if (reads === 1) return null;
+      return fixture.processes.get(pid) ?? null;
+    };
+    fixture.onDelayAsync = async () => await blocked.promise;
+    fixture.onTerminate = () => fixture.processes.delete(FIRST.pid);
+
+    const starting = fixture.controller.start(STARTUP, { signal: abort.signal });
+    await vi.waitFor(() => expect(fixture.events).toContain("delay:100"));
+    abort.abort();
+    blocked.resolve();
+    await expect(starting).rejects.toMatchObject({ code: "interrupted" });
+    expect(reads).toBeGreaterThan(1);
+    expect(fixture.terminate).toHaveBeenCalledWith({
+      pid: FIRST.pid,
+      processStartIdentity: FIRST.processStartIdentity,
+    }, expect.objectContaining({ signal: expect.any(AbortSignal) }));
   });
 
   it("bounds each readiness status call by the absolute 30 second deadline", async () => {
@@ -264,7 +309,10 @@ describe("DaemonController lifecycle", () => {
     await expect(fixture.controller.stop(DATA_DIR)).resolves.toMatchObject({ state: "stopped" });
     expect(fixture.elapsedMs).toBeLessThanOrEqual(10_000);
     expect(fixture.processReads.at(-1)).toEqual(FIRST.pid);
-    expect(fixture.terminate).toHaveBeenCalledWith(FIRST);
+    expect(fixture.terminate).toHaveBeenCalledWith(
+      FIRST,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(fixture.removed).toEqual([FIRST]);
   });
 
@@ -311,7 +359,10 @@ describe("DaemonController lifecycle", () => {
     fixture.onTerminate = () => fixture.processes.delete(FIRST.pid);
 
     await expect(fixture.controller.stop(DATA_DIR)).resolves.toMatchObject({ state: "stopped" });
-    expect(fixture.terminate).toHaveBeenCalledWith(FIRST);
+    expect(fixture.terminate).toHaveBeenCalledWith(
+      FIRST,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(fixture.removed).toEqual([FIRST]);
   });
 
@@ -421,7 +472,10 @@ describe("DaemonController lifecycle", () => {
       }
     };
     await fixture.controller.restart(STARTUP);
-    expect(fixture.spawn).toHaveBeenCalledWith(expect.objectContaining({ port: 31_409 }));
+    expect(fixture.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 31_409 }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 });
 

--- a/tests/integration/daemon_lifecycle.test.ts
+++ b/tests/integration/daemon_lifecycle.test.ts
@@ -110,6 +110,26 @@ describe("DaemonController lifecycle", () => {
     expect(fixture.spawn).toHaveBeenCalledOnce();
   });
 
+  it("finishes verified child cleanup before returning interruption after spawn", async () => {
+    const fixture = harness();
+    const abort = new AbortController();
+    const blocked = deferred();
+    fixture.processes.set(FIRST.pid, FIRST.processStartIdentity);
+    fixture.onDelayAsync = async () => await blocked.promise;
+    fixture.onTerminate = () => fixture.processes.delete(FIRST.pid);
+
+    const starting = fixture.controller.start(STARTUP, { signal: abort.signal });
+    await vi.waitFor(() => expect(fixture.spawn).toHaveBeenCalledOnce());
+    abort.abort();
+    blocked.resolve();
+    await expect(starting).rejects.toMatchObject({ code: "interrupted" });
+    expect(fixture.terminate).toHaveBeenCalledWith({
+      pid: FIRST.pid,
+      processStartIdentity: FIRST.processStartIdentity,
+    });
+    expect(fixture.child.unref).toHaveBeenCalledOnce();
+  });
+
   it("terminates only its process-identity-verified child after the 30 second ready deadline", async () => {
     const fixture = harness();
     fixture.processes.set(FIRST.pid, FIRST.processStartIdentity);
@@ -213,6 +233,28 @@ describe("DaemonController lifecycle", () => {
     expect(fixture.elapsedMs).toBe(100);
     expect(fixture.terminate).not.toHaveBeenCalled();
     expect(fixture.removed).toEqual([FIRST]);
+  });
+
+  it("reconciles an authenticated stop before returning interruption", async () => {
+    const fixture = harness({ identity: FIRST });
+    const abort = new AbortController();
+    const response = deferred();
+    let stopStarted = false;
+    fixture.controlRequest = async (identity, method) => {
+      if (method === "GET") return { state: "running", instance: instanceOf(identity) };
+      stopStarted = true;
+      await response.promise;
+      return { instance: instanceOf(identity) };
+    };
+    fixture.onDelay = () => fixture.processes.delete(FIRST.pid);
+
+    const stopping = fixture.controller.stop(DATA_DIR, { signal: abort.signal });
+    await vi.waitFor(() => expect(stopStarted).toBe(true));
+    abort.abort();
+    response.resolve();
+    await expect(stopping).rejects.toMatchObject({ code: "interrupted" });
+    expect(fixture.removed).toEqual([FIRST]);
+    expect(fixture.terminate).not.toHaveBeenCalled();
   });
 
   it("waits 10 seconds then uses a fresh process identity before force termination", async () => {
@@ -466,6 +508,12 @@ function harness(options: HarnessOptions = {}) {
     terminate,
     controller: new DaemonController(dependencies),
   });
+}
+
+function deferred() {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
 }
 
 function instanceOf(identity: Readonly<DaemonIdentity>) {

--- a/tests/integration/daemon_lifecycle_concurrency.test.ts
+++ b/tests/integration/daemon_lifecycle_concurrency.test.ts
@@ -247,10 +247,12 @@ describe("daemon lifecycle coordination", () => {
     expect(elapsedMs).toBe(60_100);
   });
 
-  it("keeps the operation lease until a never-settling spawn acknowledges its deadline", async () => {
+  it("fails closed when a dependency ignores abort until it explicitly becomes quiescent", async () => {
     vi.useFakeTimers();
     try {
       const events: string[] = [];
+      const dependency = deferred();
+      let reads = 0;
       const coordinator = new LifecycleCoordinator({
         acquire: async () => {
           events.push("lease:acquire");
@@ -259,33 +261,47 @@ describe("daemon lifecycle coordination", () => {
       });
       const controller = new DaemonController({
         lifecycleCoordinator: coordinator,
-        identityFile: { read: async () => null, remove: async () => false },
-        processIdentity: async () => null,
-        spawn: async (_startup, context) => {
-          events.push("spawn:start");
-          return await new Promise<never>((_resolve, reject) => {
-            context?.signal.addEventListener("abort", () => {
-              events.push("spawn:abort-acknowledged");
-              reject(context.signal.reason);
-            }, { once: true });
-          });
+        identityFile: {
+          read: async (_dataDir, context) => {
+            reads += 1;
+            if (reads === 1) {
+              events.push("dependency:start");
+              context.signal.addEventListener("abort", () => events.push("dependency:signaled"), { once: true });
+              await dependency.promise;
+              events.push("dependency:quiescent");
+            }
+            return null;
+          },
+          remove: async () => false,
         },
+        processIdentity: async () => null,
+        spawn: async () => ({ pid: 4242, unref() {} }),
         delay: async () => undefined,
         nowMs: Date.now,
         controlRequest: async () => undefined,
         terminate: async () => undefined,
       });
 
-      const starting = controller.start(startup("bounded-spawn"));
-      const outcome = starting.catch((error: unknown) => error);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(events).toEqual(["lease:acquire", "spawn:start"]);
+      const active = controller.status("nonconforming");
+      const next = controller.status("nonconforming");
       await vi.advanceTimersByTimeAsync(30_000);
-      expect(await outcome).toMatchObject({ code: "timeout" });
+      expect(events).toEqual(["lease:acquire", "dependency:start", "dependency:signaled"]);
+      let nextSettled = false;
+      void next.finally(() => { nextSettled = true; });
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(nextSettled).toBe(false);
+      expect(events).not.toContain("lease:release");
+
+      dependency.resolve();
+      await expect(active).rejects.toMatchObject({ code: "timeout" });
+      await expect(next).resolves.toMatchObject({ state: "stopped" });
       expect(events).toEqual([
         "lease:acquire",
-        "spawn:start",
-        "spawn:abort-acknowledged",
+        "dependency:start",
+        "dependency:signaled",
+        "dependency:quiescent",
+        "lease:release",
+        "lease:acquire",
         "lease:release",
       ]);
     } finally {

--- a/tests/integration/daemon_lifecycle_concurrency.test.ts
+++ b/tests/integration/daemon_lifecycle_concurrency.test.ts
@@ -1,0 +1,351 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { CliError } from "../../src/cli/control_client.js";
+import type { StartupConfig } from "../../src/config/startup_config.js";
+import { DaemonController, type DaemonControllerDependencies } from "../../src/daemon/controller.js";
+import type { DaemonIdentity } from "../../src/daemon/identity_file.js";
+import { LifecycleCoordinator } from "../../src/daemon/lifecycle_coordinator.js";
+import type { DaemonOperationLeaseAccess } from "../../src/daemon/operation_lease.js";
+
+function deferred() {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+describe("daemon lifecycle coordination", () => {
+  it("runs one FIFO lane per canonical data directory while different directories proceed independently", async () => {
+    const events: string[] = [];
+    const leases = scriptedLeases(events);
+    const coordinator = new LifecycleCoordinator(leases);
+    const releaseFirst = deferred();
+    const releaseOther = deferred();
+
+    const first = coordinator.run("same/../same", {}, async () => {
+      events.push("first:start");
+      await releaseFirst.promise;
+      events.push("first:end");
+      return "first";
+    });
+    const second = coordinator.run(path.resolve("same"), {}, async () => {
+      events.push("second:start");
+      return "second";
+    });
+    const other = coordinator.run("other", {}, async () => {
+      events.push("other:start");
+      await releaseOther.promise;
+      events.push("other:end");
+      return "other";
+    });
+
+    await vi.waitFor(() => {
+      expect(events).toContain("first:start");
+      expect(events).toContain("other:start");
+    });
+    expect(events).not.toContain("second:start");
+    releaseFirst.resolve();
+    await expect(first).resolves.toBe("first");
+    await expect(second).resolves.toBe("second");
+    releaseOther.resolve();
+    await expect(other).resolves.toBe("other");
+    const sameLeaseEvents = events.filter((event) => event.endsWith(":same"));
+    expect(sameLeaseEvents).toEqual([
+      "lease:acquire:same",
+      "lease:release:same",
+      "lease:acquire:same",
+      "lease:release:same",
+    ]);
+  });
+
+  it("removes a canceled pending caller without affecting active or later work", async () => {
+    const events: string[] = [];
+    const coordinator = new LifecycleCoordinator(scriptedLeases(events));
+    const release = deferred();
+    const first = coordinator.run("same", {}, async () => {
+      events.push("first");
+      await release.promise;
+      return 1;
+    });
+    const abort = new AbortController();
+    const secondWork = vi.fn(async () => 2);
+    const second = coordinator.run("same", { signal: abort.signal }, secondWork);
+    const third = coordinator.run("same", {}, async () => {
+      events.push("third");
+      return 3;
+    });
+    abort.abort();
+    await expect(second).rejects.toEqual(new CliError("interrupted"));
+    release.resolve();
+    await expect(first).resolves.toBe(1);
+    await expect(third).resolves.toBe(3);
+    expect(secondWork).not.toHaveBeenCalled();
+  });
+
+  it("serializes start across two controllers and spawns one authenticated daemon", async () => {
+    const ready = deferred();
+    let identity: DaemonIdentity | null = null;
+    const processes = new Map<number, string>();
+    const spawn = vi.fn(async () => ({ pid: 4242, unref() {} }));
+    let firstDelay = true;
+    const coordinator = new LifecycleCoordinator(scriptedLeases([]));
+    const dependencies: DaemonControllerDependencies = {
+      lifecycleCoordinator: coordinator,
+      identityFile: {
+        read: async () => identity,
+        remove: async () => false,
+      },
+      processIdentity: async (pid) => processes.get(pid) ?? null,
+      spawn,
+      delay: async () => {
+        if (!firstDelay) return;
+        firstDelay = false;
+        await ready.promise;
+        identity = runningIdentity();
+        processes.set(4242, identity.processStartIdentity);
+      },
+      nowMs: () => 0,
+      controlRequest: async (current) => ({ state: "running", instance: {
+        pid: current.pid,
+        processStartIdentity: current.processStartIdentity,
+        instanceNonce: current.instanceNonce,
+      } }),
+      terminate: async () => undefined,
+    };
+    const first = new DaemonController(dependencies).start(startup("shared"));
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+    const second = new DaemonController(dependencies).start(startup("shared"));
+    await Promise.resolve();
+    expect(spawn).toHaveBeenCalledOnce();
+    ready.resolve();
+    const results = await Promise.all([first, second]);
+    expect(results).toEqual([
+      expect.objectContaining({ state: "running", pid: 4242 }),
+      expect.objectContaining({ state: "running", pid: 4242 }),
+    ]);
+    expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  it("orders start then stop and stop then start by complete lifecycle operations", async () => {
+    const startFirst = restartHarness({ initialRunning: false, block: "ready" });
+    const starting = startFirst.controller.start(startup("start-stop"));
+    await vi.waitFor(() => expect(startFirst.events).toContain("delay:ready:4243"));
+    const stoppingAfter = startFirst.controller.stop("start-stop");
+    expect(startFirst.events).not.toContain("control:POST:4243");
+    startFirst.releaseFirstStop.resolve();
+    await expect(starting).resolves.toMatchObject({ state: "running", pid: 4243 });
+    await expect(stoppingAfter).resolves.toMatchObject({ state: "stopped", pid: null });
+
+    const stopFirst = restartHarness();
+    const stopping = stopFirst.controller.stop("stop-start");
+    await vi.waitFor(() => expect(stopFirst.events).toContain("delay:stop:4242"));
+    const startingAfter = stopFirst.controller.start(startup("stop-start"));
+    expect(stopFirst.spawn).not.toHaveBeenCalled();
+    stopFirst.releaseFirstStop.resolve();
+    await expect(stopping).resolves.toMatchObject({ state: "stopped", pid: null });
+    await expect(startingAfter).resolves.toMatchObject({ state: "running", pid: 4243 });
+  });
+
+  it("keeps restart indivisible from queued status and another restart", async () => {
+    const fixture = restartHarness();
+    const firstRestart = fixture.controller.restart(startup("restart"));
+    await vi.waitFor(() => expect(fixture.events).toContain("delay:stop:4242"));
+    const status = fixture.controller.status("restart");
+    const secondRestart = fixture.controller.restart(startup("restart"));
+    await Promise.resolve();
+    expect(fixture.spawn).not.toHaveBeenCalled();
+    expect(fixture.events.filter((event) => event.startsWith("control:"))).toHaveLength(3);
+
+    fixture.releaseFirstStop.resolve();
+    await expect(firstRestart).resolves.toMatchObject({ state: "running", pid: 4243 });
+    await expect(status).resolves.toMatchObject({ state: "running", pid: 4243 });
+    await expect(secondRestart).resolves.toMatchObject({ state: "running", pid: 4244 });
+    expect(fixture.spawn).toHaveBeenCalledTimes(2);
+    const controls = fixture.events.filter((event) => event.startsWith("control:"));
+    expect(controls.indexOf("control:GET:4243")).toBeLessThan(controls.indexOf("control:POST:4243"));
+    expect(controls.at(-1)).toBe("control:GET:4244");
+  });
+
+  it("starts lifecycle deadlines only after queued work obtains the lane", async () => {
+    const releaseRead = deferred();
+    let firstRead = true;
+    let elapsedMs = 0;
+    let identity: DaemonIdentity | null = null;
+    const processes = new Map<number, string>();
+    const coordinator = new LifecycleCoordinator(scriptedLeases([]));
+    const dependencies: DaemonControllerDependencies = {
+      lifecycleCoordinator: coordinator,
+      identityFile: {
+        read: async () => {
+          if (firstRead) {
+            firstRead = false;
+            await releaseRead.promise;
+          }
+          return identity;
+        },
+        remove: async () => false,
+      },
+      processIdentity: async (pid) => processes.get(pid) ?? null,
+      spawn: async () => {
+        processes.set(4242, runningIdentity().processStartIdentity);
+        return { pid: 4242, unref() {} };
+      },
+      delay: async (ms) => {
+        elapsedMs += ms;
+        identity = runningIdentity();
+      },
+      nowMs: () => elapsedMs,
+      controlRequest: async (current) => ({ state: "running", instance: {
+        pid: current.pid,
+        processStartIdentity: current.processStartIdentity,
+        instanceNonce: current.instanceNonce,
+      } }),
+      terminate: async () => undefined,
+    };
+    const controller = new DaemonController(dependencies);
+    const active = controller.status("queued");
+    const queuedStart = controller.start(startup("queued"));
+    elapsedMs = 60_000;
+    releaseRead.resolve();
+    await expect(active).resolves.toMatchObject({ state: "stopped" });
+    await expect(queuedStart).resolves.toMatchObject({ state: "running", pid: 4242 });
+    expect(elapsedMs).toBe(60_100);
+  });
+
+  it("does not start active work canceled while its lease is being acquired", async () => {
+    const acquired = deferred();
+    let firstAcquire = true;
+    const leases: DaemonOperationLeaseAccess = {
+      acquire: async () => {
+        if (firstAcquire) {
+          firstAcquire = false;
+          await acquired.promise;
+        }
+        return { release() {} };
+      },
+    };
+    const coordinator = new LifecycleCoordinator(leases);
+    const abort = new AbortController();
+    const canceledWork = vi.fn(async () => "canceled");
+    const canceled = coordinator.run("same", { signal: abort.signal }, canceledWork);
+    abort.abort();
+    acquired.resolve();
+    await expect(canceled).rejects.toMatchObject({ code: "interrupted" });
+    expect(canceledWork).not.toHaveBeenCalled();
+    await expect(coordinator.run("same", {}, async () => "next")).resolves.toBe("next");
+  });
+
+  it("releases the lease and advances after active failure", async () => {
+    const events: string[] = [];
+    const coordinator = new LifecycleCoordinator(scriptedLeases(events));
+    const failed = coordinator.run("same", {}, async () => { throw new Error("failed operation"); });
+    const next = coordinator.run("same", {}, async () => "next");
+    await expect(failed).rejects.toThrow("failed operation");
+    await expect(next).resolves.toBe("next");
+    expect(events.filter((event) => event === "lease:release:same")).toHaveLength(2);
+  });
+});
+
+function restartHarness(options: Readonly<{
+  initialRunning?: boolean;
+  block?: "stop" | "ready";
+}> = {}) {
+  const releaseFirstStop = deferred();
+  const events: string[] = [];
+  const initialRunning = options.initialRunning ?? true;
+  const block = options.block ?? "stop";
+  let identity: DaemonIdentity | null = initialRunning ? runningIdentity() : null;
+  const processes = new Map<number, string>(initialRunning
+    ? [[4242, runningIdentity().processStartIdentity]]
+    : []);
+  let stopping: DaemonIdentity | null = null;
+  let nextPid = 4243;
+  let spawned: DaemonIdentity | null = null;
+  let blockFirstStop = true;
+  const coordinator = new LifecycleCoordinator(scriptedLeases([]));
+  const spawn = vi.fn(async () => {
+    const pid = nextPid++;
+    spawned = {
+      ...runningIdentity(),
+      pid,
+      processStartIdentity: `linux:01234567-89ab-cdef-0123-456789abcdef:${pid}`,
+      instanceNonce: `nonce-${pid}`,
+      controlToken: `token-${pid}`,
+    };
+    processes.set(pid, spawned.processStartIdentity);
+    events.push(`spawn:${pid}`);
+    return { pid, unref() {} };
+  });
+  const dependencies: DaemonControllerDependencies = {
+    lifecycleCoordinator: coordinator,
+    identityFile: {
+      read: async () => identity,
+      remove: async (_dataDir, expected) => {
+        if (identity === null || JSON.stringify(identity) !== JSON.stringify(expected)) return false;
+        identity = null;
+        return true;
+      },
+    },
+    processIdentity: async (pid) => processes.get(pid) ?? null,
+    spawn,
+    delay: async () => {
+      if (stopping !== null) {
+        const current = stopping;
+        stopping = null;
+        events.push(`delay:stop:${current.pid}`);
+        if (blockFirstStop && block === "stop") {
+          blockFirstStop = false;
+          await releaseFirstStop.promise;
+        }
+        processes.delete(current.pid);
+        return;
+      }
+      if (spawned !== null) {
+        events.push(`delay:ready:${spawned.pid}`);
+        if (blockFirstStop && block === "ready") {
+          blockFirstStop = false;
+          await releaseFirstStop.promise;
+        }
+        identity = spawned;
+        spawned = null;
+      }
+    },
+    nowMs: () => 0,
+    controlRequest: async (current, method) => {
+      events.push(`control:${method}:${current.pid}`);
+      if (method === "POST") stopping = { ...current };
+      return method === "GET"
+        ? { state: "running", instance: { pid: current.pid, processStartIdentity: current.processStartIdentity, instanceNonce: current.instanceNonce } }
+        : { instance: { pid: current.pid, processStartIdentity: current.processStartIdentity, instanceNonce: current.instanceNonce } };
+    },
+    terminate: async () => undefined,
+  };
+  return { controller: new DaemonController(dependencies), events, spawn, releaseFirstStop };
+}
+
+function startup(dataDir: string): StartupConfig {
+  return { host: "127.0.0.1", port: 31_400, dataDir, logLevel: "info" };
+}
+
+function runningIdentity(): DaemonIdentity {
+  return {
+    version: 1,
+    managed: true,
+    pid: 4242,
+    processStartIdentity: "linux:01234567-89ab-cdef-0123-456789abcdef:100",
+    instanceNonce: "nonce",
+    controlToken: "token",
+    port: 31_400,
+    createdAt: "2026-09-03T12:00:00.000Z",
+  };
+}
+
+function scriptedLeases(events: string[]): DaemonOperationLeaseAccess {
+  return {
+    acquire: async (dataDir, context) => {
+      context?.signal?.throwIfAborted();
+      const name = path.basename(dataDir);
+      events.push(`lease:acquire:${name}`);
+      return { release: () => events.push(`lease:release:${name}`) };
+    },
+  };
+}

--- a/tests/integration/daemon_lifecycle_concurrency.test.ts
+++ b/tests/integration/daemon_lifecycle_concurrency.test.ts
@@ -4,7 +4,10 @@ import { CliError } from "../../src/cli/control_client.js";
 import type { StartupConfig } from "../../src/config/startup_config.js";
 import { DaemonController, type DaemonControllerDependencies } from "../../src/daemon/controller.js";
 import type { DaemonIdentity } from "../../src/daemon/identity_file.js";
-import { LifecycleCoordinator } from "../../src/daemon/lifecycle_coordinator.js";
+import {
+  LifecycleCoordinator,
+  MAX_PENDING_LIFECYCLE_OPERATIONS_PER_DIRECTORY,
+} from "../../src/daemon/lifecycle_coordinator.js";
 import type { DaemonOperationLeaseAccess } from "../../src/daemon/operation_lease.js";
 
 function deferred() {
@@ -55,6 +58,39 @@ describe("daemon lifecycle coordination", () => {
       "lease:acquire:same",
       "lease:release:same",
     ]);
+  });
+
+  it("bounds pending callers per directory, immediately reclaims cancellation, and isolates directories", async () => {
+    const coordinator = new LifecycleCoordinator(scriptedLeases([]));
+    const release = deferred();
+    const active = coordinator.run("limited", {}, async () => {
+      await release.promise;
+      return "active";
+    });
+    const aborts = Array.from(
+      { length: MAX_PENDING_LIFECYCLE_OPERATIONS_PER_DIRECTORY },
+      () => new AbortController(),
+    );
+    const pending = aborts.map((abort, index) => coordinator.run(
+      "limited",
+      { signal: abort.signal },
+      async () => index,
+    ));
+
+    await expect(coordinator.run("limited", {}, async () => "overflow"))
+      .rejects.toEqual(new CliError("unavailable"));
+    await expect(coordinator.run("other", {}, async () => "other"))
+      .resolves.toBe("other");
+
+    aborts[0]?.abort();
+    await expect(pending[0]).rejects.toEqual(new CliError("interrupted"));
+    const replacement = coordinator.run("limited", {}, async () => "replacement");
+    release.resolve();
+    await expect(active).resolves.toBe("active");
+    await expect(Promise.all(pending.slice(1))).resolves.toHaveLength(
+      MAX_PENDING_LIFECYCLE_OPERATIONS_PER_DIRECTORY - 1,
+    );
+    await expect(replacement).resolves.toBe("replacement");
   });
 
   it("removes a canceled pending caller without affecting active or later work", async () => {
@@ -211,6 +247,221 @@ describe("daemon lifecycle coordination", () => {
     expect(elapsedMs).toBe(60_100);
   });
 
+  it("keeps the operation lease until a never-settling spawn acknowledges its deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const events: string[] = [];
+      const coordinator = new LifecycleCoordinator({
+        acquire: async () => {
+          events.push("lease:acquire");
+          return { release: () => events.push("lease:release") };
+        },
+      });
+      const controller = new DaemonController({
+        lifecycleCoordinator: coordinator,
+        identityFile: { read: async () => null, remove: async () => false },
+        processIdentity: async () => null,
+        spawn: async (_startup, context) => {
+          events.push("spawn:start");
+          return await new Promise<never>((_resolve, reject) => {
+            context?.signal.addEventListener("abort", () => {
+              events.push("spawn:abort-acknowledged");
+              reject(context.signal.reason);
+            }, { once: true });
+          });
+        },
+        delay: async () => undefined,
+        nowMs: Date.now,
+        controlRequest: async () => undefined,
+        terminate: async () => undefined,
+      });
+
+      const starting = controller.start(startup("bounded-spawn"));
+      const outcome = starting.catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(events).toEqual(["lease:acquire", "spawn:start"]);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(await outcome).toMatchObject({ code: "timeout" });
+      expect(events).toEqual([
+        "lease:acquire",
+        "spawn:start",
+        "spawn:abort-acknowledged",
+        "lease:release",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps reconciliation owned while initial identity capture acknowledges its deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const events: string[] = [];
+      let processCalls = 0;
+      let alive = true;
+      const controller = new DaemonController({
+        lifecycleCoordinator: recordingCoordinator(events),
+        identityFile: { read: async () => null, remove: async () => false },
+        processIdentity: async (_pid, context) => {
+          processCalls += 1;
+          if (processCalls === 1) {
+            events.push("identity:start");
+            return await rejectOnAbort(context?.signal, () => events.push("identity:abort-acknowledged"));
+          }
+          return alive ? runningIdentity().processStartIdentity : null;
+        },
+        spawn: async () => ({ pid: 4242, unref() {} }),
+        delay: timedDelay,
+        nowMs: Date.now,
+        controlRequest: async () => undefined,
+        terminate: async () => { alive = false; events.push("terminate"); },
+      });
+
+      const starting = controller.start(startup("bounded-identity"));
+      const outcome = starting.catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(events).toContain("identity:abort-acknowledged");
+      expect(events).not.toContain("lease:release");
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(await outcome).toMatchObject({ state: "unreachable" });
+      expect(events.indexOf("identity:abort-acknowledged")).toBeLessThan(events.indexOf("terminate"));
+      expect(events.at(-1)).toBe("lease:release");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds a never-settling stop request and completes owned cleanup before release", async () => {
+    vi.useFakeTimers();
+    try {
+      const events: string[] = [];
+      let stopTimedOut = false;
+      const identity = runningIdentity();
+      const controller = new DaemonController({
+        lifecycleCoordinator: recordingCoordinator(events),
+        identityFile: {
+          read: async () => identity,
+          remove: async () => { events.push("remove"); return true; },
+        },
+        processIdentity: async () => stopTimedOut ? null : identity.processStartIdentity,
+        spawn: async () => ({ pid: 4243, unref() {} }),
+        delay: async () => undefined,
+        nowMs: Date.now,
+        controlRequest: async (current, method, _requestPath, context) => method === "GET"
+          ? { state: "running", instance: instanceOf(current) }
+          : await rejectOnAbort(context?.signal, () => {
+            stopTimedOut = true;
+            events.push("stop:abort-acknowledged");
+          }),
+        terminate: async () => undefined,
+      });
+
+      const stopping = controller.stop("bounded-stop");
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(stopping).resolves.toMatchObject({ state: "stopped" });
+      expect(events).toEqual([
+        "lease:acquire",
+        "stop:abort-acknowledged",
+        "remove",
+        "lease:release",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not release while a stale-identity removal is acknowledging its deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const events: string[] = [];
+      const identity = runningIdentity();
+      const controller = new DaemonController({
+        lifecycleCoordinator: recordingCoordinator(events),
+        identityFile: {
+          read: async () => identity,
+          remove: async (_dataDir, _expected, context) => {
+            events.push("remove:start");
+            return await rejectOnAbort(context?.signal, () => events.push("remove:abort-acknowledged"));
+          },
+        },
+        processIdentity: async () => null,
+        spawn: async () => ({ pid: 4243, unref() {} }),
+        delay: async () => undefined,
+        nowMs: Date.now,
+        controlRequest: async () => undefined,
+        terminate: async () => undefined,
+      });
+
+      const status = controller.status("bounded-remove");
+      const outcome = status.catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(await outcome).toMatchObject({ code: "timeout" });
+      expect(events).toEqual([
+        "lease:acquire",
+        "remove:start",
+        "remove:abort-acknowledged",
+        "lease:release",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["terminate", "post-terminate identity reconciliation"])(
+    "bounds never-settling %s before releasing the operation lease",
+    async (stage) => {
+      vi.useFakeTimers();
+      try {
+        const events: string[] = [];
+        const identity = runningIdentity();
+        let terminated = false;
+        const controller = new DaemonController({
+          lifecycleCoordinator: recordingCoordinator(events),
+          identityFile: { read: async () => identity, remove: async () => false },
+          processIdentity: async (_pid, context) => {
+            if (terminated && stage !== "terminate") {
+              events.push("reconcile:start");
+              return await rejectOnAbort(
+                context?.signal,
+                () => events.push("reconcile:abort-acknowledged"),
+              );
+            }
+            return identity.processStartIdentity;
+          },
+          spawn: async () => ({ pid: 4243, unref() {} }),
+          delay: timedDelay,
+          nowMs: Date.now,
+          controlRequest: async (current, method) => method === "GET"
+            ? { state: "running", instance: instanceOf(current) }
+            : { instance: instanceOf(current) },
+          terminate: async (_current, context) => {
+            terminated = true;
+            if (stage === "terminate") {
+              events.push("terminate:start");
+              await rejectOnAbort(
+                context?.signal,
+                () => events.push("terminate:abort-acknowledged"),
+              );
+            }
+          },
+        });
+
+        const stopping = controller.stop(`bounded-${stage}`);
+        const outcome = stopping.catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(stage === "terminate" ? 30_000 : 20_000);
+        expect(await outcome).toMatchObject({ code: "timeout" });
+        const acknowledgment = stage === "terminate"
+          ? "terminate:abort-acknowledged"
+          : "reconcile:abort-acknowledged";
+        expect(events).toContain(acknowledgment);
+        expect(events.indexOf(acknowledgment)).toBeLessThan(events.indexOf("lease:release"));
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("does not start active work canceled while its lease is being acquired", async () => {
     const acquired = deferred();
     let firstAcquire = true;
@@ -337,6 +588,46 @@ function runningIdentity(): DaemonIdentity {
     port: 31_400,
     createdAt: "2026-09-03T12:00:00.000Z",
   };
+}
+
+function instanceOf(identity: Readonly<DaemonIdentity>) {
+  return {
+    pid: identity.pid,
+    processStartIdentity: identity.processStartIdentity,
+    instanceNonce: identity.instanceNonce,
+  };
+}
+
+async function timedDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    }, { once: true });
+  });
+}
+
+async function rejectOnAbort(signal: AbortSignal | undefined, acknowledge: () => void): Promise<never> {
+  if (signal === undefined) throw new Error("missing dependency signal");
+  return await new Promise<never>((_resolve, reject) => {
+    const abort = (): void => {
+      acknowledge();
+      reject(signal.reason);
+    };
+    if (signal.aborted) abort();
+    else signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function recordingCoordinator(events: string[]): LifecycleCoordinator {
+  return new LifecycleCoordinator({
+    acquire: async () => {
+      events.push("lease:acquire");
+      return { release: () => events.push("lease:release") };
+    },
+  });
 }
 
 function scriptedLeases(events: string[]): DaemonOperationLeaseAccess {

--- a/tests/integration/daemon_lifecycle_processes.test.ts
+++ b/tests/integration/daemon_lifecycle_processes.test.ts
@@ -1,8 +1,9 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer, type ServerResponse } from "node:http";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DaemonIdentityFile, type DaemonIdentityLease } from "../../src/daemon/identity_file.js";
 import { captureProcessStartIdentity } from "../../src/daemon/process_identity.js";
@@ -22,6 +23,40 @@ afterEach(async () => {
 });
 
 describe("daemon lifecycle coordination across CLI processes", () => {
+  it("atomically initializes a fresh operation database for simultaneous first acquirers", { timeout: 120_000 }, async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ghcg-operation-first-acquirers-"));
+    const dataDir = path.join(root, "data");
+    const gatePath = path.join(root, "gate");
+    const eventsPath = path.join(root, "events");
+    try {
+      const first = runContender(dataDir, gatePath, eventsPath, "first");
+      const second = runContender(dataDir, gatePath, eventsPath, "second");
+      await Promise.all([first.ready, second.ready]);
+      await writeFile(gatePath, "go", "utf8");
+      const [firstResult, secondResult] = await Promise.all([first.result, second.result]);
+
+      expect(firstResult, firstResult.stderr).toEqual({ code: 0, stdout: "ready\ndone\n", stderr: "" });
+      expect(secondResult, secondResult.stderr).toEqual({ code: 0, stdout: "ready\ndone\n", stderr: "" });
+      const events = (await readFile(eventsPath, "utf8")).trim().split("\n");
+      expect(events).toMatchObject([
+        expect.stringMatching(/^start:(first|second)$/u),
+        expect.stringMatching(/^end:(first|second)$/u),
+        expect.stringMatching(/^start:(first|second)$/u),
+        expect.stringMatching(/^end:(first|second)$/u),
+      ]);
+      expect(events[0]?.slice(6)).toBe(events[1]?.slice(4));
+      expect(events[2]?.slice(6)).toBe(events[3]?.slice(4));
+      expect(events[0]?.slice(6)).not.toBe(events[2]?.slice(6));
+      await expectProtectedValidDatabase(dataDir);
+      expect(await operationArtifacts(dataDir)).toEqual([
+        "daemon.operation.db",
+        "daemon.operation.owner.json",
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("serializes status commands through the production operation lease", { timeout: 120_000 }, async () => {
     const fixture = await processFixture();
     try {
@@ -71,6 +106,30 @@ describe("daemon lifecycle coordination across CLI processes", () => {
       expect(fixture.requests()).toBe(2);
     } finally {
       await fixture.close();
+    }
+  });
+
+  it("recovers real initialization crashes before publication and before temp cleanup", { timeout: 240_000 }, async () => {
+    for (const phase of ["database_prepared", "database_published"] as const) {
+      const fixture = await processFixture();
+      try {
+        const crashed = runCrashHolder(fixture.dataDir, phase);
+        await expect(crashed.result).resolves.toEqual({ code: 23, stdout: `${phase}\n`, stderr: "" });
+        expect((await operationArtifacts(fixture.dataDir)).some((name) =>
+          name.startsWith(".daemon.operation.db.init-"))).toBe(true);
+
+        const recovered = runStatus(fixture.dataDir);
+        await vi.waitFor(() => expect(fixture.requests()).toBe(1), { timeout: 60_000 });
+        fixture.releaseBlockedResponse();
+        await expect(recovered.result).resolves.toMatchObject({ code: 0, stderr: "" });
+        await expectProtectedValidDatabase(fixture.dataDir);
+        expect(await operationArtifacts(fixture.dataDir)).toEqual([
+          "daemon.operation.db",
+          "daemon.operation.owner.json",
+        ]);
+      } finally {
+        await fixture.close();
+      }
     }
   });
 
@@ -191,7 +250,46 @@ function runStatus(dataDir: string) {
   return { child, result };
 }
 
-function runCrashHolder(dataDir: string, phase: "os_locked" | "released_published") {
+function runContender(dataDir: string, gatePath: string, eventsPath: string, contender: string) {
+  const child = spawn(process.execPath, [
+    "scripts/tooling/bootstrap.mjs",
+    "tests/fixtures/daemon_operation_contender.ts",
+    dataDir,
+    gatePath,
+    eventsPath,
+    contender,
+  ], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  children.add(child);
+  let stdout = "";
+  let stderr = "";
+  let signalReady = (): void => undefined;
+  const ready = new Promise<void>((resolve) => { signalReady = resolve; });
+  child.stdout!.setEncoding("utf8");
+  child.stderr!.setEncoding("utf8");
+  child.stdout!.on("data", (chunk: string) => {
+    stdout += chunk;
+    if (stdout.includes("ready\n")) signalReady();
+  });
+  child.stderr!.on("data", (chunk: string) => { stderr += chunk; });
+  const result = new Promise<{ readonly code: number | null; readonly stdout: string; readonly stderr: string }>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => {
+      children.delete(child);
+      resolve({ code, stdout, stderr });
+    });
+  });
+  return { ready, result };
+}
+
+function runCrashHolder(
+  dataDir: string,
+  phase: "database_prepared" | "database_published" | "os_locked" | "released_published",
+) {
   const child = spawn(process.execPath, [
     "scripts/tooling/bootstrap.mjs",
     "tests/fixtures/daemon_operation_crash.ts",
@@ -218,6 +316,22 @@ function runCrashHolder(dataDir: string, phase: "os_locked" | "released_publishe
     });
   });
   return { child, result };
+}
+
+async function expectProtectedValidDatabase(dataDir: string): Promise<void> {
+  const databasePath = path.join(dataDir, "daemon.operation.db");
+  if (process.platform !== "win32") expect((await stat(databasePath)).mode & 0o777).toBe(0o600);
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    expect(database.prepare("PRAGMA quick_check").all()).toEqual([{ quick_check: "ok" }]);
+  } finally {
+    database.close();
+  }
+}
+
+async function operationArtifacts(dataDir: string): Promise<string[]> {
+  return (await readdir(dataDir)).filter((name) =>
+    name.startsWith("daemon.operation") || name.startsWith(".daemon.operation")).sort();
 }
 
 function expectedStatus(dataDir: string, port: number) {

--- a/tests/integration/daemon_lifecycle_processes.test.ts
+++ b/tests/integration/daemon_lifecycle_processes.test.ts
@@ -1,0 +1,190 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type ServerResponse } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DaemonIdentityFile, type DaemonIdentityLease } from "../../src/daemon/identity_file.js";
+import { captureProcessStartIdentity } from "../../src/daemon/process_identity.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const children = new Set<ChildProcess>();
+
+afterEach(async () => {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+  }
+  await Promise.all([...children].map(async (child) => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    await new Promise<void>((resolve) => child.once("close", () => resolve()));
+  }));
+  children.clear();
+});
+
+describe("daemon lifecycle coordination across CLI processes", () => {
+  it("serializes status commands through the production operation lease", { timeout: 120_000 }, async () => {
+    const fixture = await processFixture();
+    try {
+      const first = runStatus(fixture.dataDir);
+      await vi.waitFor(() => expect(fixture.requests()).toBe(1), { timeout: 60_000 });
+      expect(JSON.parse(await readFile(path.join(fixture.dataDir, "daemon.operation.lock"), "utf8")))
+        .toMatchObject({ version: 1, pid: first.child.pid });
+
+      const second = runStatus(fixture.dataDir);
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      expect(fixture.requests()).toBe(1);
+      fixture.releaseBlockedResponse();
+
+      const [firstResult, secondResult] = await Promise.all([first.result, second.result]);
+      expect(firstResult, firstResult.stderr).toMatchObject({ code: 0 });
+      expect(secondResult, secondResult.stderr).toMatchObject({ code: 0 });
+      expect(JSON.parse(firstResult.stdout)).toEqual(expectedStatus(fixture.dataDir, fixture.port));
+      expect(JSON.parse(secondResult.stdout)).toEqual(expectedStatus(fixture.dataDir, fixture.port));
+      expect(secondResult.stdout).toBe(firstResult.stdout);
+      expect(firstResult.stderr).toBe("");
+      expect(secondResult.stderr).toBe("");
+      expect(fixture.requests()).toBe(2);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("recovers a crashed CLI owner only after its PID is proven dead", { timeout: 120_000 }, async () => {
+    const fixture = await processFixture();
+    try {
+      const crashed = runStatus(fixture.dataDir);
+      await vi.waitFor(() => expect(fixture.requests()).toBe(1), { timeout: 60_000 });
+      const crashedPid = crashed.child.pid;
+      expect(crashedPid).toBeTypeOf("number");
+      crashed.child.kill();
+      await crashed.result;
+      await vi.waitFor(async () => {
+        await expect(captureProcessStartIdentity(crashedPid!)).resolves.toBeNull();
+      }, { timeout: 30_000 });
+
+      fixture.releaseBlockedResponse();
+      const recovered = runStatus(fixture.dataDir);
+      const result = await recovered.result;
+      expect(result.code).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual(expectedStatus(fixture.dataDir, fixture.port));
+      expect(result.stderr).toBe("");
+      expect(fixture.requests()).toBe(2);
+    } finally {
+      await fixture.close();
+    }
+  });
+});
+
+async function processFixture() {
+  const root = await mkdtemp(path.join(tmpdir(), "ghcg-lifecycle-processes-"));
+  const dataDir = path.join(root, "data");
+  const processStartIdentity = await captureProcessStartIdentity(process.pid);
+  if (processStartIdentity === null) throw new Error("test process identity unavailable");
+  let requestCount = 0;
+  let blockedResponse: ServerResponse | undefined;
+  let releaseFirst = false;
+  const server = createServer((request, response) => {
+    requestCount += 1;
+    expect(request.method).toBe("GET");
+    expect(request.url).toBe("/__ghcg/control/v1/status");
+    expect(request.headers["x-ghcg-control-token"]).toBe("control-token");
+    expect(request.headers["x-ghcg-instance-nonce"]).toBe("instance-nonce");
+    if (requestCount === 1 && !releaseFirst) {
+      blockedResponse = response;
+      return;
+    }
+    writeStatus(response, processStartIdentity);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("test server address unavailable");
+  const identityFile = new DaemonIdentityFile(dataDir);
+  const identityLease = await identityFile.acquire({
+    version: 1,
+    managed: true,
+    pid: process.pid,
+    processStartIdentity,
+    instanceNonce: "instance-nonce",
+    controlToken: "control-token",
+    port: address.port,
+    createdAt: "2026-09-03T12:00:00.000Z",
+  });
+  return {
+    dataDir,
+    port: address.port,
+    requests: () => requestCount,
+    releaseBlockedResponse: () => {
+      releaseFirst = true;
+      if (blockedResponse !== undefined && !blockedResponse.destroyed) {
+        writeStatus(blockedResponse, processStartIdentity);
+      }
+      blockedResponse = undefined;
+    },
+    close: async () => {
+      closeIdentity(identityLease);
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function writeStatus(response: ServerResponse, processStartIdentity: string): void {
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ data: { state: "running", instance: {
+    pid: process.pid,
+    processStartIdentity,
+    instanceNonce: "instance-nonce",
+  } } }));
+}
+
+function runStatus(dataDir: string) {
+  const child = spawn(process.execPath, [
+    "scripts/tooling/bootstrap.mjs",
+    "src/cli/main.ts",
+    "--json",
+    "--data-dir", dataDir,
+    "status",
+  ], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  children.add(child);
+  let stdout = "";
+  let stderr = "";
+  child.stdout!.setEncoding("utf8");
+  child.stderr!.setEncoding("utf8");
+  child.stdout!.on("data", (chunk: string) => { stdout += chunk; });
+  child.stderr!.on("data", (chunk: string) => { stderr += chunk; });
+  const result = new Promise<{ readonly code: number | null; readonly stdout: string; readonly stderr: string }>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => {
+      children.delete(child);
+      resolve({ code, stdout, stderr });
+    });
+  });
+  return { child, result };
+}
+
+function expectedStatus(dataDir: string, port: number) {
+  return {
+    ok: true,
+    data: {
+      state: "running",
+      managed: true,
+      pid: process.pid,
+      startedAt: "2026-09-03T12:00:00.000Z",
+      port,
+      dataDir: path.resolve(dataDir),
+    },
+  };
+}
+
+function closeIdentity(lease: DaemonIdentityLease): void {
+  lease.cleanup();
+  lease.release();
+}

--- a/tests/integration/daemon_lifecycle_processes.test.ts
+++ b/tests/integration/daemon_lifecycle_processes.test.ts
@@ -27,8 +27,8 @@ describe("daemon lifecycle coordination across CLI processes", () => {
     try {
       const first = runStatus(fixture.dataDir);
       await vi.waitFor(() => expect(fixture.requests()).toBe(1), { timeout: 60_000 });
-      expect(JSON.parse(await readFile(path.join(fixture.dataDir, "daemon.operation.lock"), "utf8")))
-        .toMatchObject({ version: 1, pid: first.child.pid });
+      expect(JSON.parse(await readFile(path.join(fixture.dataDir, "daemon.operation.owner.json"), "utf8")))
+        .toMatchObject({ version: 1, state: "held", pid: first.child.pid });
 
       const second = runStatus(fixture.dataDir);
       await new Promise((resolve) => setTimeout(resolve, 250));
@@ -69,6 +69,27 @@ describe("daemon lifecycle coordination across CLI processes", () => {
       expect(JSON.parse(result.stdout)).toEqual(expectedStatus(fixture.dataDir, fixture.port));
       expect(result.stderr).toBe("");
       expect(fixture.requests()).toBe(2);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("survives real process crashes after OS lock and after released publication", { timeout: 240_000 }, async () => {
+    const fixture = await processFixture();
+    try {
+      const initialize = runStatus(fixture.dataDir);
+      await vi.waitFor(() => expect(fixture.requests()).toBe(1), { timeout: 60_000 });
+      fixture.releaseBlockedResponse();
+      await expect(initialize.result).resolves.toMatchObject({ code: 0 });
+
+      for (const phase of ["os_locked", "released_published"] as const) {
+        const crashed = runCrashHolder(fixture.dataDir, phase);
+        const crashedResult = await crashed.result;
+        expect(crashedResult).toMatchObject({ code: 23, stdout: `${phase}\n`, stderr: "" });
+        const recovered = runStatus(fixture.dataDir);
+        await expect(recovered.result).resolves.toMatchObject({ code: 0, stderr: "" });
+      }
+      expect(fixture.requests()).toBe(3);
     } finally {
       await fixture.close();
     }
@@ -147,6 +168,35 @@ function runStatus(dataDir: string) {
     "--json",
     "--data-dir", dataDir,
     "status",
+  ], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  children.add(child);
+  let stdout = "";
+  let stderr = "";
+  child.stdout!.setEncoding("utf8");
+  child.stderr!.setEncoding("utf8");
+  child.stdout!.on("data", (chunk: string) => { stdout += chunk; });
+  child.stderr!.on("data", (chunk: string) => { stderr += chunk; });
+  const result = new Promise<{ readonly code: number | null; readonly stdout: string; readonly stderr: string }>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => {
+      children.delete(child);
+      resolve({ code, stdout, stderr });
+    });
+  });
+  return { child, result };
+}
+
+function runCrashHolder(dataDir: string, phase: "os_locked" | "released_published") {
+  const child = spawn(process.execPath, [
+    "scripts/tooling/bootstrap.mjs",
+    "tests/fixtures/daemon_operation_crash.ts",
+    dataDir,
+    phase,
   ], {
     cwd: repoRoot,
     env: process.env,

--- a/tests/integration/daemon_runtime.test.ts
+++ b/tests/integration/daemon_runtime.test.ts
@@ -1,9 +1,11 @@
+import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
+import { authenticatedControlRequest } from "../../src/cli/control_client.js";
 import { createGateway } from "../../src/gateway/create_gateway.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
-import { runDaemonRuntime } from "../../src/daemon/runtime.js";
+import { runDaemonRuntime, spawnDaemonProcess } from "../../src/daemon/runtime.js";
 
 describe("daemon runtime listener", () => {
   it("rejects unsupported Node.js runtimes before publishing daemon identity", async () => {
@@ -198,6 +200,84 @@ describe("daemon runtime listener", () => {
     expect(events).toContain("shutdown_timeout");
     expect(events.slice(-2)).toEqual(["cleanup", "release"]);
     vi.useRealTimers();
+  });
+});
+
+describe("production lifecycle adapter abort acknowledgement", () => {
+  it("does not settle a timed-out control POST before the transport acknowledges abort", async () => {
+    vi.useFakeTimers();
+    try {
+      let rejectTransport = (_error: unknown): void => undefined;
+      let observedSignal: AbortSignal | undefined;
+      const request = authenticatedControlRequest({
+        pid: 4242,
+        processStartIdentity: "windows:1",
+        port: 31_400,
+        controlToken: "token",
+        instanceNonce: "nonce",
+        managed: true,
+      }, "POST", "/__ghcg/control/v1/stop", undefined, { timeoutMs: 10 }, async (_url, init) => {
+        observedSignal = init?.signal as AbortSignal;
+        return await new Promise<Response>((_resolve, reject) => { rejectTransport = reject; });
+      });
+      let settled = false;
+      void request.then(() => { settled = true; }, () => { settled = true; });
+      await vi.advanceTimersByTimeAsync(10);
+      expect(observedSignal?.aborted).toBe(true);
+      expect(settled).toBe(false);
+      rejectTransport(observedSignal?.reason);
+      await expect(request).rejects.toMatchObject({ code: "timeout" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("production daemon spawn adapter", () => {
+  it("passes the abort signal to child_process and waits for a pre-spawn abort acknowledgement", async () => {
+    const child = new EventEmitter() as ChildProcess;
+    const abort = new AbortController();
+    let observedOptions: SpawnOptions | undefined;
+    const spawning = spawnDaemonProcess(
+      process.execPath,
+      "child.js",
+      {},
+      parseStartupConfig(["--data-dir", "spawn-abort"], {}),
+      { signal: abort.signal, deadlineMs: Date.now() + 1_000 },
+      (_command, _args, options) => {
+        observedOptions = options;
+        return child;
+      },
+    );
+    let settled = false;
+    void spawning.then(() => { settled = true; }, () => { settled = true; });
+    abort.abort();
+    await Promise.resolve();
+    expect(observedOptions?.signal).toBe(abort.signal);
+    expect(settled).toBe(false);
+    child.emit("error", new DOMException("aborted", "AbortError"));
+    await expect(spawning).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("returns ownership to the controller when abort acknowledgement arrives after a PID exists", async () => {
+    const child = new EventEmitter() as ChildProcess;
+    Object.defineProperty(child, "pid", { value: 4242 });
+    child.unref = vi.fn(() => child);
+    const abort = new AbortController();
+    const spawning = spawnDaemonProcess(
+      process.execPath,
+      "child.js",
+      {},
+      parseStartupConfig(["--data-dir", "spawn-owned"], {}),
+      { signal: abort.signal, deadlineMs: Date.now() + 1_000 },
+      () => child,
+    );
+    abort.abort();
+    child.emit("error", new DOMException("aborted", "AbortError"));
+    const owned = await spawning;
+    expect(owned.pid).toBe(4242);
+    owned.unref();
+    expect(child.unref).toHaveBeenCalledOnce();
   });
 });
 

--- a/tests/integration/daemon_stale_pid.test.ts
+++ b/tests/integration/daemon_stale_pid.test.ts
@@ -26,7 +26,11 @@ describe("stale PID safety", () => {
       managed: true,
       pid: IDENTITY.pid,
     });
-    expect(fixture.remove).toHaveBeenCalledWith(DATA_DIR, IDENTITY);
+    expect(fixture.remove).toHaveBeenCalledWith(
+      DATA_DIR,
+      IDENTITY,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(fixture.terminate).not.toHaveBeenCalled();
   });
 

--- a/tests/integration/daemon_stale_pid.test.ts
+++ b/tests/integration/daemon_stale_pid.test.ts
@@ -54,6 +54,16 @@ describe("stale PID safety", () => {
     expect(fixture.terminate).not.toHaveBeenCalled();
   });
 
+  it("refuses cleanup when an authenticated stop response has a forged nonce", async () => {
+    const fixture = harness(IDENTITY.processStartIdentity);
+    fixture.controlRequest.mockImplementation(async (identity, method) => method === "GET"
+      ? { state: "running", instance: instanceOf(identity) }
+      : { instance: { ...instanceOf(identity), instanceNonce: "forged-nonce" } });
+    await expect(fixture.controller.stop(DATA_DIR)).resolves.toMatchObject({ state: "conflict" });
+    expect(fixture.terminate).not.toHaveBeenCalled();
+    expect(fixture.remove).not.toHaveBeenCalled();
+  });
+
   it("reports a verified live but unreachable process and never sends stop or terminate", async () => {
     const fixture = harness(IDENTITY.processStartIdentity);
     fixture.controlRequest.mockRejectedValue(new TypeError("connection refused"));
@@ -75,6 +85,18 @@ describe("stale PID safety", () => {
     });
     await expect(fixture.controller.stop(DATA_DIR)).resolves.toMatchObject({ state: "conflict" });
     expect(fixture.elapsedMs).toBeLessThanOrEqual(10_000);
+    expect(fixture.terminate).not.toHaveBeenCalled();
+    expect(fixture.remove).not.toHaveBeenCalled();
+  });
+
+  it("refuses force-stop when the post-grace identity probe becomes unknown", async () => {
+    let reads = 0;
+    const fixture = harness(async () => {
+      reads += 1;
+      if (reads > 99) throw new Error("identity unavailable after grace");
+      return IDENTITY.processStartIdentity;
+    });
+    await expect(fixture.controller.stop(DATA_DIR)).resolves.toMatchObject({ state: "conflict" });
     expect(fixture.terminate).not.toHaveBeenCalled();
     expect(fixture.remove).not.toHaveBeenCalled();
   });

--- a/tests/unit/daemon_identity.test.ts
+++ b/tests/unit/daemon_identity.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   ProcessIdentityError,
   captureProcessStartIdentity,
+  isCanonicalProcessStartIdentity,
   isSameProcess,
   parseLinuxProcStatStartTicks,
   terminateProcessIfMatching,
@@ -41,6 +42,17 @@ async function temporaryDirectory(): Promise<string> {
 }
 
 describe("daemon identity schema", () => {
+  it("uses the canonical process-start identity formats", () => {
+    expect(isCanonicalProcessStartIdentity("linux:01234567-89ab-cdef-0123-456789abcdef:0")).toBe(true);
+    expect(isCanonicalProcessStartIdentity("windows:0")).toBe(true);
+    expect(isCanonicalProcessStartIdentity("macos:2024-02-29T23:59:59Z")).toBe(true);
+    expect(isCanonicalProcessStartIdentity("linux:01234567-89AB-cdef-0123-456789abcdef:1")).toBe(false);
+    expect(isCanonicalProcessStartIdentity("linux:01234567-89ab-cdef-0123-456789abcdef:01")).toBe(false);
+    expect(isCanonicalProcessStartIdentity("windows:001")).toBe(false);
+    expect(isCanonicalProcessStartIdentity("windows:184467440737095516160")).toBe(false);
+    expect(isCanonicalProcessStartIdentity("macos:2026-02-30T12:00:00Z")).toBe(false);
+  });
+
   it("accepts only the exact versioned schema", () => {
     expect(decodeDaemonIdentity(JSON.stringify(identity))).toEqual(identity);
     expect(() => decodeDaemonIdentity(JSON.stringify({ ...identity, extra: true }))).toThrow(DaemonIdentityFileError);

--- a/tests/unit/daemon_identity.test.ts
+++ b/tests/unit/daemon_identity.test.ts
@@ -252,6 +252,22 @@ describe("process start identity", () => {
     });
   });
 
+  it("forwards abort context through identity probes and verified termination commands", async () => {
+    const abort = new AbortController();
+    const contexts: Array<AbortSignal | undefined> = [];
+    const dependencies: ProcessIdentityDependencies = {
+      platform: "win32",
+      readFile: async () => "",
+      runCommand: async (_file, _args, _env, context) => {
+        contexts.push(context?.signal);
+        return "133852868960001234\r\n";
+      },
+    };
+    await captureProcessStartIdentity(4242, dependencies, { signal: abort.signal });
+    await terminateProcessIfMatching(4242, "windows:133852868960001234", dependencies, { signal: abort.signal });
+    expect(contexts).toEqual([abort.signal, abort.signal]);
+  });
+
   it("performs Linux identity verification and termination in one command", async () => {
     const calls: string[] = [];
     const dependencies: ProcessIdentityDependencies = {

--- a/tests/unit/daemon_operation_lease.test.ts
+++ b/tests/unit/daemon_operation_lease.test.ts
@@ -1,10 +1,12 @@
-import { chmod, lstat, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { chmod, lstat, mkdir, mkdtemp, readFile, rmdir, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   DaemonOperationLeaseFile,
   decodeOperationOwner,
+  type OperationOwner,
 } from "../../src/daemon/operation_lease.js";
 
 const START_IDENTITY = "linux:01234567-89ab-cdef-0123-456789abcdef:987654";
@@ -14,137 +16,62 @@ async function temporaryDirectory(): Promise<string> {
 }
 
 describe("daemon operation lease", () => {
-  it("uses the shared canonical process identity formats for owner records", () => {
-    expect(() => decodeOperationOwner(JSON.stringify({
-      ...ownerRecord(),
-      processStartIdentity: "windows:001",
-    }))).toThrow();
-    expect(() => decodeOperationOwner(JSON.stringify({
-      ...ownerRecord(),
-      processStartIdentity: "macos:2026-02-30T12:00:00Z",
-    }))).toThrow();
+  it("accepts only the exact held/released owner schema", () => {
+    expect(decodeOperationOwner(JSON.stringify(ownerRecord()))).toEqual(ownerRecord());
+    for (const invalid of [
+      { ...ownerRecord(), extra: true },
+      { ...ownerRecord(), state: "waiting" },
+      { ...ownerRecord(), processStartIdentity: "windows:001" },
+      { ...ownerRecord(), leaseToken: "" },
+    ]) expect(() => decodeOperationOwner(JSON.stringify(invalid))).toThrow();
   });
 
-  it("exclusively owns a protected file separate from daemon lifetime identity", async () => {
+  it("uses a persistent protected SQLite database and publishes held then released metadata", async () => {
     const directory = await temporaryDirectory();
-    const leaseFile = new DaemonOperationLeaseFile({
-      pid: 4242,
-      processStartIdentity: async () => START_IDENTITY,
-      processIdentity: async () => START_IDENTITY,
-      createToken: () => "operation-token",
-    });
+    const phases: string[] = [];
+    const leaseFile = operationLease({ onPhase: (phase) => phases.push(phase) });
+    const lease = await leaseFile.acquire(directory);
+    const databasePath = path.join(directory, "daemon.operation.db");
+    const ownerPath = path.join(directory, "daemon.operation.owner.json");
 
-    const first = await leaseFile.acquire(directory);
-    const operationPath = path.join(directory, "daemon.operation.lock");
-    expect(JSON.parse(await readFile(operationPath, "utf8"))).toEqual({
-      version: 1,
-      pid: 4242,
-      processStartIdentity: START_IDENTITY,
-      leaseToken: "operation-token",
-    });
+    expect(JSON.parse(await readFile(ownerPath, "utf8"))).toEqual(ownerRecord({ leaseToken: "test-token" }));
     if (process.platform !== "win32") {
-      expect((await lstat(operationPath)).mode & 0o777).toBe(0o600);
+      expect((await lstat(databasePath)).mode & 0o777).toBe(0o600);
+      expect((await lstat(ownerPath)).mode & 0o777).toBe(0o600);
       expect((await lstat(directory)).mode & 0o777).toBe(0o700);
     }
-    await expect(lstat(path.join(directory, "daemon.lock"))).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(lstat(path.join(directory, "daemon.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    lease.release();
+    expect(JSON.parse(await readFile(ownerPath, "utf8"))).toEqual(ownerRecord({
+      state: "released",
+      leaseToken: "test-token",
+    }));
+    expect(await lstat(databasePath)).toMatchObject({ isFile: expect.any(Function) });
+    expect(phases).toEqual(["os_locked", "held_published", "released_published", "database_closing"]);
+    for (const suffix of ["-journal", "-wal", "-shm"]) {
+      await expect(lstat(databasePath + suffix)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
 
+  it("serializes the same database, allows different directories in parallel, and release is idempotent", async () => {
+    const firstDirectory = await temporaryDirectory();
+    const otherDirectory = await temporaryDirectory();
+    const leaseFile = operationLease({ createToken: (() => {
+      let token = 0;
+      return () => `token-${++token}`;
+    })() });
+    const first = await leaseFile.acquire(firstDirectory);
     let secondSettled = false;
-    const second = leaseFile.acquire(directory).finally(() => { secondSettled = true; });
-    await vi.waitFor(() => expect(secondSettled).toBe(false));
+    const second = leaseFile.acquire(firstDirectory).finally(() => { secondSettled = true; });
+    const other = await leaseFile.acquire(otherDirectory);
+    await new Promise((resolve) => setTimeout(resolve, 125));
+    expect(secondSettled).toBe(false);
+    other.release();
+    first.release();
     first.release();
     (await second).release();
-    await expect(lstat(operationPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("releases only the unchanged file owned by its token and file identity", async () => {
-    const directory = await temporaryDirectory();
-    const leaseFile = operationLease({ createToken: () => "original-token" });
-    const lease = await leaseFile.acquire(directory);
-    const operationPath = path.join(directory, "daemon.operation.lock");
-    await writeFile(operationPath, `${JSON.stringify({
-      version: 1,
-      pid: 4242,
-      processStartIdentity: START_IDENTITY,
-      leaseToken: "replacement-token",
-    })}\n`, { mode: 0o600 });
-
-    lease.release();
-    expect(JSON.parse(await readFile(operationPath, "utf8"))).toMatchObject({ leaseToken: "replacement-token" });
-    if (process.platform !== "win32") await chmod(operationPath, 0o600);
-  });
-
-  it("recovers an orphan only after its owner is proven dead", async () => {
-    const directory = await temporaryDirectory();
-    const orphan = await operationLease({ createToken: () => "orphan-token" }).acquire(directory);
-    const recovered = await operationLease({
-      processIdentity: async () => null,
-      createToken: () => "recovered-token",
-    }).acquire(directory);
-    expect(JSON.parse(await readFile(path.join(directory, "daemon.operation.lock"), "utf8")))
-      .toMatchObject({ leaseToken: "recovered-token" });
-    recovered.release();
-    orphan.release();
-  });
-
-  it("atomically serializes competing recoverers without removing the new live lease", async () => {
-    const directory = await temporaryDirectory();
-    const orphan = await operationLease({ createToken: () => "orphan-token" }).acquire(directory);
-    let probes = 0;
-    let releaseProbes = (): void => undefined;
-    const bothProbing = new Promise<void>((resolve) => { releaseProbes = resolve; });
-    const proveDead = async (): Promise<null> => {
-      probes += 1;
-      if (probes === 2) releaseProbes();
-      await bothProbing;
-      return null;
-    };
-    const firstFile = operationLease({
-      pid: 5001,
-      processIdentity: async (pid) => pid === 4242 ? await proveDead() : START_IDENTITY,
-      createToken: () => "first-recoverer",
-    });
-    const secondFile = operationLease({
-      pid: 5002,
-      processIdentity: async (pid) => pid === 4242 ? await proveDead() : START_IDENTITY,
-      createToken: () => "second-recoverer",
-    });
-    const firstAcquire = firstFile.acquire(directory);
-    const secondAcquire = secondFile.acquire(directory);
-    const winner = await Promise.race([
-      firstAcquire.then((lease) => ({ lease, token: "first-recoverer" })),
-      secondAcquire.then((lease) => ({ lease, token: "second-recoverer" })),
-    ]);
-    expect(JSON.parse(await readFile(path.join(directory, "daemon.operation.lock"), "utf8")))
-      .toMatchObject({ leaseToken: winner.token });
-
-    let loserSettled = false;
-    const loser = (winner.token === "first-recoverer" ? secondAcquire : firstAcquire)
-      .finally(() => { loserSettled = true; });
-    await vi.waitFor(() => expect(loserSettled).toBe(false));
-    winner.lease.release();
-    (await loser).release();
-    orphan.release();
-  });
-
-  it("fails closed for PID reuse and unknown owner identity without removing the lease", async () => {
-    const directory = await temporaryDirectory();
-    const owner = await operationLease({ createToken: () => "owner-token" }).acquire(directory);
-    const operationPath = path.join(directory, "daemon.operation.lock");
-
-    await expect(operationLease({
-      processIdentity: async () => "linux:01234567-89ab-cdef-0123-456789abcdef:999999",
-    }).acquire(directory)).rejects.toMatchObject({ code: "unsafe_owner" });
-    expect(JSON.parse(await readFile(operationPath, "utf8"))).toMatchObject({ leaseToken: "owner-token" });
-
-    await expect(operationLease({
-      processIdentity: async () => { throw new Error("private probe diagnostic"); },
-    }).acquire(directory)).rejects.toMatchObject({ code: "unsafe_owner", message: "unable to verify operation lease owner" });
-    expect(await readFile(operationPath, "utf8")).not.toContain("private probe diagnostic");
-    owner.release();
-  });
-
-  it("allows an independently canceled waiter to leave the active owner untouched", async () => {
+  it("cancels a busy waiter without disturbing the holder or a later waiter", async () => {
     const directory = await temporaryDirectory();
     const leaseFile = operationLease();
     const active = await leaseFile.acquire(directory);
@@ -152,36 +79,133 @@ describe("daemon operation lease", () => {
     const waiting = leaseFile.acquire(directory, { signal: abort.signal });
     abort.abort();
     await expect(waiting).rejects.toBeDefined();
-    expect(JSON.parse(await readFile(path.join(directory, "daemon.operation.lock"), "utf8")))
-      .toMatchObject({ leaseToken: "test-token" });
+    expect(JSON.parse(await readFile(path.join(directory, "daemon.operation.owner.json"), "utf8")))
+      .toMatchObject({ state: "held", leaseToken: "test-token" });
     active.release();
     (await leaseFile.acquire(directory)).release();
   });
 
-  it.skipIf(process.platform === "win32")("fails closed for malformed, excessive, and weakly protected owner files", async () => {
-    const directory = await temporaryDirectory();
-    const bootstrap = await operationLease().acquire(directory);
-    bootstrap.release();
-    const operationPath = path.join(directory, "daemon.operation.lock");
-
-    await writeFile(operationPath, "{}\n", { mode: 0o600 });
-    await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "invalid_identity" });
-    await writeFile(operationPath, "x".repeat(4097), { mode: 0o600 });
-    await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "unsafe_path" });
-    await writeFile(operationPath, `${JSON.stringify(ownerRecord())}\n`, { mode: 0o600 });
-    await chmod(operationPath, 0o644);
-    await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "unsafe_permissions" });
+  it("recovers held metadata only when the previous PID is proven dead", async () => {
+    const directory = await initializedDirectory();
+    await writeOwner(directory, ownerRecord({ leaseToken: "orphan" }));
+    const recovered = await operationLease({
+      processIdentity: async () => null,
+      createToken: () => "recovered",
+    }).acquire(directory);
+    expect(await readOwner(directory)).toMatchObject({ state: "held", leaseToken: "recovered" });
+    recovered.release();
   });
 
-  it.skipIf(process.platform === "win32")("fails closed for a symlink operation lease", async () => {
+  it.each([
+    ["same live identity", async () => START_IDENTITY],
+    ["PID reuse", async () => "linux:01234567-89ab-cdef-0123-456789abcdef:999999"],
+    ["unknown identity", async () => { throw new Error("private SQLite/path diagnostic"); }],
+  ])("fails closed for previous held metadata with %s", async (_name, processIdentity) => {
+    const directory = await initializedDirectory();
+    await writeOwner(directory, ownerRecord({ leaseToken: "previous" }));
+    const callback = vi.fn();
+    await expect(operationLease({ processIdentity }).acquire(directory).then(callback))
+      .rejects.toMatchObject({ code: "unsafe_owner" });
+    expect(callback).not.toHaveBeenCalled();
+    expect(await readFile(path.join(directory, "daemon.operation.owner.json"), "utf8"))
+      .not.toContain("private SQLite/path diagnostic");
+  });
+
+  it("permits released metadata without probing the old PID", async () => {
+    const directory = await initializedDirectory();
+    const probe = vi.fn(async () => { throw new Error("must not probe"); });
+    const acquired = await operationLease({ processIdentity: probe }).acquire(directory);
+    expect(probe).not.toHaveBeenCalled();
+    acquired.release();
+  });
+
+  it("closes the SQLite transaction after crashes before held publication and recovers dead held publication", async () => {
+    const directory = await initializedDirectory();
+    const beforeHeld = operationLease({
+      onPhase: (phase) => { if (phase === "os_locked") throw new Error("crash before held"); },
+    });
+    await expect(beforeHeld.acquire(directory)).rejects.toMatchObject({ code: "io_error" });
+    (await operationLease().acquire(directory)).release();
+
+    const afterHeld = operationLease({
+      pid: 5000,
+      createToken: () => "crashed-holder",
+      onPhase: (phase) => { if (phase === "held_published") throw new Error("crash after held"); },
+    });
+    await expect(afterHeld.acquire(directory)).rejects.toMatchObject({ code: "io_error" });
+    expect(await readOwner(directory)).toMatchObject({ state: "held", leaseToken: "crashed-holder" });
+    const recovered = await operationLease({ processIdentity: async (pid) => pid === 5000 ? null : START_IDENTITY })
+      .acquire(directory);
+    recovered.release();
+  });
+
+  it("closes the database but leaves held metadata when released publication fails", async () => {
     const directory = await temporaryDirectory();
-    const bootstrap = await operationLease().acquire(directory);
-    bootstrap.release();
-    const outside = path.join(await temporaryDirectory(), "outside.lock");
-    await operationLease().acquire(path.dirname(outside)).then((lease) => lease.release());
-    await writeFile(outside, `${JSON.stringify(ownerRecord())}\n`, { mode: 0o600 });
-    await symlink(outside, path.join(directory, "daemon.operation.lock"), "file");
-    await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "unsafe_path" });
+    const lease = await operationLease().acquire(directory);
+    await mkdir(path.join(directory, ".daemon.operation.owner.json.tmp"));
+    expect(() => lease.release()).toThrow();
+    expect(await readOwner(directory)).toMatchObject({ state: "held", leaseToken: "test-token" });
+    await rmdir(path.join(directory, ".daemon.operation.owner.json.tmp"));
+    await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "unsafe_owner" });
+  });
+
+  it("publishes released before closing the database lock", async () => {
+    const directory = await temporaryDirectory();
+    const observations: OperationOwner[] = [];
+    const lease = await operationLease({
+      onPhase: (phase) => {
+        if (phase === "database_closing") {
+          observations.push(JSON.parse(requireRead(path.join(directory, "daemon.operation.owner.json"))) as OperationOwner);
+        }
+      },
+    }).acquire(directory);
+    lease.release();
+    expect(observations).toEqual([ownerRecord({ state: "released", leaseToken: "test-token" })]);
+  });
+
+  it("fails closed when Windows reports the persistent database as a reparse point", async () => {
+    const directory = await temporaryDirectory();
+    const runCommand = (file: string, args: readonly string[]): string => {
+      const script = args.at(-1) ?? "";
+      if (file === "powershell.exe" && script.includes("ReparsePoint")
+        && script.includes("daemon.operation.db")) return "true\r\n";
+      return fakeWindowsSecurityCommand(file, args);
+    };
+    await expect(operationLease({ platform: "win32", runCommand }).acquire(directory))
+      .rejects.toMatchObject({ code: "unsafe_path" });
+  });
+
+  it.skipIf(process.platform === "win32")("fails closed for unsafe database, owner, temp, and sidecar paths", async () => {
+    const cases: Array<(directory: string) => Promise<void>> = [
+      async (directory) => { await chmod(path.join(directory, "daemon.operation.db"), 0o644); },
+      async (directory) => { await chmod(path.join(directory, "daemon.operation.owner.json"), 0o644); },
+      async (directory) => { await writeFile(path.join(directory, ".daemon.operation.owner.json.tmp"), "unsafe", { mode: 0o644 }); },
+      async (directory) => { await writeFile(path.join(directory, "daemon.operation.db-journal"), "unexpected", { mode: 0o600 }); },
+    ];
+    for (const arrange of cases) {
+      const directory = await initializedDirectory();
+      await arrange(directory);
+      await expect(operationLease().acquire(directory)).rejects.toMatchObject({
+        code: expect.stringMatching(/^unsafe_/u),
+      });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("fails closed for symlink database, owner, temp, and sidecar paths", async () => {
+    for (const name of [
+      "daemon.operation.db",
+      "daemon.operation.owner.json",
+      ".daemon.operation.owner.json.tmp",
+      "daemon.operation.db-wal",
+    ]) {
+      const directory = await initializedDirectory();
+      const target = path.join(await mkdtemp(path.join(tmpdir(), "ghcg-operation-outside-")), "target");
+      await writeFile(target, "outside", { mode: 0o600 });
+      const victim = path.join(directory, name);
+      try { await unlink(victim); } catch { /* absent is expected */ }
+      await symlink(target, victim, "file");
+      await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "unsafe_path" });
+    }
   });
 });
 
@@ -191,15 +215,49 @@ function operationLease(overrides: ConstructorParameters<typeof DaemonOperationL
     processStartIdentity: async () => START_IDENTITY,
     processIdentity: async () => START_IDENTITY,
     createToken: () => "test-token",
+    ...(process.platform === "win32" ? { runCommand: fakeWindowsSecurityCommand } : {}),
     ...overrides,
   });
 }
 
-function ownerRecord() {
+function ownerRecord(overrides: Partial<OperationOwner> = {}): OperationOwner {
   return {
     version: 1,
+    state: "held",
     pid: 4242,
     processStartIdentity: START_IDENTITY,
     leaseToken: "owner-token",
+    ...overrides,
   };
+}
+
+async function initializedDirectory(): Promise<string> {
+  const directory = await temporaryDirectory();
+  const lease = await operationLease().acquire(directory);
+  lease.release();
+  return directory;
+}
+
+async function writeOwner(directory: string, owner: OperationOwner): Promise<void> {
+  await writeFile(path.join(directory, "daemon.operation.owner.json"), `${JSON.stringify(owner)}\n`, { mode: 0o600 });
+  if (process.platform !== "win32") await chmod(path.join(directory, "daemon.operation.owner.json"), 0o600);
+}
+
+async function readOwner(directory: string): Promise<OperationOwner> {
+  return JSON.parse(await readFile(path.join(directory, "daemon.operation.owner.json"), "utf8")) as OperationOwner;
+}
+
+function requireRead(filePath: string): string {
+  return readFileSync(filePath, "utf8");
+}
+
+function fakeWindowsSecurityCommand(file: string, args: readonly string[]): string {
+  if (file === "whoami") return "\"CONTOSO\\User\",\"S-1-5-21-1000\"\r\n";
+  if (file === "powershell.exe") {
+    return args.at(-1)?.includes("Get-Acl") === true ? "CONTOSO\\User\r\n" : "false\r\n";
+  }
+  if (file === "icacls" && args.length === 1) {
+    return `${args[0]} CONTOSO\\User:(F)\r\nSuccessfully processed 1 files; Failed processing 0 files\r\n`;
+  }
+  return "";
 }

--- a/tests/unit/daemon_operation_lease.test.ts
+++ b/tests/unit/daemon_operation_lease.test.ts
@@ -2,7 +2,10 @@ import { chmod, lstat, mkdtemp, readFile, symlink, writeFile } from "node:fs/pro
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { DaemonOperationLeaseFile } from "../../src/daemon/operation_lease.js";
+import {
+  DaemonOperationLeaseFile,
+  decodeOperationOwner,
+} from "../../src/daemon/operation_lease.js";
 
 const START_IDENTITY = "linux:01234567-89ab-cdef-0123-456789abcdef:987654";
 
@@ -11,6 +14,17 @@ async function temporaryDirectory(): Promise<string> {
 }
 
 describe("daemon operation lease", () => {
+  it("uses the shared canonical process identity formats for owner records", () => {
+    expect(() => decodeOperationOwner(JSON.stringify({
+      ...ownerRecord(),
+      processStartIdentity: "windows:001",
+    }))).toThrow();
+    expect(() => decodeOperationOwner(JSON.stringify({
+      ...ownerRecord(),
+      processStartIdentity: "macos:2026-02-30T12:00:00Z",
+    }))).toThrow();
+  });
+
   it("exclusively owns a protected file separate from daemon lifetime identity", async () => {
     const directory = await temporaryDirectory();
     const leaseFile = new DaemonOperationLeaseFile({
@@ -70,6 +84,46 @@ describe("daemon operation lease", () => {
     expect(JSON.parse(await readFile(path.join(directory, "daemon.operation.lock"), "utf8")))
       .toMatchObject({ leaseToken: "recovered-token" });
     recovered.release();
+    orphan.release();
+  });
+
+  it("atomically serializes competing recoverers without removing the new live lease", async () => {
+    const directory = await temporaryDirectory();
+    const orphan = await operationLease({ createToken: () => "orphan-token" }).acquire(directory);
+    let probes = 0;
+    let releaseProbes = (): void => undefined;
+    const bothProbing = new Promise<void>((resolve) => { releaseProbes = resolve; });
+    const proveDead = async (): Promise<null> => {
+      probes += 1;
+      if (probes === 2) releaseProbes();
+      await bothProbing;
+      return null;
+    };
+    const firstFile = operationLease({
+      pid: 5001,
+      processIdentity: async (pid) => pid === 4242 ? await proveDead() : START_IDENTITY,
+      createToken: () => "first-recoverer",
+    });
+    const secondFile = operationLease({
+      pid: 5002,
+      processIdentity: async (pid) => pid === 4242 ? await proveDead() : START_IDENTITY,
+      createToken: () => "second-recoverer",
+    });
+    const firstAcquire = firstFile.acquire(directory);
+    const secondAcquire = secondFile.acquire(directory);
+    const winner = await Promise.race([
+      firstAcquire.then((lease) => ({ lease, token: "first-recoverer" })),
+      secondAcquire.then((lease) => ({ lease, token: "second-recoverer" })),
+    ]);
+    expect(JSON.parse(await readFile(path.join(directory, "daemon.operation.lock"), "utf8")))
+      .toMatchObject({ leaseToken: winner.token });
+
+    let loserSettled = false;
+    const loser = (winner.token === "first-recoverer" ? secondAcquire : firstAcquire)
+      .finally(() => { loserSettled = true; });
+    await vi.waitFor(() => expect(loserSettled).toBe(false));
+    winner.lease.release();
+    (await loser).release();
     orphan.release();
   });
 

--- a/tests/unit/daemon_operation_lease.test.ts
+++ b/tests/unit/daemon_operation_lease.test.ts
@@ -1,0 +1,151 @@
+import { chmod, lstat, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { DaemonOperationLeaseFile } from "../../src/daemon/operation_lease.js";
+
+const START_IDENTITY = "linux:01234567-89ab-cdef-0123-456789abcdef:987654";
+
+async function temporaryDirectory(): Promise<string> {
+  return path.join(await mkdtemp(path.join(tmpdir(), "ghcg-operation-lease-")), "data");
+}
+
+describe("daemon operation lease", () => {
+  it("exclusively owns a protected file separate from daemon lifetime identity", async () => {
+    const directory = await temporaryDirectory();
+    const leaseFile = new DaemonOperationLeaseFile({
+      pid: 4242,
+      processStartIdentity: async () => START_IDENTITY,
+      processIdentity: async () => START_IDENTITY,
+      createToken: () => "operation-token",
+    });
+
+    const first = await leaseFile.acquire(directory);
+    const operationPath = path.join(directory, "daemon.operation.lock");
+    expect(JSON.parse(await readFile(operationPath, "utf8"))).toEqual({
+      version: 1,
+      pid: 4242,
+      processStartIdentity: START_IDENTITY,
+      leaseToken: "operation-token",
+    });
+    if (process.platform !== "win32") {
+      expect((await lstat(operationPath)).mode & 0o777).toBe(0o600);
+      expect((await lstat(directory)).mode & 0o777).toBe(0o700);
+    }
+    await expect(lstat(path.join(directory, "daemon.lock"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(lstat(path.join(directory, "daemon.json"))).rejects.toMatchObject({ code: "ENOENT" });
+
+    let secondSettled = false;
+    const second = leaseFile.acquire(directory).finally(() => { secondSettled = true; });
+    await vi.waitFor(() => expect(secondSettled).toBe(false));
+    first.release();
+    (await second).release();
+    await expect(lstat(operationPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("releases only the unchanged file owned by its token and file identity", async () => {
+    const directory = await temporaryDirectory();
+    const leaseFile = operationLease({ createToken: () => "original-token" });
+    const lease = await leaseFile.acquire(directory);
+    const operationPath = path.join(directory, "daemon.operation.lock");
+    await writeFile(operationPath, `${JSON.stringify({
+      version: 1,
+      pid: 4242,
+      processStartIdentity: START_IDENTITY,
+      leaseToken: "replacement-token",
+    })}\n`, { mode: 0o600 });
+
+    lease.release();
+    expect(JSON.parse(await readFile(operationPath, "utf8"))).toMatchObject({ leaseToken: "replacement-token" });
+    if (process.platform !== "win32") await chmod(operationPath, 0o600);
+  });
+
+  it("recovers an orphan only after its owner is proven dead", async () => {
+    const directory = await temporaryDirectory();
+    const orphan = await operationLease({ createToken: () => "orphan-token" }).acquire(directory);
+    const recovered = await operationLease({
+      processIdentity: async () => null,
+      createToken: () => "recovered-token",
+    }).acquire(directory);
+    expect(JSON.parse(await readFile(path.join(directory, "daemon.operation.lock"), "utf8")))
+      .toMatchObject({ leaseToken: "recovered-token" });
+    recovered.release();
+    orphan.release();
+  });
+
+  it("fails closed for PID reuse and unknown owner identity without removing the lease", async () => {
+    const directory = await temporaryDirectory();
+    const owner = await operationLease({ createToken: () => "owner-token" }).acquire(directory);
+    const operationPath = path.join(directory, "daemon.operation.lock");
+
+    await expect(operationLease({
+      processIdentity: async () => "linux:01234567-89ab-cdef-0123-456789abcdef:999999",
+    }).acquire(directory)).rejects.toMatchObject({ code: "unsafe_owner" });
+    expect(JSON.parse(await readFile(operationPath, "utf8"))).toMatchObject({ leaseToken: "owner-token" });
+
+    await expect(operationLease({
+      processIdentity: async () => { throw new Error("private probe diagnostic"); },
+    }).acquire(directory)).rejects.toMatchObject({ code: "unsafe_owner", message: "unable to verify operation lease owner" });
+    expect(await readFile(operationPath, "utf8")).not.toContain("private probe diagnostic");
+    owner.release();
+  });
+
+  it("allows an independently canceled waiter to leave the active owner untouched", async () => {
+    const directory = await temporaryDirectory();
+    const leaseFile = operationLease();
+    const active = await leaseFile.acquire(directory);
+    const abort = new AbortController();
+    const waiting = leaseFile.acquire(directory, { signal: abort.signal });
+    abort.abort();
+    await expect(waiting).rejects.toBeDefined();
+    expect(JSON.parse(await readFile(path.join(directory, "daemon.operation.lock"), "utf8")))
+      .toMatchObject({ leaseToken: "test-token" });
+    active.release();
+    (await leaseFile.acquire(directory)).release();
+  });
+
+  it.skipIf(process.platform === "win32")("fails closed for malformed, excessive, and weakly protected owner files", async () => {
+    const directory = await temporaryDirectory();
+    const bootstrap = await operationLease().acquire(directory);
+    bootstrap.release();
+    const operationPath = path.join(directory, "daemon.operation.lock");
+
+    await writeFile(operationPath, "{}\n", { mode: 0o600 });
+    await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "invalid_identity" });
+    await writeFile(operationPath, "x".repeat(4097), { mode: 0o600 });
+    await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "unsafe_path" });
+    await writeFile(operationPath, `${JSON.stringify(ownerRecord())}\n`, { mode: 0o600 });
+    await chmod(operationPath, 0o644);
+    await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "unsafe_permissions" });
+  });
+
+  it.skipIf(process.platform === "win32")("fails closed for a symlink operation lease", async () => {
+    const directory = await temporaryDirectory();
+    const bootstrap = await operationLease().acquire(directory);
+    bootstrap.release();
+    const outside = path.join(await temporaryDirectory(), "outside.lock");
+    await operationLease().acquire(path.dirname(outside)).then((lease) => lease.release());
+    await writeFile(outside, `${JSON.stringify(ownerRecord())}\n`, { mode: 0o600 });
+    await symlink(outside, path.join(directory, "daemon.operation.lock"), "file");
+    await expect(operationLease().acquire(directory)).rejects.toMatchObject({ code: "unsafe_path" });
+  });
+});
+
+function operationLease(overrides: ConstructorParameters<typeof DaemonOperationLeaseFile>[0] = {}) {
+  return new DaemonOperationLeaseFile({
+    pid: 4242,
+    processStartIdentity: async () => START_IDENTITY,
+    processIdentity: async () => START_IDENTITY,
+    createToken: () => "test-token",
+    ...overrides,
+  });
+}
+
+function ownerRecord() {
+  return {
+    version: 1,
+    pid: 4242,
+    processStartIdentity: START_IDENTITY,
+    leaseToken: "owner-token",
+  };
+}

--- a/tests/unit/daemon_operation_lease.test.ts
+++ b/tests/unit/daemon_operation_lease.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { chmod, lstat, mkdir, mkdtemp, readFile, rmdir, symlink, unlink, writeFile } from "node:fs/promises";
+import { readFileSync, writeSync } from "node:fs";
+import { chmod, copyFile, link, lstat, mkdir, mkdtemp, readFile, readdir, rmdir, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -50,6 +50,55 @@ describe("daemon operation lease", () => {
     for (const suffix of ["-journal", "-wal", "-shm"]) {
       await expect(lstat(databasePath + suffix)).rejects.toMatchObject({ code: "ENOENT" });
     }
+  });
+
+  it("completes short writes while initializing the database", async () => {
+    const directory = await temporaryDirectory();
+    let writes = 0;
+    const lease = await operationLease({
+      write: (fd, buffer, offset, length, position) => {
+        writes += 1;
+        return writeSync(fd, buffer, offset, Math.min(length, 17), position);
+      },
+    }).acquire(directory);
+    lease.release();
+
+    expect(writes).toBeGreaterThan(1);
+    expect(await initializationTemps(directory)).toEqual([]);
+  });
+
+  it("recovers protected initialization temps left before and after atomic database publication", async () => {
+    for (const published of [false, true]) {
+      const directory = await initializedDirectory();
+      const databasePath = path.join(directory, "daemon.operation.db");
+      const tempPath = path.join(directory, initializationTempName(9999));
+      await copyFile(databasePath, tempPath);
+      if (process.platform !== "win32") await chmod(tempPath, 0o600);
+      await unlink(databasePath);
+      if (published) await link(tempPath, databasePath);
+
+      const lease = await operationLease({ processIdentity: async () => null }).acquire(directory);
+      lease.release();
+      expect(await initializationTemps(directory)).toEqual([]);
+      expect(await lstat(databasePath)).toMatchObject({ isFile: expect.any(Function) });
+    }
+  });
+
+  it("fails closed for unsafe or unbounded database initialization temps", async () => {
+    const unsafeDirectory = await initializedDirectory();
+    await writeFile(path.join(unsafeDirectory, initializationTempName(9999)), "not sqlite", { mode: 0o600 });
+    await expect(operationLease({ processIdentity: async () => null }).acquire(unsafeDirectory))
+      .rejects.toMatchObject({ code: "unsafe_path" });
+
+    const unboundedDirectory = await initializedDirectory();
+    await Promise.all(Array.from({ length: 17 }, async (_, index) => {
+      await copyFile(
+        path.join(unboundedDirectory, "daemon.operation.db"),
+        path.join(unboundedDirectory, initializationTempName(10_000 + index)),
+      );
+    }));
+    await expect(operationLease({ processIdentity: async () => null }).acquire(unboundedDirectory))
+      .rejects.toMatchObject({ code: "unsafe_path" });
   });
 
   it("serializes the same database, allows different directories in parallel, and release is idempotent", async () => {
@@ -180,6 +229,11 @@ describe("daemon operation lease", () => {
       async (directory) => { await chmod(path.join(directory, "daemon.operation.db"), 0o644); },
       async (directory) => { await chmod(path.join(directory, "daemon.operation.owner.json"), 0o644); },
       async (directory) => { await writeFile(path.join(directory, ".daemon.operation.owner.json.tmp"), "unsafe", { mode: 0o644 }); },
+      async (directory) => {
+        const initPath = path.join(directory, initializationTempName(9999));
+        await copyFile(path.join(directory, "daemon.operation.db"), initPath);
+        await chmod(initPath, 0o644);
+      },
       async (directory) => { await writeFile(path.join(directory, "daemon.operation.db-journal"), "unexpected", { mode: 0o600 }); },
     ];
     for (const arrange of cases) {
@@ -196,6 +250,7 @@ describe("daemon operation lease", () => {
       "daemon.operation.db",
       "daemon.operation.owner.json",
       ".daemon.operation.owner.json.tmp",
+      initializationTempName(9999),
       "daemon.operation.db-wal",
     ]) {
       const directory = await initializedDirectory();
@@ -245,6 +300,15 @@ async function writeOwner(directory: string, owner: OperationOwner): Promise<voi
 
 async function readOwner(directory: string): Promise<OperationOwner> {
   return JSON.parse(await readFile(path.join(directory, "daemon.operation.owner.json"), "utf8")) as OperationOwner;
+}
+
+function initializationTempName(pid: number): string {
+  const identity = Buffer.from(START_IDENTITY, "utf8").toString("base64url");
+  return `.daemon.operation.db.init-${pid}-${identity}-01234567-89ab-4def-8123-456789abcdef`;
+}
+
+async function initializationTemps(directory: string): Promise<string[]> {
+  return (await readdir(directory)).filter((name) => name.startsWith(".daemon.operation.db.init-"));
 }
 
 function requireRead(filePath: string): string {

--- a/tests/unit/daemon_operation_lease.test.ts
+++ b/tests/unit/daemon_operation_lease.test.ts
@@ -67,6 +67,30 @@ describe("daemon operation lease", () => {
     expect(await initializationTemps(directory)).toEqual([]);
   });
 
+  it("accepts own published initialization temp already removed by a simultaneous initializer", async () => {
+    const directory = await temporaryDirectory();
+    const databasePublished = deferred();
+    const finishOtherCleanup = deferred();
+    const firstAcquire = operationLease({
+      createToken: () => "first-token",
+      onInitializationPhase: async (phase) => {
+        if (phase !== "database_published") return;
+        databasePublished.resolve();
+        await finishOtherCleanup.promise;
+      },
+    }).acquire(directory);
+
+    await databasePublished.promise;
+    const second = await operationLease({ createToken: () => "second-token" }).acquire(directory);
+    expect(await initializationTemps(directory)).toEqual([]);
+    second.release();
+    finishOtherCleanup.resolve();
+
+    const first = await firstAcquire;
+    expect(await initializationTemps(directory)).toEqual([]);
+    first.release();
+  });
+
   it("recovers protected initialization temps left before and after atomic database publication", async () => {
     for (const published of [false, true]) {
       const directory = await initializedDirectory();
@@ -313,6 +337,12 @@ async function initializationTemps(directory: string): Promise<string[]> {
 
 function requireRead(filePath: string): string {
   return readFileSync(filePath, "utf8");
+}
+
+function deferred() {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
 }
 
 function fakeWindowsSecurityCommand(file: string, args: readonly string[]): string {


### PR DESCRIPTION
## Summary

- serialize start, stop, restart, and status per canonical data directory while allowing independent directories to proceed concurrently
- coordinate independent CLI processes with a protected dedicated SQLite `BEGIN EXCLUSIVE` operation mutex
- retain fail-closed PID/process-start ownership through atomic `held`/`released` metadata without stale pathname stealing
- make database initialization atomic and crash-recoverable, with bounded validated temp/sidecar handling
- bound in-process queues and require cooperative lifecycle dependency ownership through deadlines and reconciliation
- preserve authenticated process identity, foreground safety, CLI results, exit codes, and local-control wire behavior

## Validation

- targeted daemon and real-process suites passed, including simultaneous first initialization and crash windows
- final full `npm test`: 1161 passed, 8 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- final Standards review: no findings
- final Spec review: no findings

Official SDK suites were not run. Fixtures/golden bytes and lifecycle timeout defaults were unchanged.

Closes #178
