### PR TITLE
Make capability registry the sole effective authority

### DIFF
--- a/scripts/tooling/bench.ts
+++ b/scripts/tooling/bench.ts
@@ -561,7 +561,6 @@ async function createBenchmarkRuntime(): Promise<BenchmarkRuntime> {
     database,
     credentials,
     directory,
-    catalog,
     registry,
     copilot: backend,
     history: measuredHistory,
@@ -574,7 +573,7 @@ async function createBenchmarkRuntime(): Promise<BenchmarkRuntime> {
       if (closed) return;
       closed = true;
       await telemetry.flush();
-      await catalog.close();
+      await registry.close();
       closeDatabase(database);
     },
     forceClose() {

--- a/scripts/tooling/fixtures.ts
+++ b/scripts/tooling/fixtures.ts
@@ -11,6 +11,7 @@ import { assertNode24 } from "./node_version.js";
 import { outboundHeaders, ScriptedCopilotBackend } from "../../src/copilot/backend.js";
 import { parseChatSse } from "../../src/copilot/chat_sse.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
+import { ModelCapabilityRegistry } from "../../src/copilot/capability_registry.js";
 import type { EffectiveModelCapabilitySnapshot } from "../../src/copilot/capability_registry.js";
 import { serializeOpenAiModels } from "../../src/protocols/model_catalog/wire.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
@@ -903,7 +904,7 @@ async function createResponsesFixtureGateway(backend = new ScriptedCopilotBacken
     runtime: defaultRuntimeConfigSnapshot(),
   }, [createResponsesRoute({
     directory: accounts,
-    catalog,
+    registry: new ModelCapabilityRegistry(catalog, { get: () => null }),
     preferences: accounts.preferences,
     copilot: backend,
     history,

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -3,6 +3,7 @@ import { AgentError, type AgentErrorCode, type AgentsManager, type AgentsView, t
 import type { DeviceFlowCancelResult } from "../accounts/device_flow.js";
 import type { RuntimeConfigSnapshot } from "../config/schema.js";
 import type { BoundAccount } from "../accounts/account_directory.js";
+import type { ModelCapabilityRegistry } from "../copilot/capability_registry.js";
 import type {
   NativeModelProtocol,
   CapabilitySource,
@@ -224,64 +225,10 @@ export type AdminDeviceFlowPoll =
   | { readonly state: "expired" | "denied" | "failed" }
   | { readonly state: "complete"; readonly account: AdminAccount };
 
-export interface AdminCapabilityRegistry {
-  get(account: Readonly<BoundAccount>, signal: AbortSignal): Promise<{
-    readonly accountId: string;
-    readonly credentialGeneration: number;
-    readonly catalogGeneration: number;
-    readonly fetchedAt: string;
-    readonly models: readonly {
-      readonly modelId: string;
-      readonly name: string;
-      readonly vendor: string;
-      readonly protocols: {
-        readonly value: readonly NativeModelProtocol[] | null;
-        readonly source: CapabilitySource;
-        readonly conflict: boolean;
-        readonly liveState: CapabilityFieldState;
-      };
-      readonly maxInputTokens: {
-        readonly value: number | null;
-        readonly source: CapabilitySource;
-        readonly conflict: boolean;
-        readonly liveState: CapabilityFieldState;
-      };
-      readonly maxOutputTokens: {
-        readonly value: number | null;
-        readonly source: CapabilitySource;
-        readonly conflict: boolean;
-        readonly liveState: CapabilityFieldState;
-      };
-      readonly defaultOutputTokens: {
-        readonly configuration: {
-          readonly value: number | null;
-          readonly source: CapabilitySource;
-          readonly conflict: boolean;
-          readonly liveState: CapabilityFieldState;
-        };
-        readonly effective: number;
-        readonly source: CapabilitySource | "known_ceiling" | "unknown_fallback";
-        readonly valid: boolean;
-      };
-      readonly profile: {
-        readonly chatOutputTokenField: {
-          readonly value: ChatOutputTokenField | null;
-          readonly source: CapabilitySource;
-          readonly conflict: boolean;
-          readonly liveState: CapabilityFieldState;
-        };
-      };
-      readonly revision: {
-        readonly builtinRevision: string | null;
-      };
-    }[];
-  }>;
-  invalidate(accountId: string): void;
-  isCurrent(snapshot: Awaited<ReturnType<AdminCapabilityRegistry["get"]>>): boolean;
-  modelsUsableForAgentMapping(
-    snapshot: Awaited<ReturnType<AdminCapabilityRegistry["get"]>>,
-  ): Awaited<ReturnType<AdminCapabilityRegistry["get"]>>["models"];
-}
+export type AdminCapabilityRegistry = Pick<
+  ModelCapabilityRegistry,
+  "get" | "invalidate" | "isCurrent" | "modelsUsableForAgentMapping"
+>;
 
 export interface AdminAccountCaches {
   invalidate(accountId: string): void;

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -492,6 +492,9 @@ export class AdminManagementApi {
       const catalog = await this.dependencies.registry.get(account, signal);
       signal.throwIfAborted();
       await this.requireSameCredentialGeneration(accountId, account, signal);
+      if (!this.dependencies.registry.isCurrent(catalog)) {
+        throw new AdminApiError("revision_conflict");
+      }
       this.dependencies.preferredModels.markInvalidIfMissing(
         accountId,
         catalog,
@@ -515,6 +518,9 @@ export class AdminManagementApi {
       await this.requireSameCredentialGeneration(accountId, account, signal);
       let preference: AdminStoredPreference;
       try {
+        if (!this.dependencies.registry.isCurrent(catalog)) {
+          throw new AdminApiError("revision_conflict");
+        }
         preference = this.dependencies.preferredModels.setPreferred(
           accountId,
           modelId,

--- a/src/cli/commands/dispatcher.ts
+++ b/src/cli/commands/dispatcher.ts
@@ -2,12 +2,7 @@ import type { AccountDirectory } from "../../accounts/account_directory.js";
 import { AccountDirectoryError, type AccountSummary } from "../../accounts/account_directory.js";
 import { DeviceFlowError, type DeviceFlowService } from "../../accounts/device_flow.js";
 import { PreferenceRevisionError } from "../../accounts/model_preferences.js";
-import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
-import {
-  isCapabilitySnapshotCurrent,
-  loadCapabilitySnapshot,
-  type ModelCapabilityRegistry,
-} from "../../copilot/capability_registry.js";
+import { requireModelCapabilityRegistry, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
 import type { RuntimeConfigStore } from "../../config/runtime_config.js";
 import { isRuntimeConfigKey, readRuntimeConfigNumber, RUNTIME_CONFIG_RANGES, RuntimeConfigError, withRuntimeConfigNumber } from "../../config/runtime_config.js";
 import type { RuntimeConfigSnapshot } from "../../config/schema.js";
@@ -27,8 +22,7 @@ import {
 export interface CommandDispatcherDependencies {
   readonly directory: AccountDirectory;
   readonly deviceFlows: Pick<DeviceFlowService, "start" | "poll" | "cancel">;
-  readonly catalog: CopilotModelCatalog;
-  readonly registry?: ModelCapabilityRegistry;
+  readonly registry: ModelCapabilityRegistry;
   readonly runtimeConfig: RuntimeConfigStore;
   readonly updateRuntimeConfig?: (
     candidate: RuntimeConfigSnapshot,
@@ -39,7 +33,9 @@ export interface CommandDispatcherDependencies {
 }
 
 export class CommandDispatcher {
-  constructor(private readonly dependencies: CommandDispatcherDependencies) {}
+  constructor(private readonly dependencies: CommandDispatcherDependencies) {
+    requireModelCapabilityRegistry(dependencies.registry);
+  }
 
   async dispatch<Operation extends ControlOperation>(
     operation: Operation,
@@ -141,11 +137,11 @@ export class CommandDispatcher {
       const accountId = input.accountId ?? this.defaultAccount().accountId;
       const account = await this.dependencies.directory.bindAccount(accountId, signal);
       const beforePreference = this.dependencies.directory.preferences.get(accountId);
-      const catalog = await loadCapabilitySnapshot(this.dependencies, account, signal);
+      const catalog = await this.dependencies.registry.get(account, signal);
       await reconcilePreferredModelIfCurrent(
         this.dependencies.directory.preferences,
         this.dependencies.directory,
-        this.dependencies,
+        this.dependencies.registry,
         account,
         catalog,
         beforePreference,
@@ -168,10 +164,10 @@ export class CommandDispatcher {
       const input = args as ControlOperationMap["models.set"]["args"];
       const account = this.defaultAccount();
       const bound = await this.dependencies.directory.bindAccount(account.accountId, signal);
-      const catalog = await loadCapabilitySnapshot(this.dependencies, bound, signal);
+      const catalog = await this.dependencies.registry.get(bound, signal);
       const currentBound = await this.dependencies.directory.bindAccount(account.accountId, signal);
       if (currentBound.credentialGeneration !== bound.credentialGeneration
-        || !isCapabilitySnapshotCurrent(this.dependencies, catalog)) {
+        || !this.dependencies.registry.isCurrent(catalog)) {
         throw new PreferenceRevisionError();
       }
       const current = this.dependencies.directory.preferences.get(account.accountId);
@@ -213,7 +209,7 @@ export class CommandDispatcher {
 
   private invalidateAccountCaches(accountId: string): void {
     if (this.dependencies.invalidateAccountCaches === undefined) {
-      this.dependencies.catalog.invalidate(accountId);
+      this.dependencies.registry.invalidate(accountId);
       return;
     }
     this.dependencies.invalidateAccountCaches(accountId);

--- a/src/copilot/capability_registry.ts
+++ b/src/copilot/capability_registry.ts
@@ -37,41 +37,13 @@ export interface CapabilityCatalogSnapshot {
   readonly models: readonly EffectiveModelCapabilitySnapshot[];
 }
 
-export interface CapabilitySnapshotDependencies {
-  readonly registry?: ModelCapabilityRegistry;
-  readonly catalog?: CopilotModelCatalog;
-}
-
-export async function loadCapabilitySnapshot(
-  dependencies: Readonly<CapabilitySnapshotDependencies>,
-  account: Readonly<BoundAccount>,
-  signal: AbortSignal,
-): Promise<CapabilityCatalogSnapshot> {
-  if (dependencies.registry !== undefined) {
-    return await dependencies.registry.get(account, signal);
+export function requireModelCapabilityRegistry(
+  registry: ModelCapabilityRegistry | undefined,
+): ModelCapabilityRegistry {
+  if (registry === undefined) {
+    throw new Error("model capability registry is unavailable");
   }
-
-  if (dependencies.catalog !== undefined) {
-    return capabilitySnapshotFromCatalog(
-      account,
-      await dependencies.catalog.get(account.accountId, signal, account.credentialGeneration),
-    );
-  }
-  throw new Error("model capability registry is unavailable");
-}
-
-export function isCapabilitySnapshotCurrent(
-  dependencies: Readonly<CapabilitySnapshotDependencies>,
-  snapshot: Readonly<CapabilityCatalogSnapshot>,
-): boolean {
-  if (dependencies.registry !== undefined) {
-    return dependencies.registry.isCurrent(snapshot);
-  }
-  return dependencies.catalog?.isCurrent(
-    snapshot.accountId,
-    snapshot.catalogGeneration,
-    snapshot.credentialGeneration,
-  ) === true;
+  return registry;
 }
 
 export class ModelCapabilityRegistry {
@@ -179,58 +151,6 @@ export class ModelCapabilityRegistry {
       },
     });
   }
-}
-
-export function capabilitySnapshotFromCatalog(
-  account: Readonly<BoundAccount>,
-  catalog: Readonly<CatalogSnapshot>,
-): CapabilityCatalogSnapshot {
-  const models = catalog.models.map((model) => {
-    const protocols = effectiveField(model.capabilities.protocols, UNKNOWN_DECLARATIONS.protocols, sameProtocols);
-    const maxInputTokens = effectiveField(model.capabilities.maxInputTokens, UNKNOWN_DECLARATIONS.maxInputTokens);
-    const maxOutputTokens = effectiveField(model.capabilities.maxOutputTokens, UNKNOWN_DECLARATIONS.maxOutputTokens);
-    const defaultConfiguration = effectiveField(
-      model.capabilities.defaultOutputTokens,
-      UNKNOWN_DECLARATIONS.defaultOutputTokens,
-    );
-    const chatOutputTokenField = effectiveField(
-      model.capabilities.chatOutputTokenField,
-      UNKNOWN_DECLARATIONS.chatOutputTokenField,
-    );
-    const supportedParameters = effectiveField(
-      model.capabilities.supportedParameters,
-      UNKNOWN_DECLARATIONS.supportedParameters,
-      sameStrings,
-    );
-    const reasoningEfforts = effectiveField(
-      model.capabilities.reasoningEfforts,
-      UNKNOWN_DECLARATIONS.reasoningEfforts,
-      sameStrings,
-    );
-    return deepFreeze({
-      accountId: account.accountId,
-      modelId: model.id,
-      name: model.name,
-      vendor: model.vendor,
-      protocols,
-      maxInputTokens,
-      maxOutputTokens,
-      defaultOutputTokens: resolveDefaultOutputTokens(defaultConfiguration, maxOutputTokens.value),
-      profile: { chatOutputTokenField, supportedParameters, reasoningEfforts },
-      revision: {
-        credentialGeneration: account.credentialGeneration,
-        catalogGeneration: catalog.generation,
-        builtinRevision: null,
-      },
-    });
-  });
-  return deepFreeze({
-    accountId: account.accountId,
-    credentialGeneration: account.credentialGeneration,
-    catalogGeneration: catalog.generation,
-    fetchedAt: catalog.fetchedAt,
-    models,
-  });
 }
 
 function deepFreeze<T>(value: T): T {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { createCopilotEndpointDiscovery, refreshCopilotToken } from "./copilot/c
 import { HttpCopilotModelsSource } from "./copilot/models_source.js";
 import { CopilotModelCatalog, type CopilotModelsSource } from "./copilot/model_catalog.js";
 import { productionBuiltinModelCapabilities } from "./copilot/model_metadata.js";
-import { ModelCapabilityRegistry } from "./copilot/capability_registry.js";
+import { ModelCapabilityRegistry, requireModelCapabilityRegistry } from "./copilot/capability_registry.js";
 import { HttpCopilotBackend } from "./copilot/transport.js";
 import type { CopilotBackend } from "./copilot/backend.js";
 import { getValidToken } from "./copilot/token_refresh.js";
@@ -58,8 +58,7 @@ export interface ApplicationContext {
   readonly database?: SqliteDatabase;
   readonly credentials?: CredentialStore;
   readonly directory: AccountDirectory;
-  readonly catalog: CopilotModelCatalog;
-  readonly registry?: ModelCapabilityRegistry;
+  readonly registry: ModelCapabilityRegistry;
   readonly copilot: CopilotBackend;
   readonly history: ResponsesHistory;
   readonly telemetry?: TelemetryRecorder;
@@ -112,16 +111,17 @@ export async function bootstrapGateway(options: BootstrapOptions = {}): Promise<
 }
 
 export function createPublicRouteRegistrations(context: Readonly<ApplicationContext>): readonly RouteRegistration[] {
+  const registry = requireModelCapabilityRegistry(context.registry);
   const preferences = context.directory.preferences;
   return [
     ...createModelCatalogRoutes({
       directory: context.directory,
-      ...(context.registry === undefined ? { catalog: context.catalog } : { registry: context.registry }),
+      registry,
       preferences,
     }),
     createOpenAiChatRoute({
       directory: context.directory,
-      ...(context.registry === undefined ? { catalog: context.catalog } : { registry: context.registry }),
+      registry,
       preferences,
       copilot: context.copilot,
       ...(context.telemetry === undefined ? {} : { usageRecorder: context.telemetry }),
@@ -131,7 +131,7 @@ export function createPublicRouteRegistrations(context: Readonly<ApplicationCont
     }),
     createAnthropicMessagesRoute({
       directory: context.directory,
-      ...(context.registry === undefined ? { catalog: context.catalog } : { registry: context.registry }),
+      registry,
       preferences,
       copilot: context.copilot,
       ...(context.telemetry === undefined ? {} : { usageRecorder: context.telemetry }),
@@ -141,7 +141,7 @@ export function createPublicRouteRegistrations(context: Readonly<ApplicationCont
     }),
     createResponsesRoute({
       directory: context.directory,
-      ...(context.registry === undefined ? { catalog: context.catalog } : { registry: context.registry }),
+      registry,
       preferences,
       copilot: context.copilot,
       history: context.history,
@@ -222,7 +222,6 @@ export async function createProductionApplicationContext(
     database,
     credentials,
     directory,
-    catalog,
     registry,
     copilot,
     history,
@@ -356,7 +355,6 @@ export async function composeProductionDaemonGateway(
     const dispatcher = new CommandDispatcher({
       directory: application.directory,
       deviceFlows,
-      catalog: application.catalog,
       runtimeConfig: runtime,
       updateRuntimeConfig,
       invalidateAccountCaches: (accountId) => accountCaches.invalidate(accountId),

--- a/src/protocols/anthropic_messages/endpoint.ts
+++ b/src/protocols/anthropic_messages/endpoint.ts
@@ -1,8 +1,7 @@
 import type { AccountDirectory, BoundAccount } from "../../accounts/account_directory.js";
 import type { AccountModelPreferences } from "../../accounts/model_preferences.js";
 import type { BoundCopilot, CopilotBackend } from "../../copilot/backend.js";
-import { loadCapabilitySnapshot, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
-import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
+import { requireModelCapabilityRegistry, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
 import {
   MESSAGES_VERSION,
   type MessagesBetaFeature,
@@ -42,8 +41,7 @@ import {
 
 export interface AnthropicMessagesRouteDependencies {
   readonly directory: AccountDirectory;
-  readonly registry?: ModelCapabilityRegistry;
-  readonly catalog?: CopilotModelCatalog;
+  readonly registry: ModelCapabilityRegistry;
   readonly preferences: AccountModelPreferences;
   readonly copilot: CopilotBackend;
   readonly createUuid?: () => string;
@@ -58,6 +56,7 @@ const JSON_HEADERS = {
 } as const;
 
 export function createAnthropicMessagesRoute(dependencies: AnthropicMessagesRouteDependencies): RouteRegistration {
+  requireModelCapabilityRegistry(dependencies.registry);
   return {
     method: "POST",
     path: "/v1/messages",
@@ -338,11 +337,11 @@ async function loadCatalog(
   signal: AbortSignal,
 ) {
   try {
-    const catalog = await loadCapabilitySnapshot(dependencies, account, signal);
+    const catalog = await dependencies.registry.get(account, signal);
     await reconcilePreferredModelIfCurrent(
       dependencies.preferences,
       dependencies.directory,
-      dependencies,
+      dependencies.registry,
       account,
       catalog,
       observedPreference,

--- a/src/protocols/model_catalog/preferred.ts
+++ b/src/protocols/model_catalog/preferred.ts
@@ -1,10 +1,6 @@
 import type { AccountModelPreferences, ModelPreference } from "../../accounts/model_preferences.js";
 import { PreferenceRevisionError } from "../../accounts/model_preferences.js";
-import type { CapabilityCatalogSnapshot } from "../../copilot/capability_registry.js";
-import {
-  isCapabilitySnapshotCurrent,
-  type CapabilitySnapshotDependencies,
-} from "../../copilot/capability_registry.js";
+import type { CapabilityCatalogSnapshot, ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
 import { AccountDirectoryError, type AccountDirectory, type BoundAccount } from "../../accounts/account_directory.js";
 
 export class PreferredModelManager {
@@ -65,7 +61,7 @@ export function reconcilePreferredModel(
 export async function reconcilePreferredModelIfCurrent(
   preferences: AccountModelPreferences,
   directory: AccountDirectory,
-  capabilities: Readonly<CapabilitySnapshotDependencies>,
+  registry: Pick<ModelCapabilityRegistry, "isCurrent">,
   boundAccount: Readonly<BoundAccount>,
   catalog: CapabilityCatalogSnapshot,
   observed: ModelPreference | null,
@@ -81,7 +77,7 @@ export async function reconcilePreferredModelIfCurrent(
     throw error;
   }
   if (current.credentialGeneration !== boundAccount.credentialGeneration
-    || !isCapabilitySnapshotCurrent(capabilities, catalog)) {
+    || !registry.isCurrent(catalog)) {
     return preferences.get(boundAccount.accountId);
   }
   return reconcilePreferredModel(preferences, boundAccount.accountId, catalog, observed);

--- a/src/protocols/model_catalog/routes.ts
+++ b/src/protocols/model_catalog/routes.ts
@@ -4,8 +4,7 @@ import {
   normalizeCatalogFailure,
 } from "../../copilot/failures.js";
 import type { AccountModelPreferences } from "../../accounts/model_preferences.js";
-import { loadCapabilitySnapshot, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
-import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
+import { requireModelCapabilityRegistry, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
 import type { RouteRegistration } from "../../gateway/hono_app.js";
 import {
   serializeAnthropicModels,
@@ -16,8 +15,7 @@ import { presentModelCatalogFailure } from "./failure_presenter.js";
 
 export interface ModelCatalogRouteDependencies {
   readonly directory: AccountDirectory;
-  readonly registry?: ModelCapabilityRegistry;
-  readonly catalog?: CopilotModelCatalog;
+  readonly registry: ModelCapabilityRegistry;
   readonly preferences: AccountModelPreferences;
 }
 
@@ -27,6 +25,7 @@ const JSON_HEADERS = {
 } as const;
 
 export function createModelCatalogRoutes(dependencies: ModelCatalogRouteDependencies): readonly RouteRegistration[] {
+  requireModelCapabilityRegistry(dependencies.registry);
   return [
     {
       method: "GET",
@@ -60,11 +59,11 @@ async function loadCatalog(
   }
   try {
     const observedPreference = dependencies.preferences.get(account.accountId);
-    const catalog = await loadCapabilitySnapshot(dependencies, account, signal);
+    const catalog = await dependencies.registry.get(account, signal);
     await reconcilePreferredModelIfCurrent(
       dependencies.preferences,
       dependencies.directory,
-      dependencies,
+      dependencies.registry,
       account,
       catalog,
       observedPreference,

--- a/src/protocols/openai_chat/endpoint.ts
+++ b/src/protocols/openai_chat/endpoint.ts
@@ -2,8 +2,7 @@ import type { AccountDirectory, BoundAccount } from "../../accounts/account_dire
 import type { AccountModelPreferences, ModelPreference } from "../../accounts/model_preferences.js";
 import type { BoundCopilot, CopilotBackend } from "../../copilot/backend.js";
 import type { UpstreamByteStream } from "../../copilot/upstream_types.js";
-import { loadCapabilitySnapshot, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
-import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
+import { requireModelCapabilityRegistry, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
 import { parseChatSse } from "../../copilot/chat_sse.js";
 import {
   normalizeAccountBindingFailure,
@@ -54,8 +53,7 @@ import { chatUsageFromCounters, mergeChatUsageCounters, type ChatUsageCounters }
 
 export interface OpenAiChatRouteDependencies {
   readonly directory: AccountDirectory;
-  readonly registry?: ModelCapabilityRegistry;
-  readonly catalog?: CopilotModelCatalog;
+  readonly registry: ModelCapabilityRegistry;
   readonly preferences?: Pick<AccountModelPreferences, "get">;
   readonly copilot: CopilotBackend;
   readonly usageRecorder?: Pick<TelemetryRecorder, "recordUsage">;
@@ -79,6 +77,7 @@ interface PreparedOpenAiChatRequest {
 }
 
 export function createOpenAiChatRoute(dependencies: OpenAiChatRouteDependencies): RouteRegistration {
+  requireModelCapabilityRegistry(dependencies.registry);
   return {
     method: "POST",
     path: "/v1/chat/completions",
@@ -338,12 +337,12 @@ async function bindAccount(directory: AccountDirectory, signal: AbortSignal) {
 }
 
 async function loadCatalog(
-  dependencies: Pick<OpenAiChatRouteDependencies, "registry" | "catalog">,
+  dependencies: Pick<OpenAiChatRouteDependencies, "registry">,
   account: Readonly<BoundAccount>,
   signal: AbortSignal,
 ) {
   try {
-    return await loadCapabilitySnapshot(dependencies, account, signal);
+    return await dependencies.registry.get(account, signal);
   } catch (error: unknown) {
     throw normalizeCatalogFailure(error, signal);
   }

--- a/src/protocols/responses/endpoint.ts
+++ b/src/protocols/responses/endpoint.ts
@@ -1,8 +1,7 @@
 import type { AccountDirectory, BoundAccount } from "../../accounts/account_directory.js";
 import type { AccountModelPreferences } from "../../accounts/model_preferences.js";
 import type { BoundCopilot, CopilotBackend } from "../../copilot/backend.js";
-import { loadCapabilitySnapshot, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
-import type { CopilotModelCatalog } from "../../copilot/model_catalog.js";
+import { requireModelCapabilityRegistry, type ModelCapabilityRegistry } from "../../copilot/capability_registry.js";
 import {
   normalizeAccountBindingFailure,
   normalizeCatalogFailure,
@@ -68,8 +67,7 @@ import type {
 
 export interface ResponsesRouteDependencies {
   readonly directory: AccountDirectory;
-  readonly registry?: ModelCapabilityRegistry;
-  readonly catalog?: CopilotModelCatalog;
+  readonly registry: ModelCapabilityRegistry;
   readonly preferences: AccountModelPreferences;
   readonly copilot: CopilotBackend;
   readonly history: ResponsesHistory;
@@ -81,6 +79,7 @@ export interface ResponsesRouteDependencies {
 }
 
 export function createResponsesRoute(dependencies: ResponsesRouteDependencies): RouteRegistration {
+  requireModelCapabilityRegistry(dependencies.registry);
   return {
     method: "POST",
     path: "/v1/responses",
@@ -1393,11 +1392,11 @@ async function loadCatalog(
   signal: AbortSignal,
 ) {
   try {
-    const catalog = await loadCapabilitySnapshot(dependencies, account, signal);
+    const catalog = await dependencies.registry.get(account, signal);
     await reconcilePreferredModelIfCurrent(
       dependencies.preferences,
       dependencies.directory,
-      dependencies,
+      dependencies.registry,
       account,
       catalog,
       observedPreference,

--- a/tests/contract/admin_api.test.ts
+++ b/tests/contract/admin_api.test.ts
@@ -4,7 +4,7 @@ import type { AdminModule } from "../../src/gateway/create_gateway.js";
 import { createGateway, type Gateway } from "../../src/gateway/create_gateway.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
-import { capabilitySnapshotFromCatalog } from "../../src/copilot/capability_registry.js";
+import { ModelCapabilityRegistry } from "../../src/copilot/capability_registry.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
 import { adminDependencies } from "./admin_test_harness.js";
 import { login } from "./admin_test_harness.js";
@@ -89,9 +89,8 @@ describe("Admin API", () => {
         })) };
       },
     }, () => new Date("2027-01-15T08:00:00Z"));
-    dependencies.registry.get = async (account, signal) => capabilitySnapshotFromCatalog(
-      account, await catalog.get(account.accountId, signal, account.credentialGeneration),
-    );
+    const registry = new ModelCapabilityRegistry(catalog, { get: () => null });
+    dependencies.registry.get = registry.get.bind(registry);
     const harness = await createHarness(dependencies);
     try {
       const session = await login(harness.gateway, harness.admin);

--- a/tests/contract/admin_api.test.ts
+++ b/tests/contract/admin_api.test.ts
@@ -338,6 +338,51 @@ describe("Admin API", () => {
     }
   });
 
+  it.each(["refresh", "preferred"] as const)(
+    "rejects %s before preference writes when the registry snapshot becomes non-current during credential rebind",
+    async (operation) => {
+      const dependencies = adminDependencies();
+      const originalBind = dependencies.accounts.bindAccount;
+      const originalSetPreferred = dependencies.preferredModels.setPreferred;
+      const originalMarkInvalidIfMissing = dependencies.preferredModels.markInvalidIfMissing;
+      let bindCalls = 0;
+      let current = true;
+      let preferenceWrites = 0;
+      dependencies.accounts.bindAccount = async (...args) => {
+        const bound = await originalBind(...args);
+        bindCalls += 1;
+        if (bindCalls === 2) current = false;
+        return bound;
+      };
+      dependencies.registry.isCurrent = () => current;
+      dependencies.preferredModels.setPreferred = (...args) => {
+        preferenceWrites += 1;
+        return originalSetPreferred(...args);
+      };
+      dependencies.preferredModels.markInvalidIfMissing = (...args) => {
+        preferenceWrites += 1;
+        return originalMarkInvalidIfMissing(...args);
+      };
+      const harness = await createHarness(dependencies);
+      try {
+        const session = await login(harness.gateway, harness.admin);
+        const response = operation === "refresh"
+          ? await mutate(harness.gateway, "POST", "/admin/api/v1/models/refresh", session, {
+            accountId: "github.com/42",
+          })
+          : await mutate(harness.gateway, "PUT", "/admin/api/v1/models/preferred", session, {
+            accountId: "github.com/42", modelId: "gpt-test", expectedRevision: 0,
+          });
+        expect(response.status).toBe(409);
+        expect(bindCalls).toBe(2);
+        expect(preferenceWrites).toBe(0);
+        expect(dependencies.preferences.get("github.com/42")).toBeNull();
+      } finally {
+        await harness.close();
+      }
+    },
+  );
+
   it("keeps model mutations serialized when a queued request aborts", async () => {
     const dependencies = adminDependencies();
     let releaseCatalog = (): void => undefined;

--- a/tests/contract/admin_test_harness.ts
+++ b/tests/contract/admin_test_harness.ts
@@ -241,8 +241,24 @@ function capabilityModel(modelId: string) {
         conflict: false,
         liveState: "missing" as const,
       },
+      supportedParameters: {
+        value: null,
+        source: "unknown" as const,
+        conflict: false,
+        liveState: "missing" as const,
+      },
+      reasoningEfforts: {
+        value: null,
+        source: "unknown" as const,
+        conflict: false,
+        liveState: "missing" as const,
+      },
     },
-    revision: { builtinRevision: "test" },
+    revision: {
+      credentialGeneration: 4,
+      catalogGeneration: 7,
+      builtinRevision: "test",
+    },
   };
 }
 

--- a/tests/contract/anthropic_harness.ts
+++ b/tests/contract/anthropic_harness.ts
@@ -13,6 +13,7 @@ import { createAnthropicMessagesRoute } from "../../src/protocols/anthropic_mess
 import type { RuntimeConfigSnapshot } from "../../src/config/schema.js";
 import type { ChatRequest } from "../../src/protocols/chat_completions/types.js";
 import type { UsageUpdate } from "../../src/telemetry/recorder.js";
+import { testModelCapabilityRegistry } from "./model_capability_registry_harness.js";
 
 export const ACCOUNT_ID = "github.com/1";
 
@@ -86,7 +87,7 @@ export async function anthropicGateway(options: {
     runtime: options.runtime ?? defaultRuntimeConfigSnapshot(),
   }, [createAnthropicMessagesRoute({
     directory: accounts,
-    catalog,
+    registry: testModelCapabilityRegistry(catalog),
     preferences: accounts.preferences,
     copilot: backend,
     createUuid: options.createUuid ?? (() => "00000000-0000-4000-8000-000000000001"),

--- a/tests/contract/capability_authority.test.ts
+++ b/tests/contract/capability_authority.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import { AccountDirectory } from "../../src/accounts/account_directory.js";
+import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
+import { ScriptedCopilotBackend } from "../../src/copilot/backend.js";
+import { ModelCapabilityRegistry } from "../../src/copilot/capability_registry.js";
+import { parseLiveModelCapabilities } from "../../src/copilot/model_capabilities.js";
+import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
+import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
+import { parseStartupConfig } from "../../src/config/startup_config.js";
+import { createGateway } from "../../src/gateway/create_gateway.js";
+import { closeDatabase, openDatabase } from "../../src/persistence/database.js";
+import { embedMigration } from "../../src/persistence/migrations.js";
+import { migration as runtimeConfigMigration } from "../../src/persistence/migrations/001_runtime_config.js";
+import { migration as accountsMigration } from "../../src/persistence/migrations/010_accounts.js";
+import { migration as historyMigration } from "../../src/persistence/migrations/030_responses_history.js";
+import { migration as continuationMigration } from "../../src/persistence/migrations/041_responses_continuation_ownership.js";
+import { createAnthropicMessagesRoute } from "../../src/protocols/anthropic_messages/endpoint.js";
+import { createModelCatalogRoutes } from "../../src/protocols/model_catalog/routes.js";
+import { createOpenAiChatRoute } from "../../src/protocols/openai_chat/endpoint.js";
+import { createResponsesRoute } from "../../src/protocols/responses/endpoint.js";
+import { SqliteResponsesHistory } from "../../src/protocols/responses/history.js";
+
+const nowMs = (): number => 1_700_000_000_000;
+const encoder = new TextEncoder();
+
+describe("effective capability authority", () => {
+  it("uses one shared registry snapshot per model and inference request", async () => {
+    const database = openDatabase({
+      path: ":memory:",
+      migrations: [
+        embedMigration(runtimeConfigMigration),
+        embedMigration(accountsMigration),
+        embedMigration(historyMigration),
+        embedMigration(continuationMigration),
+      ],
+      nowMs,
+    });
+    const directory = new AccountDirectory(database, new MemoryCredentialStore(), nowMs);
+    const account = await directory.upsertAuthenticated({
+      host: "github.com",
+      userId: "1",
+      secret: { generation: 0, githubToken: "test-token" },
+    });
+    const catalog = new CopilotModelCatalog({
+      async fetch() {
+        return { data: [{
+          id: "authority",
+          name: "Authority",
+          vendor: "test",
+          model_picker_enabled: true,
+          model_info: {
+            supported_endpoints: ["/v1/responses"],
+            max_input_tokens: 100_000,
+            max_output_tokens: 12_000,
+          },
+        }] };
+      },
+    }, () => new Date(nowMs()));
+    const registry = new ModelCapabilityRegistry(catalog, {
+      get: (modelId) => modelId === "authority" ? {
+        revision: "builtin-authority-v1",
+        capabilities: parseLiveModelCapabilities({
+          supported_endpoints: ["/v1/chat/completions"],
+          max_input_tokens: 64_000,
+          max_output_tokens: 16_000,
+          chat_output_token_field: "max_tokens",
+        }),
+      } : null,
+    });
+    const snapshot = await registry.get(account, new AbortController().signal);
+    expect(snapshot.models[0]).toMatchObject({
+      modelId: "authority",
+      protocols: { value: ["responses"], source: "live", conflict: true },
+      maxInputTokens: { value: 100_000, source: "live", conflict: true },
+      maxOutputTokens: { value: 12_000, source: "live", conflict: true },
+      revision: { builtinRevision: "builtin-authority-v1" },
+    });
+
+    const backend = new ScriptedCopilotBackend({
+      responses: {
+        status: 200,
+        headers: new Headers(),
+        body: encoder.encode(JSON.stringify({
+          id: "resp_authority",
+          object: "response",
+          created_at: 1_700_000_000,
+          status: "completed",
+          output: [{
+            id: "msg_authority",
+            type: "message",
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "output_text", text: "ok", annotations: [] }],
+          }],
+          usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+        })),
+      },
+    });
+    const history = new SqliteResponsesHistory(database, { nowMs });
+    const shared = {
+      directory,
+      registry,
+      preferences: directory.preferences,
+      copilot: backend,
+    };
+    const get = vi.spyOn(registry, "get");
+    const gateway = await createGateway({
+      startup: parseStartupConfig([], {}, { homedir: "." }),
+      runtime: defaultRuntimeConfigSnapshot(),
+    }, [
+      ...createModelCatalogRoutes(shared),
+      createOpenAiChatRoute(shared),
+      createAnthropicMessagesRoute(shared),
+      createResponsesRoute({ ...shared, history }),
+    ], { createRequestId: () => "req_authority", onClose: () => registry.close() });
+    try {
+      const models = await gateway.fetch(new Request("http://127.0.0.1:31400/v1/models"));
+      expect(models.status).toBe(200);
+      expect(await models.json()).toMatchObject({
+        data: [{ id: "authority", max_input_tokens: 100_000, max_output_tokens: 12_000 }],
+      });
+      const chat = await gateway.fetch(jsonRequest("/v1/chat/completions", {
+        model: "authority",
+        messages: [{ role: "user", content: "hello" }],
+      }));
+      expect(chat.status).toBe(200);
+      const messages = await gateway.fetch(jsonRequest("/v1/messages", {
+        model: "authority",
+        max_tokens: 128,
+        messages: [{ role: "user", content: "hello" }],
+      }, { "anthropic-version": "2023-06-01" }));
+      expect(messages.status).toBe(200);
+      const responses = await gateway.fetch(jsonRequest("/v1/responses", {
+        model: "authority",
+        input: "hello",
+      }));
+      expect(responses.status).toBe(200);
+
+      expect(get).toHaveBeenCalledTimes(4);
+      expect(get.mock.calls.every(([bound]) => bound.accountId === account.accountId)).toBe(true);
+      expect(backend.captured).toEqual([
+        { accountId: account.accountId, kind: "responses" },
+        { accountId: account.accountId, kind: "responses" },
+        { accountId: account.accountId, kind: "responses" },
+      ]);
+    } finally {
+      await gateway.close();
+      closeDatabase(database);
+    }
+  });
+});
+
+function jsonRequest(path: string, body: unknown, headers: HeadersInit = {}): Request {
+  return new Request(`http://127.0.0.1:31400${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}

--- a/tests/contract/failure_presenters.test.ts
+++ b/tests/contract/failure_presenters.test.ts
@@ -19,6 +19,8 @@ import {
 } from "../../src/protocols/responses/endpoint.js";
 import { presentResponsesFailure } from "../../src/protocols/responses/failure_presenter.js";
 import { presentModelCatalogFailure } from "../../src/protocols/model_catalog/failure_presenter.js";
+import { ModelCapabilityRegistry } from "../../src/copilot/capability_registry.js";
+import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
 
 const requestId = "req_failure_matrix";
 const openAiModelsRequest = new Request("http://127.0.0.1:31400/v1/models");
@@ -127,13 +129,19 @@ describe("semantic failure presenters", () => {
     const recordUsage = vi.fn();
     const request = new Request("http://127.0.0.1:31400/");
     const failure: GatewayFailure = { kind: "upstream_timeout" };
+    const registry = new ModelCapabilityRegistry(new CopilotModelCatalog({
+      async fetch() { return { data: [] }; },
+    }), { get: () => null });
     const chat = createOpenAiChatRoute({
+      registry,
       usageRecorder: { recordUsage },
     } as unknown as OpenAiChatRouteDependencies);
     const messages = createAnthropicMessagesRoute({
+      registry,
       usageRecorder: { recordUsage },
     } as unknown as AnthropicMessagesRouteDependencies);
     const responses = createResponsesRoute({
+      registry,
       usageRecorder: { recordUsage },
     } as unknown as ResponsesRouteDependencies);
 

--- a/tests/contract/model_capability_registry_harness.ts
+++ b/tests/contract/model_capability_registry_harness.ts
@@ -1,0 +1,35 @@
+import type { BoundAccount } from "../../src/accounts/account_directory.js";
+import {
+  ModelCapabilityRegistry,
+  type CapabilityCatalogSnapshot,
+} from "../../src/copilot/capability_registry.js";
+import type { BuiltinModelCapabilityLookup } from "../../src/copilot/model_capabilities.js";
+import type { CatalogSnapshot, CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
+
+export const noBuiltinModelCapabilities: BuiltinModelCapabilityLookup = {
+  get: () => null,
+};
+
+export function testModelCapabilityRegistry(
+  catalog: CopilotModelCatalog,
+  builtins: BuiltinModelCapabilityLookup = noBuiltinModelCapabilities,
+): ModelCapabilityRegistry {
+  return new ModelCapabilityRegistry(catalog, builtins);
+}
+
+export async function registrySnapshotFromDiscovery(
+  account: Readonly<BoundAccount>,
+  snapshot: Readonly<CatalogSnapshot>,
+  builtins: BuiltinModelCapabilityLookup = noBuiltinModelCapabilities,
+): Promise<CapabilityCatalogSnapshot> {
+  const catalog = {
+    get: async () => snapshot,
+    invalidate: () => undefined,
+    isCurrent: () => true,
+    close: async () => undefined,
+  } as unknown as CopilotModelCatalog;
+  return await new ModelCapabilityRegistry(catalog, builtins).get(
+    account,
+    new AbortController().signal,
+  );
+}

--- a/tests/contract/model_catalog.test.ts
+++ b/tests/contract/model_catalog.test.ts
@@ -13,7 +13,7 @@ import {
   parseCapiModels,
 } from "../../src/copilot/model_catalog.js";
 import { productionModelInfoLookup } from "../../src/copilot/model_metadata.js";
-import { capabilitySnapshotFromCatalog } from "../../src/copilot/capability_registry.js";
+import { registrySnapshotFromDiscovery, testModelCapabilityRegistry } from "./model_capability_registry_harness.js";
 import { CapiFetchError, HttpCopilotModelsSource } from "../../src/copilot/models_source.js";
 import { defaultRuntimeConfigSnapshot } from "../../src/config/schema.js";
 import { parseStartupConfig } from "../../src/config/startup_config.js";
@@ -183,7 +183,7 @@ describe("CAPI parse and cache", () => {
       maxOutputTokens: { state: "value", value: 64_000 },
       chatOutputTokenField: { state: "value", value: "max_completion_tokens" },
     });
-    const effective = capabilitySnapshotFromCatalog(bound("github.com/1"), snapshot);
+    const effective = await registrySnapshotFromDiscovery(bound("github.com/1"), snapshot);
     expect(JSON.parse(serializeOpenAiModels(effective)).data[0]).toEqual({
       id: "native", object: "model", created: 1_677_610_602, owned_by: "openai",
       max_input_tokens: 128_000,
@@ -500,17 +500,18 @@ describe("CAPI parse and cache", () => {
       },
     );
     const catalog = new CopilotModelCatalog(source);
+    const registry = testModelCapabilityRegistry(catalog);
     const gw = await createGateway({
       startup: parseStartupConfig([], {}, { homedir: dir }),
       runtime: defaultRuntimeConfigSnapshot(),
     }, createModelCatalogRoutes({
       directory: accounts,
-      catalog,
+      registry,
       preferences: accounts.preferences,
-    }), { onClose: () => catalog.close() });
+    }), { onClose: () => registry.close() });
     try {
       expect((await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"))).status).toBe(200);
-      catalog.invalidate("github.com/1");
+      registry.invalidate("github.com/1");
       expect((await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"))).status).toBe(200);
       expect(requests).toBe(2);
       expect(createdDispatchers).toBe(1);
@@ -843,9 +844,8 @@ describe("model resolver", () => {
       }],
     }),
   };
-  const catalog = capabilitySnapshotFromCatalog(bound("github.com/1"), discovered);
-
-  it("uses valid visible preference only when model is missing", () => {
+  it("uses valid visible preference only when model is missing", async () => {
+    const catalog = await registrySnapshotFromDiscovery(bound("github.com/1"), discovered);
     const resolved = resolveModel(catalog, undefined, { modelId: "gpt", validity: "valid" });
     expect(resolved).toMatchObject({ source: "preferred", upstreamModel: "gpt" });
     expect(resolveModel(catalog, undefined, { modelId: "gpt", validity: "invalid" })).toEqual({ kind: "invalid_request" });
@@ -878,7 +878,7 @@ describe("listing routes", () => {
       runtime: defaultRuntimeConfigSnapshot(),
     }, createModelCatalogRoutes({
       directory: accounts,
-      catalog,
+      registry: testModelCapabilityRegistry(catalog),
       preferences: accounts.preferences,
     }));
     try {
@@ -906,7 +906,7 @@ describe("listing routes", () => {
 });
 
 describe("serializers", () => {
-  it("omits routing metadata from public OpenAI objects", () => {
+  it("omits routing metadata from public OpenAI objects", async () => {
     const discovered = {
       accountId: "a",
       fetchedAt: "2026-08-30T05:00:00Z",
@@ -917,7 +917,7 @@ describe("serializers", () => {
         capabilities: { supported_endpoints: ["/v1/responses"] },
       }] }),
     };
-    const catalog = capabilitySnapshotFromCatalog(bound("a"), discovered);
+    const catalog = await registrySnapshotFromDiscovery(bound("a"), discovered);
     const openai = JSON.parse(serializeOpenAiModels(catalog)) as { data: Array<Record<string, unknown>> };
     expect(openai.data[0]?.supported_endpoints).toBeUndefined();
     expect(openai.data[0]?.supportedEndpoints).toBeUndefined();

--- a/tests/contract/openai_chat_endpoint.test.ts
+++ b/tests/contract/openai_chat_endpoint.test.ts
@@ -23,6 +23,7 @@ import type {
   UpstreamByteStream,
 } from "../../src/copilot/upstream_types.js";
 import type { ChatRequest, ChatResponse } from "../../src/protocols/chat_completions/types.js";
+import { testModelCapabilityRegistry } from "./model_capability_registry_harness.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -139,7 +140,7 @@ async function openAiGateway(backend: CapturingCopilotBackend, options: {
     : { createRequestId: () => options.requestId ?? "req_test" };
   const routeDependencies = {
     directory: accounts,
-    catalog,
+    registry: testModelCapabilityRegistry(catalog),
     copilot: backend,
     ...(options.throwingPreferences
       ? {

--- a/tests/contract/protocol_conversion_matrix.test.ts
+++ b/tests/contract/protocol_conversion_matrix.test.ts
@@ -16,6 +16,7 @@ import { createAnthropicMessagesRoute } from "../../src/protocols/anthropic_mess
 import { createOpenAiChatRoute } from "../../src/protocols/openai_chat/endpoint.js";
 import { createResponsesRoute } from "../../src/protocols/responses/endpoint.js";
 import { SqliteResponsesHistory } from "../../src/protocols/responses/history.js";
+import { testModelCapabilityRegistry } from "./model_capability_registry_harness.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -1029,7 +1030,7 @@ async function matrixGateway(): Promise<MatrixHarness> {
   });
   const routeDependencies = {
     directory,
-    catalog,
+    registry: testModelCapabilityRegistry(catalog),
     preferences: directory.preferences,
     copilot: backend,
     createUuid: () => "00000000-0000-4000-8000-000000000104",

--- a/tests/contract/protocol_usage.test.ts
+++ b/tests/contract/protocol_usage.test.ts
@@ -21,6 +21,7 @@ import { convertBufferedResponse } from "../../src/protocols/conversion/buffered
 import { convertProtocolStream } from "../../src/protocols/conversion/stream.js";
 import type { InferenceProtocol, SemanticUsage } from "../../src/protocols/conversion/types.js";
 import { TelemetryRecorder, type UsageUpdate } from "../../src/telemetry/recorder.js";
+import { testModelCapabilityRegistry } from "./model_capability_registry_harness.js";
 
 const encoder = new TextEncoder();
 const protocols = ["chat", "messages", "responses"] as const;
@@ -256,7 +257,7 @@ async function usageGateway(source: InferenceProtocol, updates: Counters[], usag
   });
   const recorder = new TelemetryRecorder(database, nowMs);
   const observations: UsageUpdate[] = [];
-  const dependencies = { directory, preferences: directory.preferences, catalog, copilot: backend, nowMs, createUuid: uuid, usageRecorder: { recordUsage(update: UsageUpdate) { observations.push(update); recorder.recordUsage(update); } } };
+  const dependencies = { directory, preferences: directory.preferences, registry: testModelCapabilityRegistry(catalog), copilot: backend, nowMs, createUuid: uuid, usageRecorder: { recordUsage(update: UsageUpdate) { observations.push(update); recorder.recordUsage(update); } } };
   const history = new SqliteResponsesHistory(database, { nowMs });
   const gw = await createGateway({ startup: parseStartupConfig([], {}, { homedir: "." }), runtime: defaultRuntimeConfigSnapshot() }, [createOpenAiChatRoute(dependencies), createAnthropicMessagesRoute(dependencies), createResponsesRoute({ ...dependencies, history, nowUnixSeconds: () => nowMs() / 1000 })], { createRequestId: () => "req_usage" });
   return { gw, database, recorder, updates: observations, backend, close: async () => { await gw.close(); closeDatabase(database); } };

--- a/tests/contract/responses_endpoint.test.ts
+++ b/tests/contract/responses_endpoint.test.ts
@@ -6,6 +6,7 @@ import { AccountDirectory } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import { ScriptedCopilotBackend } from "../../src/copilot/backend.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
+import { testModelCapabilityRegistry } from "./model_capability_registry_harness.js";
 import { CapiFetchError } from "../../src/copilot/models_source.js";
 import { TokenRefreshError } from "../../src/copilot/token_refresh.js";
 import { UpstreamTimeoutError } from "../../src/copilot/transport.js";
@@ -680,7 +681,7 @@ describe("Responses endpoint", () => {
       runtime: options.runtime ?? defaultRuntimeConfigSnapshot(),
     }, [createResponsesRoute({
       directory: accounts,
-      catalog,
+      registry: testModelCapabilityRegistry(catalog),
       preferences: accounts.preferences,
       copilot: backend,
       history,

--- a/tests/integration/cli_commands.test.ts
+++ b/tests/integration/cli_commands.test.ts
@@ -10,6 +10,7 @@ import { DeviceFlowService, type DeviceOAuthClient } from "../../src/accounts/de
 import { ScriptedCopilotBackend } from "../../src/copilot/backend.js";
 import { createCopilotEndpointDiscovery, refreshCopilotToken } from "../../src/copilot/credential_provider.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
+import { ModelCapabilityRegistry } from "../../src/copilot/capability_registry.js";
 import type { TokenRefreshError } from "../../src/copilot/token_refresh.js";
 import { isMainModule, runCli } from "../../src/cli/main.js";
 import { CliError, HttpControlClient, ScriptedControlClient } from "../../src/cli/control_client.js";
@@ -407,8 +408,8 @@ describe("CLI commands", () => {
       harness.directory.preferences.get = originalGet;
       expect(await client.request("models.list", {}, { dataDir: "unused" })).toMatchObject({ accountId: "github.com/42", items: [{ id: "gpt" }] });
       expect(await client.request("models.set", { modelId: "gpt" }, { dataDir: "unused" })).toMatchObject({ accountId: "github.com/42", modelId: "gpt", validity: "valid" });
-      const isCurrent = harness.catalog.isCurrent.bind(harness.catalog);
-      harness.catalog.isCurrent = () => false;
+      const isCurrent = harness.registry.isCurrent.bind(harness.registry);
+      harness.registry.isCurrent = () => false;
       await expect(client.request("models.set", { modelId: "gpt" }, { dataDir: "unused" }))
         .rejects.toMatchObject({ code: "revision_conflict" });
       await client.request("models.list", { accountId: "github.com/42" }, { dataDir: "unused" });
@@ -416,17 +417,17 @@ describe("CLI commands", () => {
         modelId: "gpt",
         validity: "valid",
       });
-      harness.catalog.isCurrent = isCurrent;
+      harness.registry.isCurrent = isCurrent;
       await client.request("models.list", { accountId: "github.com/42" }, { dataDir: "unused" });
       expect(harness.directory.preferences.get("github.com/42")?.validity).toBe("valid");
-      harness.catalog.invalidate("github.com/42");
+      harness.registry.invalidate("github.com/42");
       harness.capiModels = [];
       await client.request("models.list", { accountId: "github.com/42" }, { dataDir: "unused" });
       expect(harness.directory.preferences.get("github.com/42")?.validity).toBe("invalid");
-      harness.catalog.invalidate("github.com/42");
+      harness.registry.invalidate("github.com/42");
       harness.capiModels = [{ id: "claude", name: "Claude", vendor: "anthropic", model_picker_enabled: true }];
       expect(await client.request("models.set", { modelId: "claude" }, { dataDir: "unused" })).toMatchObject({ accountId: "github.com/42", modelId: "claude", validity: "valid" });
-      harness.catalog.invalidate("github.com/42");
+      harness.registry.invalidate("github.com/42");
       harness.capiModels = [];
       const getPreference = harness.directory.preferences.get.bind(harness.directory.preferences);
       let forcePreferenceConflict = true;
@@ -763,7 +764,7 @@ describe("CLI commands", () => {
       });
       const routes = createPublicRouteRegistrations({
         directory: harness.directory,
-        catalog: harness.catalog,
+        registry: harness.registry,
         copilot: harness.backend,
         history: harness.history,
       });
@@ -892,7 +893,7 @@ async function dispatcherHarness(options: {
 } = {}): Promise<{
   readonly dispatcher: CommandDispatcher;
   readonly directory: AccountDirectory;
-  readonly catalog: CopilotModelCatalog;
+  readonly registry: ModelCapabilityRegistry;
   readonly backend: ScriptedCopilotBackend;
   readonly history: SqliteResponsesHistory;
   readonly runtimeConfig: RuntimeConfigStore;
@@ -922,6 +923,7 @@ async function dispatcherHarness(options: {
       return { data: harness.capiModels };
     },
   });
+  const registry = new ModelCapabilityRegistry(catalog, { get: () => null });
   const runtimeConfig = new RuntimeConfigStore(database, now);
   runtimeConfig.seedIfEmpty({});
   const history = new SqliteResponsesHistory(database, { nowMs: now });
@@ -932,13 +934,13 @@ async function dispatcherHarness(options: {
   const dispatcher = new CommandDispatcher({
     directory,
     deviceFlows: new DeviceFlowService(directory, options.device ?? deviceClient(), now),
-    catalog,
+    registry,
     runtimeConfig,
   });
   return {
     dispatcher,
     directory,
-    catalog,
+    registry,
     backend,
     history,
     runtimeConfig,

--- a/tests/integration/daemon_composition.test.ts
+++ b/tests/integration/daemon_composition.test.ts
@@ -50,7 +50,7 @@ describe("production composition", () => {
     );
     const order: string[] = [];
     const closeCopilot = application.copilot.close.bind(application.copilot);
-    const closeCatalog = application.catalog.close.bind(application.catalog);
+    const closeRegistry = application.registry.close.bind(application.registry);
     const telemetryRuntime = application.telemetryRuntime;
     const endpointDiscovery = application.endpointDiscovery;
     const database = application.database;
@@ -64,9 +64,9 @@ describe("production composition", () => {
       order.push("copilot");
       await closeCopilot();
     };
-    application.catalog.close = async () => {
-      order.push("catalog");
-      await closeCatalog();
+    application.registry.close = async () => {
+      order.push("registry");
+      await closeRegistry();
     };
     endpointDiscovery.close = async () => {
       order.push("endpoint-discovery");
@@ -82,7 +82,7 @@ describe("production composition", () => {
     };
     try {
       await application.close?.();
-      expect(order).toEqual(["copilot", "catalog", "endpoint-discovery", "telemetry", "sqlite"]);
+      expect(order).toEqual(["copilot", "registry", "endpoint-discovery", "telemetry", "sqlite"]);
     } finally {
       application.forceClose?.();
       await rm(dataDir, { recursive: true, force: true });
@@ -100,9 +100,9 @@ describe("production composition", () => {
       order.push("copilot");
       throw new Error("copilot close failed");
     };
-    application.catalog.close = async () => {
-      order.push("catalog");
-      throw new Error("catalog close failed");
+    application.registry.close = async () => {
+      order.push("registry");
+      throw new Error("registry close failed");
     };
     const telemetryRuntime = application.telemetryRuntime;
     const endpointDiscovery = application.endpointDiscovery;
@@ -127,13 +127,13 @@ describe("production composition", () => {
         name: "AggregateError",
         errors: [
           expect.objectContaining({ message: "copilot close failed" }),
-          expect.objectContaining({ message: "catalog close failed" }),
+          expect.objectContaining({ message: "registry close failed" }),
           expect.objectContaining({ message: "endpoint discovery close failed" }),
           expect.objectContaining({ message: "telemetry close failed" }),
           expect.objectContaining({ message: "sqlite close failed" }),
         ],
       });
-      expect(order).toEqual(["copilot", "catalog", "endpoint-discovery", "telemetry", "sqlite"]);
+      expect(order).toEqual(["copilot", "registry", "endpoint-discovery", "telemetry", "sqlite"]);
       expect(application.database.prepare("SELECT 1").get()).toEqual({ "1": 1 });
     } finally {
       application.database.close = closeSqlite;
@@ -207,7 +207,7 @@ describe("production composition", () => {
         userId: "177",
         secret: { generation: 0, githubToken: "context-b" },
       });
-      await contextA.registry!.get(accountA, signal());
+      await contextA.registry.get(accountA, signal());
       await contextA.copilot.bind(accountA, signal());
       expect(discoveryRequests).toEqual(["a"]);
       await contextB.copilot.bind(accountB, signal());
@@ -239,7 +239,7 @@ describe("production composition", () => {
         login: "composition",
         secret: { generation: 0, githubToken: "test-token" },
       });
-      await harness.catalog.get(account.accountId, signal());
+      await harness.registry.get(account, signal());
       expect(harness.catalogFetchCount()).toBe(1);
       await harness.endpointDiscovery.discover(account);
       expect(harness.endpointFetchCount()).toBe(1);
@@ -350,8 +350,8 @@ describe("production composition", () => {
         arguments: { accountId: account.accountId },
       });
       expect(removed.status).toBe(200);
-      await harness.catalog.get(account.accountId, signal());
-      expect(harness.catalogFetchCount()).toBe(3);
+      await harness.registry.get(account, signal());
+      expect(harness.catalogFetchCount()).toBe(2);
       await harness.endpointDiscovery.discover(account);
       expect(harness.endpointFetchCount()).toBe(2);
     } finally {
@@ -413,7 +413,7 @@ interface CompositionHarness {
   readonly application: ApplicationContext;
   readonly database: ReturnType<typeof openDatabase>;
   readonly directory: AccountDirectory;
-  readonly catalog: CopilotModelCatalog;
+  readonly registry: ModelCapabilityRegistry;
   readonly history: SqliteResponsesHistory;
   readonly telemetry: TelemetryRecorder;
   readonly runtime: RuntimeConfigStore;
@@ -472,7 +472,6 @@ function compositionHarness(
     database,
     credentials,
     directory,
-    catalog,
     registry,
     copilot: new ScriptedCopilotBackend({}),
     history,
@@ -481,7 +480,7 @@ function compositionHarness(
     runtime,
     async close() {
       await telemetry.flush();
-      await catalog.close();
+      await registry.close();
       await endpointDiscovery.close();
       closeDatabase(database);
     },
@@ -491,7 +490,7 @@ function compositionHarness(
     application,
     database,
     directory,
-    catalog,
+    registry,
     history,
     telemetry,
     runtime,

--- a/tests/integration/model_routes.test.ts
+++ b/tests/integration/model_routes.test.ts
@@ -6,7 +6,6 @@ import { AccountDirectory } from "../../src/accounts/account_directory.js";
 import { MemoryCredentialStore } from "../../src/accounts/credential_store.js";
 import { CapiFetchError } from "../../src/copilot/models_source.js";
 import { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
-import { capabilitySnapshotFromCatalog } from "../../src/copilot/capability_registry.js";
 import { ModelCapabilityRegistry } from "../../src/copilot/capability_registry.js";
 import { parseLiveModelCapabilities } from "../../src/copilot/model_capabilities.js";
 import { TokenRefreshError } from "../../src/copilot/token_refresh.js";
@@ -36,12 +35,13 @@ describe("model routes errors and preferences", () => {
         return { data: [{ id: "visible", name: "V", vendor: "x", model_picker_enabled: true }] };
       },
     });
+    const registry = new ModelCapabilityRegistry(catalog, { get: () => null });
     const gw = await createGateway({
       startup: parseStartupConfig([], {}, { homedir: dir }),
       runtime: defaultRuntimeConfigSnapshot(),
     }, createModelCatalogRoutes({
       directory: accounts,
-      catalog,
+      registry,
       preferences: accounts.preferences,
     }));
     try {
@@ -54,10 +54,10 @@ describe("model routes errors and preferences", () => {
       });
       const ok = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"));
       expect(ok.status).toBe(200);
-      const snapshot = await catalog.get("github.com/1", new AbortController().signal);
+      const snapshot = await registry.get(account, new AbortController().signal);
       const manager = new PreferredModelManager(accounts.preferences);
-      manager.setPreferred("github.com/1", "visible", 0, capabilitySnapshotFromCatalog(account, snapshot));
-      catalog.invalidate("github.com/1");
+      manager.setPreferred("github.com/1", "visible", 0, snapshot);
+      registry.invalidate("github.com/1");
       const empty = new CopilotModelCatalog({
         async fetch() {
           return { data: [] };
@@ -91,12 +91,13 @@ describe("model routes errors and preferences", () => {
         throw new CapiFetchError(429, retryAfter);
       },
     });
+    const registry = new ModelCapabilityRegistry(catalog, { get: () => null });
     const gw = await createGateway({
       startup: parseStartupConfig([], {}, { homedir: dir }),
       runtime: defaultRuntimeConfigSnapshot(),
     }, createModelCatalogRoutes({
       directory: accounts,
-      catalog,
+      registry,
       preferences: accounts.preferences,
     }));
     try {
@@ -105,7 +106,7 @@ describe("model routes errors and preferences", () => {
       expect(valid.headers.get("retry-after")).toBe("120");
 
       retryAfter = undefined;
-      catalog.invalidate("github.com/1");
+      registry.invalidate("github.com/1");
       const invalid = await gw.fetch(new Request("http://127.0.0.1:31400/v1/models"));
       expect(invalid.status).toBe(429);
       expect(invalid.headers.get("retry-after")).toBeNull();
@@ -322,12 +323,13 @@ describe("model routes errors and preferences", () => {
         throw error;
       },
     });
+    const registry = new ModelCapabilityRegistry(catalog, { get: () => null });
     const gateway = await createGateway({
       startup: parseStartupConfig([], {}, { homedir: dir }),
       runtime: defaultRuntimeConfigSnapshot(),
     }, createModelCatalogRoutes({
       directory: accounts,
-      catalog,
+      registry,
       preferences: accounts.preferences,
     }), { createRequestId: () => "req_models" });
     try {
@@ -338,7 +340,7 @@ describe("model routes errors and preferences", () => {
         error: { type: "api_error", code: "504" },
       });
 
-      catalog.invalidate("github.com/1");
+      registry.invalidate("github.com/1");
       const anthropic = await gateway.fetch(new Request("http://127.0.0.1:31400/v1/models", {
         headers: { "anthropic-version": "2023-06-01" },
       }));
@@ -351,7 +353,7 @@ describe("model routes errors and preferences", () => {
       });
 
       error = new TokenRefreshError("missing", "secret-token https://unsafe.example/private");
-      catalog.invalidate("github.com/1");
+      registry.invalidate("github.com/1");
       const authentication = await gateway.fetch(new Request("http://127.0.0.1:31400/v1/models"));
       expect(authentication.status).toBe(401);
       expect(await authentication.text()).not.toContain("secret-token");

--- a/tests/integration/request_lifecycle_loopback.test.ts
+++ b/tests/integration/request_lifecycle_loopback.test.ts
@@ -14,6 +14,7 @@ import { migration as accountsMigration } from "../../src/persistence/migrations
 import { createResponsesRoute } from "../../src/protocols/responses/endpoint.js";
 import type { ResponsesHistory } from "../../src/protocols/responses/history.js";
 import type { UsageUpdate } from "../../src/telemetry/recorder.js";
+import { testModelCapabilityRegistry } from "../contract/model_capability_registry_harness.js";
 
 describe("request lifecycle over loopback", () => {
   const closing: HostedGateway[] = [];
@@ -173,7 +174,7 @@ async function responsesGateway(options: {
     runtime,
   }, [createResponsesRoute({
     directory: accounts,
-    catalog,
+    registry: testModelCapabilityRegistry(catalog),
     preferences: accounts.preferences,
     copilot: backend,
     history: EMPTY_HISTORY,

--- a/tests/integration/responses_endpoint_stream.test.ts
+++ b/tests/integration/responses_endpoint_stream.test.ts
@@ -23,6 +23,7 @@ import { migration as runtimeConfigMigration } from "../../src/persistence/migra
 import { migration as accountsMigration } from "../../src/persistence/migrations/010_accounts.js";
 import type { ResponsesRequest } from "../../src/protocols/responses/dto.js";
 import { createResponsesRoute } from "../../src/protocols/responses/endpoint.js";
+import { testModelCapabilityRegistry } from "../contract/model_capability_registry_harness.js";
 import type {
   ResponsesHistory,
   ResponsesHistoryRecord,
@@ -456,7 +457,7 @@ async function streamGateway(
     runtime: options.runtime ?? defaultRuntimeConfigSnapshot(),
   }, [createResponsesRoute({
     directory: accounts,
-    catalog,
+    registry: testModelCapabilityRegistry(catalog),
     preferences: accounts.preferences,
     copilot: backend,
     history,

--- a/tests/sdk/harness.ts
+++ b/tests/sdk/harness.ts
@@ -157,12 +157,11 @@ export async function startOfflineSdkHarness(): Promise<OfflineSdkHarness> {
       database,
       credentials: new MemoryCredentialStore(),
       directory,
-      catalog,
       registry,
       copilot: backend,
       history,
       async close() {
-        await catalog.close();
+        await registry.close();
         closeState();
       },
       forceClose: closeState,

--- a/tests/sdk/replay_harness.ts
+++ b/tests/sdk/replay_harness.ts
@@ -117,13 +117,12 @@ export async function startReplaySdkHarness(options: {
       database,
       credentials,
       directory,
-      catalog,
       registry,
       copilot,
       history,
       modelsSource,
       async close() {
-        await catalog.close();
+        await registry.close();
         await copilot.close();
         await modelsSource.close();
         await endpointDiscovery.close();

--- a/tests/unit/agents_model_resolution.test.ts
+++ b/tests/unit/agents_model_resolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { capabilitySnapshotFromCatalog } from "../../src/copilot/capability_registry.js";
+import { registrySnapshotFromDiscovery } from "../contract/model_capability_registry_harness.js";
 import { resolveGitHubEnvironment } from "../../src/accounts/github_environment.js";
 import { resolveModel } from "../../src/protocols/model_catalog/resolver.js";
 import { planProtocolExecution } from "../../src/protocols/conversion/planner.js";
@@ -24,8 +24,8 @@ const account = {
   credentialGeneration: 4,
 };
 
-function snapshotWith(models: readonly { id: string; protocols: readonly string[] }[]) {
-  return capabilitySnapshotFromCatalog(account, {
+async function snapshotWith(models: readonly { id: string; protocols: readonly string[] }[]) {
+  return await registrySnapshotFromDiscovery(account, {
     accountId: account.accountId,
     generation: 7,
     credentialGeneration: 4,
@@ -44,8 +44,8 @@ function snapshotWith(models: readonly { id: string; protocols: readonly string[
 }
 
 describe("agent configuration compatibility with Gateway model resolution", () => {
-  it("resolves every generated Codex catalog slug explicitly and plans native Responses", () => {
-    const snapshot = snapshotWith([
+  it("resolves every generated Codex catalog slug explicitly and plans native Responses", async () => {
+    const snapshot = await snapshotWith([
       { id: "gpt-test", protocols: ["responses"] },
       { id: "claude-test", protocols: ["messages", "chat"] },
     ]);
@@ -90,8 +90,8 @@ describe("agent configuration compatibility with Gateway model resolution", () =
     expect(bridged.target).toBe("chat");
   });
 
-  it("resolves Claude role model IDs explicitly through the Messages endpoint", () => {
-    const snapshot = snapshotWith([
+  it("resolves Claude role model IDs explicitly through the Messages endpoint", async () => {
+    const snapshot = await snapshotWith([
       { id: "sonnet-real", protocols: ["messages"] },
       { id: "opus-real", protocols: ["chat"] },
       { id: "haiku-real", protocols: ["messages"] },

--- a/tests/unit/capability_registry_dependencies.test.ts
+++ b/tests/unit/capability_registry_dependencies.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { AccountDirectory } from "../../src/accounts/account_directory.js";
+import type { AccountModelPreferences } from "../../src/accounts/model_preferences.js";
+import type { DeviceFlowService } from "../../src/accounts/device_flow.js";
+import type { CopilotBackend } from "../../src/copilot/backend.js";
+import type { CopilotModelCatalog } from "../../src/copilot/model_catalog.js";
+import type { ModelCapabilityRegistry } from "../../src/copilot/capability_registry.js";
+import type { RuntimeConfigStore } from "../../src/config/runtime_config.js";
+import type { ResponsesHistory } from "../../src/protocols/responses/history.js";
+import type { ApplicationContext } from "../../src/main.js";
+import { createPublicRouteRegistrations } from "../../src/main.js";
+import type { ModelCatalogRouteDependencies } from "../../src/protocols/model_catalog/routes.js";
+import type { OpenAiChatRouteDependencies } from "../../src/protocols/openai_chat/endpoint.js";
+import type { AnthropicMessagesRouteDependencies } from "../../src/protocols/anthropic_messages/endpoint.js";
+import type { ResponsesRouteDependencies } from "../../src/protocols/responses/endpoint.js";
+import type { CommandDispatcherDependencies } from "../../src/cli/commands/dispatcher.js";
+
+const directory = {} as AccountDirectory;
+const registry = {} as ModelCapabilityRegistry;
+const catalog = {} as CopilotModelCatalog;
+const preferences = {} as AccountModelPreferences;
+const copilot = {} as CopilotBackend;
+const history = {} as ResponsesHistory;
+const runtimeConfig = {} as RuntimeConfigStore;
+const deviceFlows = {} as Pick<DeviceFlowService, "start" | "poll" | "cancel">;
+
+// Compile-time authority contract: every effective consumer requires the registry.
+const validApplication: ApplicationContext = { directory, registry, copilot, history };
+const validModels: ModelCatalogRouteDependencies = { directory, registry, preferences };
+const validChat: OpenAiChatRouteDependencies = { directory, registry, preferences, copilot };
+const validMessages: AnthropicMessagesRouteDependencies = { directory, registry, preferences, copilot };
+const validResponses: ResponsesRouteDependencies = { directory, registry, preferences, copilot, history };
+const validDispatcher: CommandDispatcherDependencies = { directory, registry, deviceFlows, runtimeConfig };
+void [validApplication, validModels, validChat, validMessages, validResponses, validDispatcher];
+
+// @ts-expect-error catalog-only application composition is forbidden
+const invalidApplication: ApplicationContext = { directory, catalog, copilot, history };
+// @ts-expect-error model routes require registry
+const invalidModels: ModelCatalogRouteDependencies = { directory, catalog, preferences };
+// @ts-expect-error Chat requires registry
+const invalidChat: OpenAiChatRouteDependencies = { directory, catalog, preferences, copilot };
+// @ts-expect-error Messages requires registry
+const invalidMessages: AnthropicMessagesRouteDependencies = { directory, catalog, preferences, copilot };
+// @ts-expect-error Responses requires registry
+const invalidResponses: ResponsesRouteDependencies = { directory, catalog, preferences, copilot, history };
+// @ts-expect-error CLI dispatcher requires registry
+const invalidDispatcher: CommandDispatcherDependencies = { directory, catalog, deviceFlows, runtimeConfig };
+void [invalidApplication, invalidModels, invalidChat, invalidMessages, invalidResponses, invalidDispatcher];
+
+describe("capability registry construction authority", () => {
+  it("fails closed when unsafe JavaScript composition omits the registry", () => {
+    expect(() => createPublicRouteRegistrations({ directory, copilot, history } as ApplicationContext))
+      .toThrow("model capability registry is unavailable");
+  });
+});


### PR DESCRIPTION
## Summary

- make `ModelCapabilityRegistry` the required authority for every effective capability decision
- remove catalog-only snapshot composition/currentness and raw-catalog consumer fallbacks
- require one registry across public protocol routes, model listing, CLI, Admin, agents, preferences, and application composition
- preserve immutable account/generation snapshots, builtin precedence, conflict and unknown fail-closed behavior
- fence Admin preference writes against superseded registry generations

## Validation

- focused registry/model/protocol/CLI/Admin tests passed
- full `npm test`: 1171 passed, 8 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run fixtures:verify` (53 entries)
- no fixture/golden changes
- Standards review: no findings
- Spec review: no findings

Official SDK suites and live inference were not run; SDK harnesses received compile-only coverage.

Closes #181
