### PR TITLE
Lazy-load Stream Execution owner from idle startup

### DIFF
--- a/src/gateway/stream_execution.ts
+++ b/src/gateway/stream_execution.ts
@@ -4,7 +4,6 @@ import {
   type GatewayFailureOrigin,
 } from "./failures.js";
 import type { UpstreamByteStream } from "../copilot/upstream_types.js";
-import { createStreamResponseWriter, type StreamResponseWriter } from "./stream_response.js";
 
 export type StreamExecutionState = "precommit" | "committed" | "terminating" | "completed";
 
@@ -43,13 +42,7 @@ export interface StreamExecutionHandle {
   abort(cause: "shutdown" | "request_abort" | "total_timeout"): Promise<void>;
 }
 
-const executionHandles = new WeakMap<Response, StreamExecutionHandle>();
-
-export function getStreamExecutionHandle(response: Response): StreamExecutionHandle | undefined {
-  return executionHandles.get(response);
-}
-
-export async function createStreamExecutionResponse<T>(input: {
+export interface CreateStreamExecutionResponseInput<T> {
   readonly upstream: UpstreamByteStream;
   readonly emissions: AsyncIterable<StreamExecutionEmission<T>>;
   readonly signal: AbortSignal;
@@ -64,279 +57,35 @@ export async function createStreamExecutionResponse<T>(input: {
     | { readonly kind: "success"; readonly value: T }
     | { readonly kind: "failure"; readonly error: unknown }
   >) => void;
-}): Promise<Response> {
-  const iterator = input.emissions[Symbol.asyncIterator]();
-  let state: StreamExecutionState = "precommit";
-  let cause: StreamExecutionTerminalCause | undefined;
-  const resources: {
-    writer?: StreamResponseWriter;
-    producer?: Promise<void>;
-  } = {};
-  let resolveCompletion: () => void = () => undefined;
-  const completion = new Promise<void>((resolve) => {
-    resolveCompletion = resolve;
-  });
-  let barrier: Promise<void> | undefined;
-  let deliveryAdapterClaimed = false;
-  let deliveryFinalizer: (() => void) | undefined;
-  let deliveryFinalized = false;
-  let deliverySettled = false;
-  let resolveDelivery: () => void = () => undefined;
-  const deliverySettlement = new Promise<void>((resolve) => {
-    resolveDelivery = resolve;
-  });
-  let firstDelivered = false;
-  let resolveFirstDelivery: () => void = () => undefined;
-  const firstDelivery = new Promise<void>((resolve) => {
-    resolveFirstDelivery = resolve;
-  });
-  const settleDelivery = (): void => {
-    if (!deliverySettled) {
-      deliverySettled = true;
-      resolveDelivery();
-    }
-  };
-  const markDelivered = (): void => {
-    if (!firstDelivered) {
-      firstDelivered = true;
-      if (state === "precommit") {
-        state = "committed";
-      }
-      resolveFirstDelivery();
-    }
-  };
-  const finalizeDelivery = (): void => {
-    if (deliveryFinalized || deliveryFinalizer === undefined) {
-      return;
-    }
-    deliveryFinalized = true;
+}
+
+const executionHandles = new WeakMap<Response, StreamExecutionHandle>();
+
+export function getStreamExecutionHandle(response: Response): StreamExecutionHandle | undefined {
+  return executionHandles.get(response);
+}
+
+export async function createStreamExecutionResponse<T>(
+  input: CreateStreamExecutionResponseInput<T>,
+): Promise<Response> {
+  const owner = await (async () => {
     try {
-      deliveryFinalizer();
-    } catch {
-      // Host finalization cannot prevent completion or listener cleanup.
-    }
-  };
-
-  const observe = (result: Parameters<typeof input.onTerminal>[0]): void => {
-    try {
-      input.onTerminal(result);
-    } catch {
-      // Observability cannot alter stream delivery or resource cleanup.
-    }
-  };
-
-  const finish = async (
-    terminalCause: StreamExecutionTerminalCause,
-    result: Parameters<typeof input.onTerminal>[0],
-    writerMode: "close" | "abort" = terminalCause === "semantic_success" ? "close" : "abort",
-    fromProducer = false,
-  ): Promise<void> => {
-    if (barrier !== undefined) {
-      if (!fromProducer) {
-        await barrier;
-      }
-      return;
-    }
-    cause = terminalCause;
-    state = "terminating";
-    barrier = (async () => {
-      try {
-        observe(result);
-        if (writerMode === "abort") {
-          const error = result.kind === "failure"
-            ? (input.presentPostCommitFailure?.(result.error) ?? result.error)
-            : undefined;
-          resources.writer?.abort(error);
-        }
-        await boundedCleanup(
-          Promise.resolve().then(async () => await input.upstream.cancel()),
-          input.cleanupTimeoutMs ?? 1_000,
-        );
-        if (iterator.return !== undefined) {
-          await boundedCleanup(
-            Promise.resolve().then(async () => await iterator.return!()),
-            input.cleanupTimeoutMs ?? 1_000,
-          );
-        }
-        if (!fromProducer && resources.producer !== undefined) {
-          await boundedCleanup(resources.producer, input.cleanupTimeoutMs ?? 1_000);
-        }
-        if (writerMode === "close") {
-          resources.writer?.close();
-        }
-        if (!deliveryAdapterClaimed) {
-          settleDelivery();
-        }
-        await deliverySettlement;
-        finalizeDelivery();
-      } finally {
-        input.signal.removeEventListener("abort", onRequestAbort);
-        input.deliverySignal.removeEventListener("abort", onDeliveryAbort);
-        state = "completed";
-        resolveCompletion();
-      }
-    })();
-    await barrier;
-  };
-
-  const signalCause = (): "request_abort" | "total_timeout" => {
-    const reason = input.signal.reason;
-    return reason instanceof GatewayFailureError && reason.failure.kind === "upstream_timeout"
-      ? "total_timeout"
-      : "request_abort";
-  };
-  const failureCause = (error: unknown, committed: boolean): StreamExecutionTerminalCause => {
-    if (error instanceof GatewayFailureError && error.failure.kind === "upstream_timeout") {
-      if (input.signal.aborted) {
-        return signalCause();
-      }
-      return committed ? "idle_timeout" : "first_byte_timeout";
-    }
-    return committed ? "postcommit_failure" : "precommit_failure";
-  };
-  const abortFailure = (): GatewayFailureError => new GatewayFailureError(failureFromSignal(input.signal, {
-    source: "parser",
-    phase: "stream",
-  }));
-  const onRequestAbort = (): void => {
-    const error = abortFailure();
-    void finish(signalCause(), { kind: "failure", error });
-  };
-  const onDeliveryAbort = (): void => {
-    const error = new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
-    void finish("client_cancel", { kind: "failure", error });
-  };
-
-  input.signal.addEventListener("abort", onRequestAbort, { once: true });
-  input.deliverySignal.addEventListener("abort", onDeliveryAbort, { once: true });
-  if (input.signal.aborted) {
-    onRequestAbort();
-    await completion;
-    throw abortFailure();
-  }
-  if (input.deliverySignal.aborted) {
-    onDeliveryAbort();
-    await completion;
-    throw new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
-  }
-
-  let firstWire: Uint8Array;
-  try {
-    const first = input.firstEmissionTimeoutMs === undefined
-      ? await iterator.next()
-      : await nextWithDeadline(
-        iterator,
-        input.firstEmissionTimeoutMs,
-        input.signal,
-        { source: "parser", phase: "stream" },
-      );
-    if (first.done === true || first.value.kind === "terminal") {
-      throw new GatewayFailureError({
-        kind: "upstream_stream_truncated",
-        source: "parser",
-        phase: "stream",
-      });
-    }
-    firstWire = first.value.bytes;
-  } catch (error: unknown) {
-    const failure = input.normalizeFailure(error);
-    await finish(failureCause(failure, false), { kind: "failure", error: failure });
-    throw failure;
-  }
-
-  resources.writer = createStreamResponseWriter({
-    ...(input.status === undefined ? {} : { status: input.status }),
-    ...(input.headers === undefined ? {} : { headers: input.headers }),
-    onCommit: () => {
-      if (!deliveryAdapterClaimed) {
-        markDelivered();
-      }
-    },
-    onCancel: async () => {
-      if (!deliveryAdapterClaimed) {
-        settleDelivery();
-      }
-      const error = new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
-      await finish("client_cancel", { kind: "failure", error });
-    },
-  });
-  const response = resources.writer.response;
-  const handle: StreamExecutionHandle = {
-    get state() {
-      return state;
-    },
-    get cause() {
-      return cause;
-    },
-    completion,
-    claimDeliveryAdapter: (finalize) => {
-      if (deliveryAdapterClaimed) {
-        throw new Error("stream delivery adapter already claimed");
-      }
-      deliveryAdapterClaimed = true;
-      deliveryFinalizer = finalize;
-      if (state === "terminating") {
-        settleDelivery();
-      } else if (state === "completed") {
-        finalizeDelivery();
-      }
-      return {
-        markDelivered,
-        settle: settleDelivery,
-      };
-    },
-    abort: async (terminalCause) => {
-      const error = terminalCause === "total_timeout"
-        ? new GatewayFailureError({ kind: "upstream_timeout", source: "gateway", phase: "stream" })
-        : new GatewayFailureError({ kind: "aborted", source: "gateway", phase: "stream" });
-      await finish(terminalCause, { kind: "failure", error });
-    },
-  };
-  executionHandles.set(response, handle);
-
-  const produce = async (): Promise<void> => {
-    try {
-      if (!await resources.writer!.enqueue(firstWire)) {
-        return;
-      }
-      await firstDelivery;
-      if (barrier !== undefined) {
-        return;
-      }
-      for (;;) {
-        const next = await iterator.next();
-        if (next.done === true) {
-          throw new GatewayFailureError({
-            kind: "upstream_stream_truncated",
-            source: "parser",
-            phase: "stream",
-          });
-        }
-        if (next.value.kind === "wire") {
-          if (!await resources.writer!.enqueue(next.value.bytes)) {
-            return;
-          }
-          continue;
-        }
-        await finish(
-          next.value.outcome.kind === "success" ? "semantic_success" : "postcommit_failure",
-          next.value.outcome,
-          next.value.writerMode,
-          true,
-        );
-        return;
-      }
+      return await import("./stream_execution_owner.js");
     } catch (error: unknown) {
-      const failure = input.normalizeFailure(error);
-      await finish(failureCause(failure, resources.writer!.committed), {
-        kind: "failure",
-        error: failure,
-      }, "abort", true);
+      await boundedCleanup(
+        Promise.resolve().then(async () => await input.upstream.cancel()),
+        input.cleanupTimeoutMs ?? 1_000,
+      );
+      throw error;
     }
-  };
-  resources.producer = produce();
-  void resources.producer.catch(() => undefined);
-  return response;
+  })();
+
+  const result = await owner.createStreamExecutionResponseOwner(input, {
+    boundedCleanup,
+    nextWithDeadline,
+  });
+  executionHandles.set(result.response, result.handle);
+  return result.response;
 }
 
 export async function nextWithDeadline<T>(

--- a/src/gateway/stream_execution_owner.ts
+++ b/src/gateway/stream_execution_owner.ts
@@ -1,0 +1,299 @@
+import {
+  failureFromSignal,
+  GatewayFailureError,
+  type GatewayFailureOrigin,
+} from "./failures.js";
+import { createStreamResponseWriter, type StreamResponseWriter } from "./stream_response.js";
+import type {
+  CreateStreamExecutionResponseInput,
+  StreamExecutionHandle,
+  StreamExecutionState,
+  StreamExecutionTerminalCause,
+} from "./stream_execution.js";
+
+interface StreamExecutionOwnerDependencies {
+  boundedCleanup(operation: Promise<unknown>, timeoutMs?: number): Promise<void>;
+  nextWithDeadline<T>(
+    iterator: AsyncIterator<T>,
+    timeoutMs: number,
+    signal: AbortSignal,
+    origin: Readonly<GatewayFailureOrigin>,
+  ): Promise<IteratorResult<T>>;
+}
+
+export async function createStreamExecutionResponseOwner<T>(
+  input: CreateStreamExecutionResponseInput<T>,
+  dependencies: StreamExecutionOwnerDependencies,
+): Promise<Readonly<{ response: Response; handle: StreamExecutionHandle }>> {
+  const iterator = input.emissions[Symbol.asyncIterator]();
+  let state: StreamExecutionState = "precommit";
+  let cause: StreamExecutionTerminalCause | undefined;
+  const resources: {
+    writer?: StreamResponseWriter;
+    producer?: Promise<void>;
+  } = {};
+  let resolveCompletion: () => void = () => undefined;
+  const completion = new Promise<void>((resolve) => {
+    resolveCompletion = resolve;
+  });
+  let barrier: Promise<void> | undefined;
+  let deliveryAdapterClaimed = false;
+  let deliveryFinalizer: (() => void) | undefined;
+  let deliveryFinalized = false;
+  let deliverySettled = false;
+  let resolveDelivery: () => void = () => undefined;
+  const deliverySettlement = new Promise<void>((resolve) => {
+    resolveDelivery = resolve;
+  });
+  let firstDelivered = false;
+  let resolveFirstDelivery: () => void = () => undefined;
+  const firstDelivery = new Promise<void>((resolve) => {
+    resolveFirstDelivery = resolve;
+  });
+  const settleDelivery = (): void => {
+    if (!deliverySettled) {
+      deliverySettled = true;
+      resolveDelivery();
+    }
+  };
+  const markDelivered = (): void => {
+    if (!firstDelivered) {
+      firstDelivered = true;
+      if (state === "precommit") {
+        state = "committed";
+      }
+      resolveFirstDelivery();
+    }
+  };
+  const finalizeDelivery = (): void => {
+    if (deliveryFinalized || deliveryFinalizer === undefined) {
+      return;
+    }
+    deliveryFinalized = true;
+    try {
+      deliveryFinalizer();
+    } catch {
+      // Host finalization cannot prevent completion or listener cleanup.
+    }
+  };
+
+  const observe = (result: Parameters<typeof input.onTerminal>[0]): void => {
+    try {
+      input.onTerminal(result);
+    } catch {
+      // Observability cannot alter stream delivery or resource cleanup.
+    }
+  };
+
+  const finish = async (
+    terminalCause: StreamExecutionTerminalCause,
+    result: Parameters<typeof input.onTerminal>[0],
+    writerMode: "close" | "abort" = terminalCause === "semantic_success" ? "close" : "abort",
+    fromProducer = false,
+  ): Promise<void> => {
+    if (barrier !== undefined) {
+      if (!fromProducer) {
+        await barrier;
+      }
+      return;
+    }
+    cause = terminalCause;
+    state = "terminating";
+    barrier = (async () => {
+      try {
+        observe(result);
+        if (writerMode === "abort") {
+          const error = result.kind === "failure"
+            ? (input.presentPostCommitFailure?.(result.error) ?? result.error)
+            : undefined;
+          resources.writer?.abort(error);
+        }
+        await dependencies.boundedCleanup(
+          Promise.resolve().then(async () => await input.upstream.cancel()),
+          input.cleanupTimeoutMs ?? 1_000,
+        );
+        if (iterator.return !== undefined) {
+          await dependencies.boundedCleanup(
+            Promise.resolve().then(async () => await iterator.return!()),
+            input.cleanupTimeoutMs ?? 1_000,
+          );
+        }
+        if (!fromProducer && resources.producer !== undefined) {
+          await dependencies.boundedCleanup(resources.producer, input.cleanupTimeoutMs ?? 1_000);
+        }
+        if (writerMode === "close") {
+          resources.writer?.close();
+        }
+        if (!deliveryAdapterClaimed) {
+          settleDelivery();
+        }
+        await deliverySettlement;
+        finalizeDelivery();
+      } finally {
+        input.signal.removeEventListener("abort", onRequestAbort);
+        input.deliverySignal.removeEventListener("abort", onDeliveryAbort);
+        state = "completed";
+        resolveCompletion();
+      }
+    })();
+    await barrier;
+  };
+
+  const signalCause = (): "request_abort" | "total_timeout" => {
+    const reason = input.signal.reason;
+    return reason instanceof GatewayFailureError && reason.failure.kind === "upstream_timeout"
+      ? "total_timeout"
+      : "request_abort";
+  };
+  const failureCause = (error: unknown, committed: boolean): StreamExecutionTerminalCause => {
+    if (error instanceof GatewayFailureError && error.failure.kind === "upstream_timeout") {
+      if (input.signal.aborted) {
+        return signalCause();
+      }
+      return committed ? "idle_timeout" : "first_byte_timeout";
+    }
+    return committed ? "postcommit_failure" : "precommit_failure";
+  };
+  const abortFailure = (): GatewayFailureError => new GatewayFailureError(failureFromSignal(input.signal, {
+    source: "parser",
+    phase: "stream",
+  }));
+  const onRequestAbort = (): void => {
+    const error = abortFailure();
+    void finish(signalCause(), { kind: "failure", error });
+  };
+  const onDeliveryAbort = (): void => {
+    const error = new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
+    void finish("client_cancel", { kind: "failure", error });
+  };
+
+  input.signal.addEventListener("abort", onRequestAbort, { once: true });
+  input.deliverySignal.addEventListener("abort", onDeliveryAbort, { once: true });
+  if (input.signal.aborted) {
+    onRequestAbort();
+    await completion;
+    throw abortFailure();
+  }
+  if (input.deliverySignal.aborted) {
+    onDeliveryAbort();
+    await completion;
+    throw new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
+  }
+
+  let firstWire: Uint8Array;
+  try {
+    const first = input.firstEmissionTimeoutMs === undefined
+      ? await iterator.next()
+      : await dependencies.nextWithDeadline(
+        iterator,
+        input.firstEmissionTimeoutMs,
+        input.signal,
+        { source: "parser", phase: "stream" },
+      );
+    if (first.done === true || first.value.kind === "terminal") {
+      throw new GatewayFailureError({
+        kind: "upstream_stream_truncated",
+        source: "parser",
+        phase: "stream",
+      });
+    }
+    firstWire = first.value.bytes;
+  } catch (error: unknown) {
+    const failure = input.normalizeFailure(error);
+    await finish(failureCause(failure, false), { kind: "failure", error: failure });
+    throw failure;
+  }
+
+  resources.writer = createStreamResponseWriter({
+    ...(input.status === undefined ? {} : { status: input.status }),
+    ...(input.headers === undefined ? {} : { headers: input.headers }),
+    onCommit: () => {
+      if (!deliveryAdapterClaimed) {
+        markDelivered();
+      }
+    },
+    onCancel: async () => {
+      if (!deliveryAdapterClaimed) {
+        settleDelivery();
+      }
+      const error = new GatewayFailureError({ kind: "aborted", source: "request", phase: "stream" });
+      await finish("client_cancel", { kind: "failure", error });
+    },
+  });
+  const response = resources.writer.response;
+  const handle: StreamExecutionHandle = {
+    get state() {
+      return state;
+    },
+    get cause() {
+      return cause;
+    },
+    completion,
+    claimDeliveryAdapter: (finalize) => {
+      if (deliveryAdapterClaimed) {
+        throw new Error("stream delivery adapter already claimed");
+      }
+      deliveryAdapterClaimed = true;
+      deliveryFinalizer = finalize;
+      if (state === "terminating") {
+        settleDelivery();
+      } else if (state === "completed") {
+        finalizeDelivery();
+      }
+      return {
+        markDelivered,
+        settle: settleDelivery,
+      };
+    },
+    abort: async (terminalCause) => {
+      const error = terminalCause === "total_timeout"
+        ? new GatewayFailureError({ kind: "upstream_timeout", source: "gateway", phase: "stream" })
+        : new GatewayFailureError({ kind: "aborted", source: "gateway", phase: "stream" });
+      await finish(terminalCause, { kind: "failure", error });
+    },
+  };
+
+  const produce = async (): Promise<void> => {
+    try {
+      if (!await resources.writer!.enqueue(firstWire)) {
+        return;
+      }
+      await firstDelivery;
+      if (barrier !== undefined) {
+        return;
+      }
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done === true) {
+          throw new GatewayFailureError({
+            kind: "upstream_stream_truncated",
+            source: "parser",
+            phase: "stream",
+          });
+        }
+        if (next.value.kind === "wire") {
+          if (!await resources.writer!.enqueue(next.value.bytes)) {
+            return;
+          }
+          continue;
+        }
+        await finish(
+          next.value.outcome.kind === "success" ? "semantic_success" : "postcommit_failure",
+          next.value.outcome,
+          next.value.writerMode,
+          true,
+        );
+        return;
+      }
+    } catch (error: unknown) {
+      const failure = input.normalizeFailure(error);
+      await finish(failureCause(failure, resources.writer!.committed), {
+        kind: "failure",
+        error: failure,
+      }, "abort", true);
+    }
+  };
+  resources.producer = produce();
+  void resources.producer.catch(() => undefined);
+  return { response, handle };
+}

--- a/tests/fixtures/stream-execution-loader/loader.mjs
+++ b/tests/fixtures/stream-execution-loader/loader.mjs
@@ -1,0 +1,44 @@
+import { writeFileSync } from "node:fs";
+
+let configuration;
+let ownerRequestedByFacade = false;
+
+export function initialize(data) {
+  configuration = data;
+}
+
+export async function resolve(specifier, context, nextResolve) {
+  const resolved = await nextResolve(specifier, context);
+  if (specifier === "./stream_execution_owner.js"
+    && context.parentURL === configuration.facadeUrl
+    && resolved.url === configuration.ownerUrl) {
+    ownerRequestedByFacade = true;
+  }
+  return resolved;
+}
+
+export async function load(url, context, nextLoad) {
+  const loaded = await nextLoad(url, context);
+  if (!ownerRequestedByFacade || url !== configuration.ownerUrl) {
+    return loaded;
+  }
+
+  writeFileSync(configuration.blockedPath, "", { flag: "wx" });
+  if (configuration.mode === "reject") {
+    throw new Error(configuration.privateMarker);
+  }
+
+  const source = typeof loaded.source === "string"
+    ? loaded.source
+    : new TextDecoder().decode(loaded.source);
+  const gate = JSON.stringify(configuration.releasePath);
+  const prefix = [
+    'import { existsSync as __ghcgOwnerGateExists } from "node:fs";',
+    "const __ghcgOwnerGateDeadline = Date.now() + 10_000;",
+    `while (!__ghcgOwnerGateExists(${gate})) {`,
+    "  if (Date.now() >= __ghcgOwnerGateDeadline) throw new Error(\"stream owner loader gate timed out\");",
+    "  await new Promise((resolve) => setImmediate(resolve));",
+    "}",
+  ].join("\n");
+  return { ...loaded, source: `${prefix}\n${source}` };
+}

--- a/tests/fixtures/stream-execution-loader/register.mjs
+++ b/tests/fixtures/stream-execution-loader/register.mjs
@@ -1,0 +1,25 @@
+import { register } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const gatePath = process.env.GHCG_STREAM_OWNER_GATE_PATH;
+const outputRoot = process.env.GHCG_STREAM_OWNER_OUTPUT_ROOT;
+const mode = process.env.GHCG_STREAM_OWNER_LOADER_MODE;
+const privateMarker = process.env.GHCG_STREAM_OWNER_PRIVATE_MARKER;
+if (gatePath === undefined
+  || outputRoot === undefined
+  || !["delay", "reject"].includes(mode)
+  || privateMarker === undefined) {
+  throw new Error("invalid stream owner loader fixture configuration");
+}
+
+register("./loader.mjs", import.meta.url, {
+  data: {
+    blockedPath: `${gatePath}.blocked`,
+    facadeUrl: pathToFileURL(path.join(outputRoot, "src/gateway/stream_execution.js")).href,
+    mode,
+    ownerUrl: pathToFileURL(path.join(outputRoot, "src/gateway/stream_execution_owner.js")).href,
+    privateMarker,
+    releasePath: `${gatePath}.release`,
+  },
+});

--- a/tests/fixtures/stream-execution-loader/runner.mjs
+++ b/tests/fixtures/stream-execution-loader/runner.mjs
@@ -1,0 +1,195 @@
+import { existsSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const mode = process.argv[2];
+const outputRoot = process.argv[3];
+const privateMarker = process.env.GHCG_STREAM_OWNER_PRIVATE_MARKER;
+const gatePath = process.env.GHCG_STREAM_OWNER_GATE_PATH;
+if (!["delay", "reject"].includes(mode)
+  || outputRoot === undefined
+  || privateMarker === undefined
+  || gatePath === undefined) {
+  throw new Error("invalid stream owner runner fixture configuration");
+}
+
+const importOutput = async (relativePath) => await import(pathToFileURL(
+  path.join(outputRoot, relativePath),
+).href);
+const [{ defaultRuntimeConfigSnapshot }, { parseStartupConfig }, gatewayModule, streamModule] = await Promise.all([
+  importOutput("src/config/schema.js"),
+  importOutput("src/config/startup_config.js"),
+  importOutput("src/gateway/create_gateway.js"),
+  importOutput("src/gateway/stream_execution.js"),
+]);
+
+let detachedRejections = 0;
+process.on("unhandledRejection", () => {
+  detachedRejections += 1;
+});
+
+const waitForFile = async (filePath) => {
+  const deadline = Date.now() + 10_000;
+  while (!existsSync(filePath)) {
+    if (Date.now() >= deadline) {
+      throw new Error("stream owner runner gate timed out");
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+};
+const runtime = defaultRuntimeConfigSnapshot();
+runtime.admission.activeMax = 1;
+runtime.admission.queueMax = 0;
+runtime.timeouts.totalMs = 123;
+let releaseTotalTimeout;
+let signalAbortedResolve;
+const signalAborted = new Promise((resolve) => {
+  signalAbortedResolve = resolve;
+});
+let totalTimeoutArmedResolve;
+const totalTimeoutArmed = new Promise((resolve) => {
+  totalTimeoutArmedResolve = resolve;
+});
+const counts = {
+  cancel: 0,
+  iteratorCreated: 0,
+  iteratorNext: 0,
+  iteratorReturn: 0,
+  terminal: 0,
+};
+let ownerObservedAlreadyAborted = false;
+let routeCalls = 0;
+const route = {
+  method: "POST",
+  path: "/v1/loader-lifecycle",
+  admission: "inference",
+  body: "none",
+  presentFailure: (failure) => new Response(JSON.stringify({ kind: failure.kind }), {
+    status: failure.kind === "upstream_timeout" ? 504 : 500,
+    headers: { "content-type": "application/json" },
+  }),
+  endpoint: async (_request, scope) => {
+    routeCalls += 1;
+    if (routeCalls > 1) {
+      return new Response("next");
+    }
+    if (scope.signal.aborted) {
+      signalAbortedResolve();
+    } else {
+      scope.signal.addEventListener("abort", signalAbortedResolve, { once: true });
+    }
+    return await streamModule.createStreamExecutionResponse({
+      upstream: {
+        status: 200,
+        headers: new Headers(),
+        bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+        cancel: async () => { counts.cancel += 1; },
+      },
+      emissions: {
+        [Symbol.asyncIterator]() {
+          counts.iteratorCreated += 1;
+          ownerObservedAlreadyAborted = scope.signal.aborted;
+          return {
+            next: async () => {
+              counts.iteratorNext += 1;
+              return await new Promise(() => undefined);
+            },
+            return: async () => {
+              counts.iteratorReturn += 1;
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      },
+      signal: scope.signal,
+      deliverySignal: scope.deliverySignal,
+      normalizeFailure: (error) => error,
+      onTerminal: () => { counts.terminal += 1; },
+    });
+  },
+};
+const gateway = await gatewayModule.createGateway({
+  startup: parseStartupConfig([], {}, { homedir: process.cwd() }),
+  runtime,
+}, [route], {
+  admin: {
+    handle: (_request, context) => Promise.resolve(new Response(
+      JSON.stringify(context.activity.snapshot()),
+    )),
+    mintBootstrap: () => ({ kind: "closed" }),
+    close: () => undefined,
+  },
+  delay: async (ms, signal) => {
+    if (ms !== runtime.timeouts.totalMs) {
+      throw new Error("unexpected fixture delay");
+    }
+    totalTimeoutArmedResolve();
+    await new Promise((resolve, reject) => {
+      const onAbort = () => reject(signal.reason);
+      releaseTotalTimeout = () => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  },
+});
+
+let response;
+let responseSettled = false;
+let settledBeforeRelease = false;
+let settledAfterAbort = false;
+let loaderInterceptions = 0;
+try {
+  const pendingResponse = gateway.fetch(new Request(
+    `http://127.0.0.1:31400/v1/loader-lifecycle?private=${encodeURIComponent(privateMarker)}`,
+    { method: "POST", headers: { "x-private-fixture": privateMarker } },
+  ));
+  void pendingResponse.then(
+    () => { responseSettled = true; },
+    () => { responseSettled = true; },
+  );
+  await waitForFile(`${gatePath}.blocked`);
+  loaderInterceptions += 1;
+  settledBeforeRelease = responseSettled;
+
+  if (mode === "delay") {
+    await totalTimeoutArmed;
+    releaseTotalTimeout();
+    await signalAborted;
+    settledAfterAbort = responseSettled;
+    writeFileSync(`${gatePath}.release`, "", { flag: "wx" });
+  }
+
+  response = await pendingResponse;
+  const responseBody = await response.text();
+  const handlePresent = streamModule.getStreamExecutionHandle(response) !== undefined;
+  const nextResponse = await gateway.fetch(new Request(
+    "http://127.0.0.1:31400/v1/loader-lifecycle",
+    { method: "POST" },
+  ));
+  const nextBody = await nextResponse.text();
+  const activityResponse = await gateway.fetch(new Request("http://127.0.0.1:31400/admin/api/v1/activity"));
+  const activity = await activityResponse.json();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  process.stdout.write(`${JSON.stringify({
+    activity,
+    counts,
+    detachedRejections,
+    handlePresent,
+    loaderInterceptions,
+    nextBody,
+    nextStatus: nextResponse.status,
+    ownerObservedAlreadyAborted,
+    responseBody,
+    responseStatus: response.status,
+    settledAfterAbort,
+    settledBeforeRelease,
+  })}\n`);
+} finally {
+  if (mode === "delay") {
+    writeFileSync(`${gatePath}.release`, "", { flag: "a" });
+  }
+  await gateway.close();
+}

--- a/tests/integration/gateway_stream_lifecycle.test.ts
+++ b/tests/integration/gateway_stream_lifecycle.test.ts
@@ -43,6 +43,49 @@ describe("stream writer", () => {
 });
 
 describe("Stream Execution owner", () => {
+  it("owns first and subsequent responses independently through the public seam", async () => {
+    const cleanupCounts = [0, 0];
+    const terminalCounts = [0, 0];
+    const responses: Response[] = [];
+
+    for (const index of [0, 1]) {
+      responses.push(await createStreamExecutionResponse({
+        upstream: {
+          status: 200,
+          headers: new Headers(),
+          bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+          cancel: async () => { cleanupCounts[index] = (cleanupCounts[index] ?? 0) + 1; },
+        },
+        emissions: {
+          async *[Symbol.asyncIterator]() {
+            yield { kind: "wire", bytes: new TextEncoder().encode(`response-${index}`) } as const;
+            yield {
+              kind: "terminal",
+              outcome: { kind: "success", value: `result-${index}` },
+              writerMode: "close",
+            } as const;
+          },
+        },
+        signal: new AbortController().signal,
+        deliverySignal: new AbortController().signal,
+        onTerminal: () => { terminalCounts[index] = (terminalCounts[index] ?? 0) + 1; },
+        normalizeFailure: (error) => error,
+      }));
+    }
+
+    const handles = responses.map((response) => getStreamExecutionHandle(response));
+    expect(handles[0]).toBeDefined();
+    expect(handles[1]).toBeDefined();
+    expect(handles[0]).not.toBe(handles[1]);
+    expect(await Promise.all(responses.map(async (response) => await response.text())))
+      .toEqual(["response-0", "response-1"]);
+    await Promise.all(handles.map(async (handle) => await handle?.completion));
+    expect(handles.map((handle) => handle?.cause)).toEqual(["semantic_success", "semantic_success"]);
+    expect(handles.map((handle) => handle?.state)).toEqual(["completed", "completed"]);
+    expect(cleanupCounts).toEqual([1, 1]);
+    expect(terminalCounts).toEqual([1, 1]);
+  });
+
   it("does not produce past the host claim window without real body demand", async () => {
     let nextCalls = 0;
     let terminalCalls = 0;
@@ -474,6 +517,95 @@ describe("Stream Execution owner", () => {
 });
 
 describe("stream route lifecycle", () => {
+  it("presents a total timeout during first emission and releases owned resources", async () => {
+    const runtime = defaultRuntimeConfigSnapshot();
+    runtime.admission.activeMax = 1;
+    runtime.admission.queueMax = 0;
+    runtime.timeouts.totalMs = 123;
+    let releaseTotalTimeout: (() => void) | undefined;
+    let firstEmissionStarted!: () => void;
+    const emissionStarted = new Promise<void>((resolve) => { firstEmissionStarted = resolve; });
+    let releaseFirstEmission: ((value: IteratorResult<StreamExecutionEmission<string>>) => void) | undefined;
+    const firstEmission = new Promise<IteratorResult<StreamExecutionEmission<string>>>((resolve) => {
+      releaseFirstEmission = resolve;
+    });
+    const counts = { cancel: 0, returned: 0, terminal: 0 };
+    let requestCount = 0;
+    const route: RouteRegistration = {
+      method: "POST",
+      path: "/v1/total-timeout",
+      admission: "inference",
+      body: "none",
+      presentFailure: (failure) => new Response(JSON.stringify({ kind: failure.kind }), {
+        status: failure.kind === "upstream_timeout" ? 504 : 400,
+      }),
+      endpoint: async (_request, scope) => {
+        if (requestCount++ > 0) {
+          return new Response("next");
+        }
+        return await createStreamExecutionResponse({
+          upstream: {
+            status: 200,
+            headers: new Headers(),
+            bytes: { async *[Symbol.asyncIterator]() { yield new Uint8Array(); } },
+            cancel: async () => { counts.cancel += 1; },
+          },
+          emissions: {
+            [Symbol.asyncIterator](): AsyncIterator<StreamExecutionEmission<string>> {
+              return {
+                next: async () => {
+                  firstEmissionStarted();
+                  return await firstEmission;
+                },
+                return: async () => {
+                  counts.returned += 1;
+                  releaseFirstEmission?.({ done: true, value: undefined });
+                  return { done: true, value: undefined };
+                },
+              };
+            },
+          },
+          signal: scope.signal,
+          deliverySignal: scope.deliverySignal,
+          onTerminal: () => { counts.terminal += 1; },
+          normalizeFailure: (error) => error,
+        });
+      },
+    };
+    const gw = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: "Q:\\tmp-ghc-gateway" }),
+      runtime,
+    }, [route], {
+      delay: async (ms, signal) => {
+        if (ms !== runtime.timeouts.totalMs) {
+          return await defaultDelay(ms, signal);
+        }
+        await new Promise<void>((resolve, reject) => {
+          releaseTotalTimeout = resolve;
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      },
+    });
+
+    try {
+      const pending = gw.fetch(new Request("http://127.0.0.1:31400/v1/total-timeout", { method: "POST" }));
+      await emissionStarted;
+      expect(releaseTotalTimeout).toBeDefined();
+      releaseTotalTimeout?.();
+      const response = await pending;
+      expect(response.status).toBe(504);
+      expect(JSON.parse(await response.text())).toEqual({ kind: "upstream_timeout" });
+      expect(counts).toEqual({ cancel: 1, returned: 1, terminal: 1 });
+
+      const next = await gw.fetch(new Request("http://127.0.0.1:31400/v1/total-timeout", { method: "POST" }));
+      expect(next.status).toBe(200);
+      expect(await next.text()).toBe("next");
+    } finally {
+      releaseFirstEmission?.({ done: true, value: undefined });
+      await gw.close();
+    }
+  });
+
   it("does not commit headers-only construction as success body", async () => {
     const route: RouteRegistration = {
       method: "POST",

--- a/tests/integration/stream_execution_dynamic_import.test.ts
+++ b/tests/integration/stream_execution_dynamic_import.test.ts
@@ -1,0 +1,142 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const fixtureDirectory = path.resolve("tests/fixtures/stream-execution-loader");
+const privateMarker = "private-request-and-loader-content";
+let outputRoot = "";
+
+interface FixtureResult {
+  readonly activity: {
+    readonly activeRequests: number;
+    readonly activeStreams: number;
+    readonly queuedRequests: number;
+  };
+  readonly counts: {
+    readonly cancel: number;
+    readonly iteratorCreated: number;
+    readonly iteratorNext: number;
+    readonly iteratorReturn: number;
+    readonly terminal: number;
+  };
+  readonly detachedRejections: number;
+  readonly handlePresent: boolean;
+  readonly loaderInterceptions: number;
+  readonly nextBody: string;
+  readonly nextStatus: number;
+  readonly ownerObservedAlreadyAborted: boolean;
+  readonly responseBody: string;
+  readonly responseStatus: number;
+  readonly settledAfterAbort: boolean;
+  readonly settledBeforeRelease: boolean;
+}
+
+async function runFixture(mode: "delay" | "reject"): Promise<FixtureResult> {
+  const registerUrl = pathToFileURL(path.join(fixtureDirectory, "register.mjs")).href;
+  const runnerPath = path.join(fixtureDirectory, "runner.mjs");
+  const result = await execFileAsync(process.execPath, [
+    "--import",
+    registerUrl,
+    runnerPath,
+    mode,
+    outputRoot,
+  ], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GHCG_STREAM_OWNER_GATE_PATH: path.join(outputRoot, `owner-loader-${mode}`),
+      GHCG_STREAM_OWNER_LOADER_MODE: mode,
+      GHCG_STREAM_OWNER_OUTPUT_ROOT: outputRoot,
+      GHCG_STREAM_OWNER_PRIVATE_MARKER: privateMarker,
+      NODE_OPTIONS: "",
+    },
+    timeout: 30_000,
+    windowsHide: true,
+  });
+
+  expect(result.stderr).toBe("");
+  expect(result.stdout).not.toContain(privateMarker);
+  return JSON.parse(result.stdout) as FixtureResult;
+}
+
+describe("Stream Execution dynamic import lifecycle", () => {
+  beforeAll(async () => {
+    await mkdir(path.resolve("artifacts"), { recursive: true });
+    outputRoot = await mkdtemp(path.resolve("artifacts/stream-owner-loader-"));
+    await execFileAsync(process.execPath, [
+      path.resolve("node_modules/typescript/bin/tsc"),
+      "-p",
+      path.resolve("tsconfig.json"),
+      "--outDir",
+      outputRoot,
+      "--declaration",
+      "false",
+      "--sourceMap",
+      "false",
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      timeout: 30_000,
+      windowsHide: true,
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (outputRoot !== "") {
+      await rm(outputRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("bounds cleanup and sanitizes output when the real owner import rejects", async () => {
+    const result = await runFixture("reject");
+
+    expect(result).toMatchObject({
+      activity: { activeRequests: 0, activeStreams: 0, queuedRequests: 0 },
+      counts: {
+        cancel: 1,
+        iteratorCreated: 0,
+        iteratorNext: 0,
+        iteratorReturn: 0,
+        terminal: 0,
+      },
+      detachedRejections: 0,
+      handlePresent: false,
+      loaderInterceptions: 1,
+      nextBody: "next",
+      nextStatus: 200,
+      ownerObservedAlreadyAborted: false,
+      responseBody: "{\"kind\":\"internal\"}",
+      responseStatus: 500,
+    });
+  });
+
+  it("keeps the facade awaited until a timed-out request enters the real owner", async () => {
+    const result = await runFixture("delay");
+
+    expect(result).toEqual({
+      activity: { activeRequests: 0, activeStreams: 0, queuedRequests: 0 },
+      counts: {
+        cancel: 1,
+        iteratorCreated: 1,
+        iteratorNext: 0,
+        iteratorReturn: 1,
+        terminal: 1,
+      },
+      detachedRejections: 0,
+      handlePresent: false,
+      loaderInterceptions: 1,
+      nextBody: "next",
+      nextStatus: 200,
+      ownerObservedAlreadyAborted: true,
+      responseBody: "{\"kind\":\"upstream_timeout\"}",
+      responseStatus: 504,
+      settledAfterAbort: false,
+      settledBeforeRelease: false,
+    });
+  });
+});

--- a/tests/unit/toolchain.test.ts
+++ b/tests/unit/toolchain.test.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import path from "node:path";
-import { access, readdir, readFile } from "node:fs/promises";
+import { access, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import ts from "typescript";
@@ -33,34 +34,18 @@ async function readPackageJson(): Promise<PackageJson> {
 }
 
 function isRuntimeBearingImport(statement: ts.ImportDeclaration): boolean {
-  const clause = statement.importClause;
-  if (clause === undefined) {
-    return true;
-  }
-  if (clause.isTypeOnly) {
-    return false;
-  }
-  if (clause.name !== undefined || clause.namedBindings === undefined) {
-    return true;
-  }
-  if (ts.isNamespaceImport(clause.namedBindings)) {
-    return true;
-  }
-  return clause.namedBindings.elements.some((element) => !element.isTypeOnly);
+  return statement.importClause?.isTypeOnly !== true;
 }
 
 function isRuntimeBearingExport(statement: ts.ExportDeclaration): boolean {
-  if (statement.isTypeOnly) {
-    return false;
-  }
-  if (statement.exportClause === undefined || !ts.isNamedExports(statement.exportClause)) {
-    return true;
-  }
-  return statement.exportClause.elements.some((element) => !element.isTypeOnly);
+  return !statement.isTypeOnly;
 }
 
-async function staticRuntimeImportGraph(entrypoint: string): Promise<Set<string>> {
-  const repositoryRoot = path.resolve(".");
+async function staticRuntimeImportGraph(
+  entrypoint: string,
+  graphRoot = path.resolve("."),
+): Promise<Set<string>> {
+  const repositoryRoot = path.resolve(graphRoot);
   const pending = [path.resolve(entrypoint)];
   const reached = new Set<string>();
 
@@ -97,9 +82,39 @@ async function staticRuntimeImportGraph(entrypoint: string): Promise<Set<string>
 }
 
 describe("package entrypoints and toolchain", () => {
+  it("follows verbatim runtime declarations but excludes type-only and dynamic imports", async () => {
+    const fixtureRoot = await mkdtemp(path.join(tmpdir(), "ghcg-static-import-graph-"));
+    const files = new Map([
+      ["entry.ts", [
+        "import { type InlineImport } from \"./inline-import.js\";",
+        "export { type InlineExport } from \"./inline-export.js\";",
+        "import type { ImportType } from \"./import-type.js\";",
+        "export type { ExportType } from \"./export-type.js\";",
+        "void import(\"./dynamic.js\");",
+      ].join("\n")],
+      ["inline-import.ts", "export interface InlineImport {}\n"],
+      ["inline-export.ts", "export interface InlineExport {}\n"],
+      ["import-type.ts", "export interface ImportType {}\n"],
+      ["export-type.ts", "export interface ExportType {}\n"],
+      ["dynamic.ts", "export const dynamic = true;\n"],
+    ]);
+
+    try {
+      await Promise.all([...files].map(async ([name, source]) => {
+        await writeFile(path.join(fixtureRoot, name), source, "utf8");
+      }));
+      const graph = await staticRuntimeImportGraph(path.join(fixtureRoot, "entry.ts"), fixtureRoot);
+
+      expect([...graph].sort()).toEqual(["entry.ts", "inline-export.ts", "inline-import.ts"]);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps request-only Stream Execution modules out of the idle runtime import graph", async () => {
     const graph = await staticRuntimeImportGraph("src/main.ts");
 
+    expect(graph).toContain("src/main.ts");
     expect(graph).toContain("src/gateway/hono_app.ts");
     expect(graph).toContain("src/gateway/stream_execution.ts");
     expect(graph).not.toContain("src/gateway/stream_execution_owner.ts");

--- a/tests/unit/toolchain.test.ts
+++ b/tests/unit/toolchain.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { access, readdir, readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import { VERSION } from "../../src/version.js";
 import { assertNode24, currentNodeMajor } from "../../scripts/tooling/node_version.js";
@@ -31,7 +32,80 @@ async function readPackageJson(): Promise<PackageJson> {
   return JSON.parse(await readFile("package.json", "utf8")) as PackageJson;
 }
 
+function isRuntimeBearingImport(statement: ts.ImportDeclaration): boolean {
+  const clause = statement.importClause;
+  if (clause === undefined) {
+    return true;
+  }
+  if (clause.isTypeOnly) {
+    return false;
+  }
+  if (clause.name !== undefined || clause.namedBindings === undefined) {
+    return true;
+  }
+  if (ts.isNamespaceImport(clause.namedBindings)) {
+    return true;
+  }
+  return clause.namedBindings.elements.some((element) => !element.isTypeOnly);
+}
+
+function isRuntimeBearingExport(statement: ts.ExportDeclaration): boolean {
+  if (statement.isTypeOnly) {
+    return false;
+  }
+  if (statement.exportClause === undefined || !ts.isNamedExports(statement.exportClause)) {
+    return true;
+  }
+  return statement.exportClause.elements.some((element) => !element.isTypeOnly);
+}
+
+async function staticRuntimeImportGraph(entrypoint: string): Promise<Set<string>> {
+  const repositoryRoot = path.resolve(".");
+  const pending = [path.resolve(entrypoint)];
+  const reached = new Set<string>();
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined) {
+      continue;
+    }
+    const relativeCurrent = path.relative(repositoryRoot, current).replaceAll(path.sep, "/");
+    if (reached.has(relativeCurrent)) {
+      continue;
+    }
+    reached.add(relativeCurrent);
+
+    const source = await readFile(current, "utf8");
+    const sourceFile = ts.createSourceFile(current, source, ts.ScriptTarget.Latest, true);
+    for (const statement of sourceFile.statements) {
+      const declaration = ts.isImportDeclaration(statement) && isRuntimeBearingImport(statement)
+        ? statement
+        : ts.isExportDeclaration(statement) && isRuntimeBearingExport(statement)
+          ? statement
+          : undefined;
+      if (declaration?.moduleSpecifier === undefined
+        || !ts.isStringLiteral(declaration.moduleSpecifier)
+        || !declaration.moduleSpecifier.text.startsWith(".")) {
+        continue;
+      }
+      const sourceSpecifier = declaration.moduleSpecifier.text.replace(/\.js$/u, ".ts");
+      pending.push(path.resolve(path.dirname(current), sourceSpecifier));
+    }
+  }
+
+  return reached;
+}
+
 describe("package entrypoints and toolchain", () => {
+  it("keeps request-only Stream Execution modules out of the idle runtime import graph", async () => {
+    const graph = await staticRuntimeImportGraph("src/main.ts");
+
+    expect(graph).toContain("src/gateway/hono_app.ts");
+    expect(graph).toContain("src/gateway/stream_execution.ts");
+    expect(graph).not.toContain("src/gateway/stream_execution_owner.ts");
+    expect(graph).not.toContain("src/gateway/stream_response.ts");
+  });
+
   it("exposes the production package identity and entrypoints", async () => {
     const pkg = await readPackageJson();
 


### PR DESCRIPTION
## Summary

- keep the Stream Execution interface, handle registry, and deadline helpers in a lightweight idle-loaded facade
- lazy-load the request-only lifecycle owner and response writer on the first real stream execution
- register the owner handle before returning the response to Hono and retain single-owner cleanup
- add deterministic static-import-graph coverage plus real Node ESM rejection/delay lifecycle tests
- preserve the 64 MiB idle threshold, three-repeat policy, protocol bytes, history ownership, and daemon behavior

## Evidence

Current `main` and PR #189 both reproduced the macOS arm64 idle RSS gate while the daemon operation-lock modules were absent from the idle import graph. This change removes the known request-only Stream Execution owner/writer from that graph rather than changing the benchmark contract.

## Validation

- static import graph: expected red before split, green after split
- lifecycle/toolchain focused tests: 37 passed
- targeted protocol tests: 92 passed
- full `npm test`: 1119 passed, 6 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run fixtures:verify` (53 entries)
- local three-repeat benchmark passed with unchanged thresholds
- Standards review: no findings
- Spec review: no findings

Official SDK suites, live inference, and capture were not run. Fixture/golden bytes were unchanged.

Closes #190
